### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ all:
 	$(TOPDIR)/gen_partition.py -i partitions.conf -o partitions.xml
 	$(TOPDIR)/ptool.py -x partitions.xml
 
+check:
+	# W605: invalid escape sequence
+	pycodestyle --select=W605 *.py
+

--- a/gen_partition.py
+++ b/gen_partition.py
@@ -234,7 +234,7 @@ try:
    line = f.readline()
    partition_index = 0
    while line:
-      if not re.search("^\s*#", line) and not re.search("^\s*$", line):
+      if not re.search(r'^\s*#', line) and not re.search(r'^\s*$', line):
          line = line.strip()
          if re.search("^--disk", line):
             if disk_entry == None:

--- a/msp.py
+++ b/msp.py
@@ -1279,7 +1279,7 @@ def Usage():
     print "\n%-40s\t%s python msp.py -n -r rawprogram.xml -d %s" % ("no prompts (-n) i.e. automation",sudo,drive)
     print "%-40s\t%s python msp.py -i -r rawprogram.xml -d %s " % ("Interactively choose files (-i)",sudo,drive)
     print "%-40s\t%s python msp.py -f sbl1.mbn,sbl2.mbn -r rawprogram.xml -d %s " % ("Specify files from rawprogram.xml (-f)",sudo,drive)
-    print "%-40s\t%s python msp.py -s c:\windows,d:\ -r rawprogram.xml -d %s " % ("Search this path for files (-s)",sudo,drive)
+    print "%-40s\t%s python msp.py -s c:\\windows,d:\\ -r rawprogram.xml -d %s " % ("Search this path for files (-s)",sudo,drive)
     print "\n%-40s\t%s python msp.py -p patch0.xml -d %s" % ("Patch a device (-p)",sudo,drive)
     print "%-40s\t%s python msp.py -p patch0.xml -d singleimage.bin" % ("Patch files to singleimage (-p)",sudo)
     print "%-40s\t%s python msp.py -p patch0.xml -d 16777216" % ("PRE-PATCH images for an 8GB disk (-p)",sudo)

--- a/msp.py
+++ b/msp.py
@@ -193,7 +193,7 @@ def HandleNUM_DISK_SECTORS(field):
         #print "returning since this is not a string"
         return field
     
-    m = re.search("NUM_DISK_SECTORS-(\d+)", field)
+    m = re.search(r'NUM_DISK_SECTORS-(\d+)', field)
     if type(m) is not NoneType:
         if DiskSizeInBytes > 0 :
             field           = int((DiskSizeInBytes/SECTOR_SIZE)-int(m.group(1)))   # here I know DiskSizeInBytes
@@ -245,7 +245,7 @@ def ReturnParsedValues(element):
     MyDict['size_in_bytes']             = int(float(MyDict['size_in_bytes']))
 
     # These only affect patching
-    m = re.search("CRC32\((\d+).?,(\d+).?\)", MyDict['value'])
+    m = re.search(r'CRC32\((\d+).?,(\d+).?\)', MyDict['value'])
     if type(m) is not NoneType:
         MyDict['value']          = 0
         MyDict['function']       = "CRC32"
@@ -253,7 +253,7 @@ def ReturnParsedValues(element):
         MyDict['arg1']           = int(float(m.group(2)))   # len_in_bytes
     else:
         ## above didn't match, so try this
-        m = re.search("CRC32\((NUM_DISK_SECTORS-\d+).?,(\d+).?\)", MyDict['value'])
+        m = re.search(r'CRC32\((NUM_DISK_SECTORS-\d+).?,(\d+).?\)', MyDict['value'])
         if type(m) is not NoneType:
             MyDict['value']          = 0
             MyDict['function']       = "CRC32"
@@ -309,9 +309,9 @@ def ParseXML(xml_filename):     ## this function updates all the global arrays
     
 
 def ReturnArrayFromCommaSeparatedList(sz):
-    temp = re.sub("\s+|\n"," ",sz)
-    temp = re.sub("^\s+","",temp)
-    temp = re.sub("\s+$","",temp)
+    temp = re.sub(r'\s+|\n'," ",sz)
+    temp = re.sub(r'^\s+',"",temp)
+    temp = re.sub(r'\s+$',"",temp)
     return temp.split(',')
 
 def find_file(filename, search_paths):
@@ -912,7 +912,7 @@ def GetPartitions():
         for line in output:
             #print line
 
-            m = re.search("(\d+) (sd[a-z])$", line)
+            m = re.search(r'(\d+) (sd[a-z])$', line)
             if type(m) is not NoneType:
                 Size    = int(m.group(1))
                 Device  = "/dev/"+m.group(2)
@@ -943,7 +943,7 @@ def GetPartitions():
 
         response = response.replace('\r', '').strip("\n").split("\n")[1:]
         for line in response:
-            m = re.search("(PHYSICALDRIVE\d+).+ (\d+) ", line)
+            m = re.search(r'(PHYSICALDRIVE\d+).+ (\d+) ', line)
             if type(m) is not NoneType:
                 Size    = int(m.group(2))       # size in bytes
                 Device  = "\\\\.\\"+m.group(1)  # \\.\PHYSICALDRIVE1

--- a/ptool.py
+++ b/ptool.py
@@ -190,11 +190,11 @@ def ValidGUIDForm(GUID):
 
     print("Testing if GUID=",GUID)
 
-    m = re.search("0x([a-fA-F\d]{32})$", GUID)     #0xC79926B7B668C0874433B9E5EBD0A0A2
+    m = re.search(r'0x([a-fA-F\d]{32})$', GUID)     #0xC79926B7B668C0874433B9E5EBD0A0A2
     if m is not None:
         return True
 
-    m = re.search("([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})", GUID)
+    m = re.search(r'([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})', GUID)
     if m is not None:
         return True
 
@@ -212,7 +212,7 @@ def ValidateTYPE(Type):
     if type(Type) is not str:
         Type = str(Type)
 
-    m = re.search("^(0x)?([a-fA-F\d][a-fA-F\d]?)$", Type)
+    m = re.search(r'^(0x)?([a-fA-F\d][a-fA-F\d]?)$', Type)
     if m is None:
         print("\tWARNING: Type \"%s\" is not in the form 0x4C" % Type)
         sys.exit(1)
@@ -229,7 +229,7 @@ def ValidateGUID(GUID):
 
     print("Looking to validate GUID=",GUID)
 
-    m = re.search("0x([a-fA-F\d]{32})$", GUID)     #0xC79926B7B668C0874433B9E5EBD0A0A2
+    m = re.search(r'0x([a-fA-F\d]{32})$', GUID)     #0xC79926B7B668C0874433B9E5EBD0A0A2
     if m is not None:
         tempGUID = int(m.group(1),16)
         print("\tGUID \"%s\"" % GUID)
@@ -247,7 +247,7 @@ def ValidateGUID(GUID):
 
     else:
         #ebd0a0a2-b9e5-4433-87c0-68b6b72699c7  --> #0x C7 99 26 B7 B6 68 C087 4433 B9E5 EBD0A0A2
-        m = re.search("([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})", GUID)
+        m = re.search(r'([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})', GUID)
         if m is not None:
             print("Found more advanced type")
             tempGUID = (int(m.group(4),16)<<64) | (int(m.group(3),16)<<48) | (int(m.group(2),16)<<32) | int(m.group(1),16)
@@ -1080,7 +1080,7 @@ def ParseXML(XMLFile):
 
     if 'SECTOR_SIZE_IN_BYTES' in HashInstructions:
         if type(HashInstructions['SECTOR_SIZE_IN_BYTES']) is str:
-            m = re.search("^(\d+)$", HashInstructions['SECTOR_SIZE_IN_BYTES'])
+            m = re.search(r'^(\d+)$', HashInstructions['SECTOR_SIZE_IN_BYTES'])
             if m is None:
                 ## we didn't match, so assign deafult
                 HashInstructions['SECTOR_SIZE_IN_BYTES'] = 512
@@ -1101,7 +1101,7 @@ def ParseXML(XMLFile):
 
     if 'WRITE_PROTECT_BOUNDARY_IN_KB' in HashInstructions:
         if type(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']) is str:
-            m = re.search("^(\d+)$", HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
+            m = re.search(r'^(\d+)$', HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
             if m is None:
                 ## we didn't match, so assign deafult
                 HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'] = 0
@@ -1113,7 +1113,7 @@ def ParseXML(XMLFile):
 
     if 'PERFORMANCE_BOUNDARY_IN_KB' in HashInstructions:
         if type(HashInstructions['PERFORMANCE_BOUNDARY_IN_KB']) is str:
-            m = re.search("^(\d+)$", HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
+            m = re.search(r'^(\d+)$', HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
             if m is None:
                 ## we didn't match, so assign deafult
                 HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] = 0
@@ -1178,7 +1178,7 @@ def ParseXML(XMLFile):
 
     if 'DISK_SIGNATURE' in HashInstructions:
         if type(HashInstructions['DISK_SIGNATURE']) is str:
-            m = re.search("^0x([\da-fA-F]+)$", HashInstructions['DISK_SIGNATURE'])
+            m = re.search(r'^0x([\da-fA-F]+)$', HashInstructions['DISK_SIGNATURE'])
             if m is None:
                 print("WARNING: DISK_SIGNATURE is not formed correctly, expected format is 0x12345678\n")
                 HashInstructions['DISK_SIGNATURE'] = 0x00000000
@@ -1190,7 +1190,7 @@ def ParseXML(XMLFile):
 
     if 'ALIGN_BOUNDARY_IN_KB' in HashInstructions:
         if type(HashInstructions['ALIGN_BOUNDARY_IN_KB']) is str:
-            m = re.search("^(\d+)$", HashInstructions['ALIGN_BOUNDARY_IN_KB'])
+            m = re.search(r'^(\d+)$', HashInstructions['ALIGN_BOUNDARY_IN_KB'])
             if m is None:
                 ## we didn't match, so assign deafult
                 HashInstructions['ALIGN_BOUNDARY_IN_KB'] = HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']
@@ -1541,7 +1541,7 @@ def ParseCommandLine():
         print("\nWill AUTO-DETECT from file")
 
     if len(sys.argv) >= 4:  # Should mean PHY partition was specified
-        m = re.search("^\d+$", sys.argv[3] )
+        m = re.search(r'^\d+$', sys.argv[3] )
         if m is not None:
             PhysicalPartitionNumber = int(sys.argv[3])
             print("PhysicalPartitionNumber specified as %d" % PhysicalPartitionNumber)
@@ -2387,7 +2387,7 @@ for o, a in opts:
 
     elif o in ("-k", "--use128partitions"):
         ## Force there to be 128 partitions in the partition table
-        m = re.search("\d", a)     #mbr|gpt
+        m = re.search(r'\d', a)     #mbr|gpt
         if m is None:
             force128partitions = 0
         else:
@@ -2401,7 +2401,7 @@ for o, a in opts:
 
     elif o in ("-g", "--sequentialguid"):
         ## also allow seperating commas
-        m = re.search("\d", a)     #mbr|gpt
+        m = re.search(r'\d', a)     #mbr|gpt
         if m is None:
             sequentialguid = 0
         else:
@@ -2410,7 +2410,7 @@ for o, a in opts:
     elif o in ("-p", "--partition"):
         UsingGetOpts = True
         PhysicalPartitionNumber = a
-        m = re.search("^(\d)$", a)     #0|1|2
+        m = re.search(r'^(\d)$', a)     #0|1|2
         if m is None:
             PrintBigError("ERROR: PhysicalPartitionNumber (-p) must be a number, you supplied *",a,"*")
         else:

--- a/ptool.py
+++ b/ptool.py
@@ -1726,7 +1726,7 @@ def ShowUsage():
     print("python ptool.py -x partition.xml")
     PrintBanner("Advanced Usage")
     print("%-44s\t\tpython ptool.py -x partition.xml" % ("Basic Usage"))
-    print("%-44s\t\tpython ptool.py -x partition.xml -s c:\windows" % ("Search path to find partition.xml"))
+    print("%-44s\t\tpython ptool.py -x partition.xml -s c:\\windows" % ("Search path to find partition.xml"))
     print("%-44s\tpython ptool.py -x partition.xml -p 0" % ("Specify PHY Partition 0, (creates rawprogram0.xml)"))
     print("%-44s\tpython ptool.py -x partition.xml -p 1" % ("Specify PHY Partition 1, (creates rawprogram1.xml)"))
     print("%-44s\tpython ptool.py -x partition.xml -p 2" % ("Specify PHY Partition 2, (creates rawprogram2.xml)"))


### PR DESCRIPTION
Fix invalid escape sequence Python warnings in regular expressions

Fix a couple of quoting errors on Windows pathnames.

Add an initial check target. This should be added to the CI/CT workflow, but
that depends how the github runners are setup (with or without sudo).
