### PR TITLE
RB1: Partition table update as well as some cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # qcom-tool
 
-qcom-ptool contains various device partitioning utilities like ptool.py, gen_partitions.py and various sample partition configuration files needed for Qualcomm SoCs.
+qcom-ptool contains various device partitioning utilities like ptool.py, gen_partitions.py and various sample partition configuration files needed for Qualcomm SoCs. Qualcomm Linux currently supports two reference Linux based OSes (Yocto with [meta-qcom](https://github.com/qualcomm-linux/meta-qcom) and Debian with [qcom-deb-images](https://github.com/qualcomm-linux/qcom-deb-images)) which uses this tool to generate partition table layouts. The partition GUIDs, names and size budgets are picked to support boot flows as follows:
+
+- (preferred) "edk2/UEFI": PBL => XBL => edk2/UEFI => high-level OS (Linux)
+- (legacy) "U-Boot/UEFI": PBL => XBL => ABL => U-Boot/UEFI => high-level OS (Linux)
 
 # Development
 

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -94,4 +94,4 @@
 --partition --name=fsg --size=2048KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
 --partition --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB
 --partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
---partition --name=rootfs --size=9960572KB --type-guid=1B81E7E6-F50D-419B-A739-2AEEF8DA3335 --filename=rootfs.img
+--partition --name=rootfs --size=9960572KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -22,19 +22,14 @@
 # This is physical partition 0
 --partition --name=xbl_a --size=3584KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
 --partition --name=xbl_b --size=3584KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=xbl.elf
---partition --name=xbl_r --size=3584KB --type-guid=17EEDC01-1490-C7E4-13C9-6A026B106695 --filename=xbl.elf
 --partition --name=xbl_config_a --size=128KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_feature_config.elf
 --partition --name=xbl_config_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=xbl_feature_config.elf
---partition --name=xbl_config_r --size=128KB --type-guid=BA0FD29E-0B7E-4D18-BE87-53F5C9056726 --filename=xbl_feature_config.elf
 --partition --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --name=tz_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=tz.mbn
---partition --name=tz_r --size=4096KB --type-guid=B8926291-2A76-407C-89FE-FA76BE8FA8F3 --filename=tz.mbn
 --partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
 --partition --name=rpm_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=rpm.mbn
---partition --name=rpm_r --size=512KB --type-guid=EDE665C0-9F65-47D9-A8C1-73D61EF3C7D6 --filename=rpm.mbn	
 --partition --name=hyp_a --size=512KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
 --partition --name=hyp_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=hyp.mbn
---partition --name=hyp_r --size=512KB --type-guid=4BACB256-C6E9-46F5-A3B6-A245080A9727 --filename=hyp.mbn
 --partition --name=boot_a --size=98304KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
 --partition --name=boot_b --size=98304KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
 --partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=km4.mbn
@@ -49,7 +44,6 @@
 --partition --name=dsp_b --size=65536KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
 --partition --name=abl_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=abl.elf
---partition --name=abl_r --size=1024KB --type-guid=4ED7A78D-9BB0-478A-B0B8-9349BCB2D934 --filename=abl.elf
 --partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
 --partition --name=bluetooth_a --size=1024KB --type-guid=6cb747f1-c2ef-4092-add0-ca39f79c7af4
 --partition --name=bluetooth_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
@@ -64,7 +58,6 @@
 --partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
 --partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
 --partition --name=devcfg_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=devcfg.mbn
---partition --name=devcfg_r --size=128KB --type-guid=F5973784-F577-49EF-90DA-6D91156B73DE --filename=devcfg.mbn
 --partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7 --filename=featenabler.mbn
 --partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=featenabler.mbn
 --partition --name=qupfw_a --size=64KB --type-guid=21d1219f-2ed1-4ab4-930a-41a16ae75f7f --filename=qupv3fw.elf

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -30,8 +30,8 @@
 --partition --name=rpm_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=rpm.mbn
 --partition --name=hyp_a --size=512KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
 --partition --name=hyp_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=hyp.mbn
---partition --name=boot_a --size=98304KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
---partition --name=boot_b --size=98304KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
+--partition --name=boot_a --size=4096KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
+--partition --name=boot_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
 --partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=km4.mbn
 --partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=km4.mbn
 --partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -49,7 +49,8 @@
 --partition --name=dsp_b --size=65536KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
 --partition --name=abl_b --size=1024KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=abl.elf
---partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
 --partition --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
 --partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
 --partition --name=imagefv_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -32,6 +32,11 @@
 --partition --name=hyp_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=hyp.mbn
 --partition --name=boot_a --size=4096KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
 --partition --name=boot_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
+--partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388
+--partition --name=uefi_b --size=8192KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B
+--partition --name=uefi_dtb_a --size=1024KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6
+--partition --name=uefi_dtb_b --size=1024KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662
+--partition --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
 --partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=km4.mbn
 --partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=km4.mbn
 --partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -45,8 +45,6 @@
 --partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
 --partition --name=abl_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=abl.elf
 --partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
---partition --name=bluetooth_a --size=1024KB --type-guid=6cb747f1-c2ef-4092-add0-ca39f79c7af4
---partition --name=bluetooth_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
 --partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
 --partition --name=imagefv_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -21,15 +21,15 @@
 
 # This is physical partition 0
 --partition --name=xbl_a --size=3584KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
---partition --name=xbl_b --size=3584KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=xbl.elf
+--partition --name=xbl_b --size=3584KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
 --partition --name=xbl_config_a --size=128KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_feature_config.elf
---partition --name=xbl_config_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=xbl_feature_config.elf
+--partition --name=xbl_config_b --size=128KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_feature_config.elf
 --partition --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
---partition --name=tz_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=tz.mbn
+--partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
---partition --name=rpm_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=rpm.mbn
+--partition --name=rpm_b --size=512KB --type-guid=EDE665C0-9F65-47D9-A8C1-73D61EF3C7D6 --filename=rpm.mbn
 --partition --name=hyp_a --size=512KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
---partition --name=hyp_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=hyp.mbn
+--partition --name=hyp_b --size=512KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hyp.mbn
 --partition --name=boot_a --size=4096KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
 --partition --name=boot_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
 --partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388
@@ -48,7 +48,7 @@
 --partition --name=dsp_a --size=65536KB --type-guid=7EFE5010-2A1A-4A1A-B8BC-990257813512
 --partition --name=dsp_b --size=65536KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
---partition --name=abl_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=abl.elf
+--partition --name=abl_b --size=1024KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=abl.elf
 --partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
 --partition --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
 --partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
@@ -60,7 +60,7 @@
 --partition --name=misc_boot --size=1024KB --type-guid=F4EEE7D9-AB97-4297-954B-1B8AF9C14B19 --filename=zeros_33sectors.bin
 --partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
 --partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
---partition --name=devcfg_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=devcfg.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg.mbn
 --partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7 --filename=featenabler.mbn
 --partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=featenabler.mbn
 --partition --name=qupfw_a --size=64KB --type-guid=21d1219f-2ed1-4ab4-930a-41a16ae75f7f --filename=qupv3fw.elf


### PR DESCRIPTION
This PR intends to update RB1 partition layout such that it is compatible with future edk2/UEFI support as well as optimising for size to drop redundant partitions and reducing size for boot partition.