### PR TITLE
partitions: remove the filenames not needed on QCS615

### DIFF
--- a/platforms/qcs615-adp-air/partitions.conf
+++ b/platforms/qcs615-adp-air/partitions.conf
@@ -30,8 +30,8 @@
 --partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
 --partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
 --partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=keymint.mbn
---partition --name=secs2d_a --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c --filename=secs2d.mbn
+--partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --name=secs2d_a --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c
 --partition --name=cmnlib_a --size=512KB --type-guid=73471795-AB54-43F9-A847-4F72EA5CBEF5
 --partition --name=cmnlib64_a --size=512KB --type-guid=8EA64893-1267-4A1B-947C-7C362ACAAD2C
 --partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
@@ -64,7 +64,7 @@
 --partition --name=qupfw_b --size=64KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
 --partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
 --partition --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
---partition --name=secs2d_b --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c --filename=secs2d.mbn
+--partition --name=secs2d_b --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c
 --partition --name=cmnlib_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=cmnlib64_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf


### PR DESCRIPTION
This change is to fix the build flash failure when the non-exist image files specified in partition conf file, following is the failure log from PCAT:

WARNING   [  Response - Firehose proces failed: 'keymint.mbn' not found.You could possibly try
--notfiles=keymint.mbn,OtherFileToSkip.bin (note, exiting since you specified --noprompt) ]
ERROR     =====: Failed to load the software build on the device - qcs615-adp-air :=====