### PR TITLE
qcs6490-rb3gen2: Explicitly erase apdp_a/b partitions

### DIFF
--- a/platforms/qcs6490-rb3gen2/partitions.conf
+++ b/platforms/qcs6490-rb3gen2/partitions.conf
@@ -51,7 +51,7 @@
 # These are the 'A' partition's needed for the A/B boot/ota update feature.
 # If you add something to this section remember to add it to B as well
 --partition --lun=4 --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
---partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
@@ -71,7 +71,7 @@
 #These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 #For convinience sake we keep all the B partitions with the same GUID
 --partition --lun=4 --name=aop_b --size=512KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896
---partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587
 --partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=FF608BF6-AEDF-4084-BEC5-C92AB4E4534D
 --partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B


### PR DESCRIPTION
apdp_a/b partitions are optional during boot. Garbage data in that partition can lead to boot crash as follows:

...
B -   1001101 - APDP -  Image Load, Start
D -       244 - Auth Metadata
B -   1009489 - Error code 65 at boot_platforminfo.c Line 76
B -   1010709 - Call Stack:
B -   1016229 - func_addr  :   1481E438
B -   1018822 - func_addr  :   1481D8BC
B -   1022482 - ^^^^^^^^^^^^^^^^^^^^^
B -   1031205 - sbl_error_handler: copied boot regions to crash dump region

Lets erase apdp_a/b partitions explicitly to avoid the above crash.