### PR TITLE
platforms: By default erase apdp{_a/b} partitions

### DIFF
--- a/platforms/apq8096-db820c/partitions.conf
+++ b/platforms/apq8096-db820c/partitions.conf
@@ -65,7 +65,7 @@
 --partition --lun=4 --name=cmnlibbak --size=256KB --type-guid=73471795-AB54-43F9-A847-4F72EA5CBEF5 --filename=cmnlib.mbn
 --partition --lun=4 --name=cmnlib64 --size=256KB --type-guid=8EA64893-1267-4A1B-947C-7C362ACAAD2C --filename=cmnlib64.mbn
 --partition --lun=4 --name=cmnlib64bak --size=256KB --type-guid=8EA64893-1267-4A1B-947C-7C362ACAAD2C --filename=cmnlib64.mbn
---partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=msadp --size=256KB --type-guid=ED9E8101-05FA-46B7-82AA-8D58770D200B
 --partition --lun=4 --name=dpo --size=1KB --type-guid=11406F35-1173-4869-807B-27DF71802812
 --partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B

--- a/platforms/qcm6490-idp/partitions.conf
+++ b/platforms/qcm6490-idp/partitions.conf
@@ -51,7 +51,7 @@
 # These are the 'A' partition's needed for the A/B boot/ota update feature.
 # If you add something to this section remember to add it to B as well
 --partition --lun=4 --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
---partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
@@ -71,7 +71,7 @@
 #These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 #For convinience sake we keep all the B partitions with the same GUID
 --partition --lun=4 --name=aop_b --size=512KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896
---partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587
 --partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=FF608BF6-AEDF-4084-BEC5-C92AB4E4534D
 --partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B

--- a/platforms/qcs615-adp-air/partitions.conf
+++ b/platforms/qcs615-adp-air/partitions.conf
@@ -38,7 +38,7 @@
 --partition --name=qupfw_a --size=64KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
 --partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
 --partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
---partition --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
 --partition --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
@@ -63,7 +63,7 @@
 --partition --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2
 --partition --name=qupfw_b --size=64KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
 --partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
---partition --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --name=secs2d_b --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c
 --partition --name=cmnlib_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=cmnlib64_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34

--- a/platforms/qcs8300-ride-sx/partitions.conf
+++ b/platforms/qcs8300-ride-sx/partitions.conf
@@ -61,7 +61,7 @@
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
---partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
@@ -79,7 +79,7 @@
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
---partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf

--- a/platforms/qcs9100-ride-sx/partitions.conf
+++ b/platforms/qcs9100-ride-sx/partitions.conf
@@ -61,7 +61,7 @@
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
---partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
@@ -79,7 +79,7 @@
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
---partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf

--- a/platforms/qrb2210-rb1/partitions.conf
+++ b/platforms/qrb2210-rb1/partitions.conf
@@ -70,7 +70,7 @@
 --partition --name=rawdump --size=131072KB --type-guid=66C9B323-F7FC-48B6-BF96-6F32E335A428
 --partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --name=spunvm --size=8192KB --type-guid=e42e2b4c-33b0-429b-b1ef-d341c547022c
 --partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
 --partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794

--- a/platforms/qrb4210-rb2/partitions.conf
+++ b/platforms/qrb4210-rb2/partitions.conf
@@ -77,7 +77,7 @@
 --partition --name=rawdump --size=131072KB --type-guid=66C9B323-F7FC-48B6-BF96-6F32E335A428
 --partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --name=spunvm --size=8192KB --type-guid=e42e2b4c-33b0-429b-b1ef-d341c547022c
 --partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
 --partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794

--- a/platforms/qrb5165-rb5/partitions.conf
+++ b/platforms/qrb5165-rb5/partitions.conf
@@ -96,7 +96,7 @@
 #These are non A/B partitions. In a A/B build these would not be updated via a OTA update
 --partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=msadp --size=256KB --type-guid=ED9E8101-05FA-46B7-82AA-8D58770D200B
 --partition --lun=4 --name=spunvm --size=32768KB --type-guid=e42e2b4c-33b0-429b-b1ef-d341c547022c
 --partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794

--- a/platforms/sdm845-db845c/partitions.conf
+++ b/platforms/sdm845-db845c/partitions.conf
@@ -85,7 +85,7 @@
 --partition --lun=4 --name=devinfo --size=1KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
 --partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
 --partition --lun=4 --name=fdemeta --size=512KB --type-guid=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
---partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=4 --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=msadp --size=256KB --type-guid=ED9E8101-05FA-46B7-82AA-8D58770D200B
 --partition --lun=4 --name=spunvm --size=8192KB --type-guid=e42e2b4c-33b0-429b-b1ef-d341c547022c
 --partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B


### PR DESCRIPTION
APDP firmware partition stands for "Apps Processor Debug Policy". It is generally used to enable debug functionality on a secured/fused device.

It is recommended to erase this option debug partition by default since any garbage contents with correct magic value for APDP can lead to a boot crash which was observed on RB3G2 as follows:

```
...
B -   1001101 - APDP -  Image Load, Start
D -       244 - Auth Metadata
B -   1009489 - Error code 65 at boot_platforminfo.c Line 76
B -   1010709 - Call Stack:
B -   1016229 - func_addr  :   1481E438
B -   1018822 - func_addr  :   1481D8BC
B -   1022482 - ^^^^^^^^^^^^^^^^^^^^^
B -   1031205 - sbl_error_handler: copied boot regions to crash dump region
```

Lets fix this issue on all platforms via erasing this APDP partition.