### PR TITLE
Add build_id placeholder to contents.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ install: $(BINS)
 	install -m 755 $^ $(DESTDIR)$(PREFIX)/bin
 
 clean:
-	@rm -f platforms/*/*.xml platforms/*/*.bin
+	@rm -f platforms/*/*/*.xml platforms/*/*/*.bin

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ CONTENTS_XML := $(patsubst %.xml.in,%.xml, $(CONTENTS_XML_IN))
 BINS := gen_contents.py gen_partition.py msp.py ptool.py
 PREFIX ?= /usr/local
 
+# optional build_id for Axiom contents.xml files
+BUILD_ID ?=
+
 .PHONY: all check clean lint integration
 
 all: $(PLATFORMS) $(PARTITIONS_XML) $(CONTENTS_XML)
@@ -19,7 +22,7 @@ all: $(PLATFORMS) $(PARTITIONS_XML) $(CONTENTS_XML)
 	$(TOPDIR)/gen_partition.py -i $^ -o $@
 
 %/contents.xml: %/partitions.xml %/contents.xml.in
-	$(TOPDIR)/gen_contents.py -p $< -t $@.in -o $@
+	$(TOPDIR)/gen_contents.py -p $< -t $@.in -o $@ $${BUILD_ID:+ -b $(BUILD_ID)}
 
 lint:
 	# W605: invalid escape sequence

--- a/gen_contents.py
+++ b/gen_contents.py
@@ -27,7 +27,7 @@ def ParseXML(XMLFile):
         return None
 
 
-def UpdateMetaData(TemplateRoot, PartitionRoot):
+def UpdateMetaData(TemplateRoot, PartitionRoot, BuildId):
     ChipIdList = TemplateRoot.findall('product_info/chipid')
     DefaultStorageType = None
     for ChipId in ChipIdList:
@@ -64,6 +64,8 @@ def UpdateMetaData(TemplateRoot, PartitionRoot):
     for build in builds:
         Name = build.find('name')
         print(f"Build Name: {Name.text}")
+        new_build_id = ET.SubElement(build, "build_id")
+        new_build_id.text = BuildId
         if Name.text != "common":
             continue
         DownloadFile = build.find('download_file')
@@ -113,7 +115,8 @@ try:
     if sys.argv[1] == "-h" or sys.argv[1] == "--help":
         usage()
     try:
-        opts, rem = getopt.getopt(sys.argv[1:], "t:p:o:")
+        build_id = ""
+        opts, rem = getopt.getopt(sys.argv[1:], "t:p:o:b:")
         for (opt, arg) in opts:
             if opt in ["-t"]:
                 template = arg
@@ -121,6 +124,8 @@ try:
                 partition_xml = arg
             elif opt in ["-o"]:
                 output_xml = arg
+            elif opt in ["-b"]:
+                build_id = arg
             else:
                 usage()
     except Exception as argerr:
@@ -133,11 +138,11 @@ try:
     print("Selected Partition XML:  " + partition_xml)
     partition_root = ParseXML(partition_xml)
 
-    UpdateMetaData(xml_root, partition_root)
+    UpdateMetaData(xml_root, partition_root, build_id)
 
     OutputTree = ET.ElementTree(xml_root)
     ET.indent(OutputTree, space="\t", level=0)
-    OutputTree.write(output_xml, encoding="utf-8", xml_declaration=True)
+    OutputTree.write(output_xml, encoding="utf-8", xml_declaration=True, short_empty_elements=False)
 except Exception as e:
     print(("Error: ", e))
     sys.exit(1)


### PR DESCRIPTION
Axiom requires a unique identifier (build_id) to track published artifacts. Since values like github.run_id or build path are not
accessible at the ptool repository level, add a placeholder field in contents.xml.

The actual build_id can be injected during the final build stage in meta-qcom by passing "BUILD_ID=" to make. 

Initial change to fix https://github.com/qualcomm-linux/meta-qcom/issues/1081