### PR TITLE
Fix GPT file names to use .bin extension in gen_contents.py

### DIFF
--- a/gen_contents.py
+++ b/gen_contents.py
@@ -78,10 +78,10 @@ def UpdateMetaData(TemplateRoot, PartitionRoot):
             for PhysicalPartitionNumber in range(0, len(PhyPartition)):
                 new_download_file = ET.SubElement(build, "download_file")
                 new_download_file.set("storage_type", DefaultStorageType)
-                _add_file_elements(new_download_file, 'gpt_main%d.xml' % (PhysicalPartitionNumber))
+                _add_file_elements(new_download_file, 'gpt_main%d.bin' % (PhysicalPartitionNumber))
                 new_download_file = ET.SubElement(build, "download_file")
                 new_download_file.set("storage_type", DefaultStorageType)
-                _add_file_elements(new_download_file, 'gpt_backup%d.xml' % (PhysicalPartitionNumber))
+                _add_file_elements(new_download_file, 'gpt_backup%d.bin' % (PhysicalPartitionNumber))
 
         PartitionFile = build.find('partition_file')
         if PartitionFile is not None:


### PR DESCRIPTION
Correct the filenames for GPT partitions in the generated contents.xml to use `.bin` instead of `.xml` to match with the actual content being generated at build time and to ensure the correct files are flashed.