### PR TITLE
gen_partition: skip physical_partition with no partition

### DIFF
--- a/gen_partition.py
+++ b/gen_partition.py
@@ -188,13 +188,18 @@ def generate_ufs_xml (disk_params, partition_entries_dict, output_xml):
    )
    lun_index=0
    while lun_index < 6:
-      phy_part = ET.SubElement(root, "physical_partition")
+      found = False
 
       for partition_index, entry in partition_entries_dict.items():
          part_entry = parse_partition_entry(entry)
          if part_entry["physical_partition"] == str(lun_index):
             del part_entry["physical_partition"]
+            # if there is no partition in the LUN, skip the physical_partition in XML
+            # only create the physical_partition once we have at least one partition
+            if not found:
+               phy_part = ET.SubElement(root, "physical_partition")
             part = ET.SubElement(phy_part, "partition", attrib=part_entry)
+            found = True
       lun_index +=1
 
    xmlstr = minidom.parseString(ET.tostring(root)).toprettyxml()


### PR DESCRIPTION
gen_partition.py assumes there can be up to 5 LUNs, and generate an XML file with 5 physical_partition entries. For QCS615, there are only 4 LUNs, and we end up generating partitions.xml with an extra, empty physical_partition entry.

The right thing would probably be to parse partition.conf and detect how many LUNs we have in there, but a simpler solution is to keep trying 5 LUNs but only create the physical_partition entry once we find at least one partition, which is what this patch does. It should fix the problem we've noticed in #42.