### PR TITLE
Update sail_nor image names in contents.xml

### DIFF
--- a/platforms/iq-8275-evk/ufs/contents.xml.in
+++ b/platforms/iq-8275-evk/ufs/contents.xml.in
@@ -81,7 +81,11 @@
         <file_path flavor="default">.</file_path>
       </partition_patch_file>
       <download_file storage_type="spinor" fastboot_complete="SAIL_HYP">
-        <file_name>sailfreertos.elf</file_name>
+        <file_name>sailhyp.elf</file_name>
+        <file_path flavor="sail_nor">./sail_nor</file_path>
+      </download_file>
+      <download_file storage_type="spinor" fastboot_complete="SAIL_SW1">
+        <file_name>sailsw1.elf</file_name>
         <file_path flavor="sail_nor">./sail_nor</file_path>
       </download_file>
       <download_file storage_type="spinor" flavor="sail_nor">

--- a/platforms/iq-9075-evk/ufs/contents.xml.in
+++ b/platforms/iq-9075-evk/ufs/contents.xml.in
@@ -81,7 +81,11 @@
         <file_path flavor="default">.</file_path>
       </partition_patch_file>
       <download_file storage_type="spinor" fastboot_complete="SAIL_HYP">
-        <file_name>sailfreertos.elf</file_name>
+        <file_name>sailhyp.elf</file_name>
+        <file_path flavor="sail_nor">./sail_nor</file_path>
+      </download_file>
+      <download_file storage_type="spinor" fastboot_complete="SAIL_SW1">
+        <file_name>sailsw1.elf</file_name>
         <file_path flavor="sail_nor">./sail_nor</file_path>
       </download_file>
       <download_file storage_type="spinor" flavor="sail_nor">

--- a/platforms/qcs8300-ride-sx/ufs/contents.xml.in
+++ b/platforms/qcs8300-ride-sx/ufs/contents.xml.in
@@ -81,7 +81,11 @@
         <file_path flavor="default">.</file_path>
       </partition_patch_file>
       <download_file storage_type="spinor" fastboot_complete="SAIL_HYP">
-        <file_name>sailfreertos.elf</file_name>
+        <file_name>sailhyp.elf</file_name>
+        <file_path flavor="sail_nor">./sail_nor</file_path>
+      </download_file>
+      <download_file storage_type="spinor" fastboot_complete="SAIL_SW1">
+        <file_name>sailsw1.elf</file_name>
         <file_path flavor="sail_nor">./sail_nor</file_path>
       </download_file>
       <download_file storage_type="spinor" flavor="sail_nor">

--- a/platforms/qcs9100-ride-sx/ufs/contents.xml.in
+++ b/platforms/qcs9100-ride-sx/ufs/contents.xml.in
@@ -81,7 +81,11 @@
         <file_path flavor="default">.</file_path>
       </partition_patch_file>
       <download_file storage_type="spinor" fastboot_complete="SAIL_HYP">
-        <file_name>sailfreertos.elf</file_name>
+        <file_name>sailhyp.elf</file_name>
+        <file_path flavor="sail_nor">./sail_nor</file_path>
+      </download_file>
+      <download_file storage_type="spinor" fastboot_complete="SAIL_SW1">
+        <file_name>sailsw1.elf</file_name>
         <file_path flavor="sail_nor">./sail_nor</file_path>
       </download_file>
       <download_file storage_type="spinor" flavor="sail_nor">

--- a/tests/integration/check-missing-files
+++ b/tests/integration/check-missing-files
@@ -59,7 +59,8 @@ for xml in "$@"; do
           qupv3fw.elf) ;;
           rootfs.img) ;;
           rpm.mbn) ;;
-          sailfreertos.elf) ;;
+          sailhyp.elf) ;;
+          sailsw1.elf) ;;
           sbc_1.0_8016.bin) ;;
           sbc_1.0_8096.bin) ;;
           sbl1.mbn) ;;


### PR DESCRIPTION
Starting with the 00103.0 release, sailfreertos.elf has been replaced by sailhyp.elf and sailsw1.elf in sail_nor images. Update the contents.xml templates to reflect this change.