### PR TITLE
qrb2210-rb1: increase HYP partition size

### DIFF
--- a/platforms/qrb2210-rb1/emmc/partitions.conf
+++ b/platforms/qrb2210-rb1/emmc/partitions.conf
@@ -28,8 +28,8 @@
 --partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
 --partition --name=rpm_b --size=512KB --type-guid=EDE665C0-9F65-47D9-A8C1-73D61EF3C7D6 --filename=rpm.mbn
---partition --name=hyp_a --size=512KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
---partition --name=hyp_b --size=512KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hyp.mbn
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hyp.mbn
 --partition --name=boot_a --size=4096KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
 --partition --name=boot_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
 --partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388


### PR DESCRIPTION
For QLI mainline firmware support, Gunyah requires at maximum 8MB HYP image partition size. Let's update HYP partition size to support that.