### PR TITLE
platforms: klmt: remove mdtp partitions

### DIFF
--- a/platforms/iq-8275-evk/ufs/partitions.conf
+++ b/platforms/iq-8275-evk/ufs/partitions.conf
@@ -55,8 +55,6 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F

--- a/platforms/iq-9075-evk/ufs/partitions.conf
+++ b/platforms/iq-9075-evk/ufs/partitions.conf
@@ -55,8 +55,6 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F

--- a/platforms/qcm6490-idp/ufs/partitions.conf
+++ b/platforms/qcm6490-idp/ufs/partitions.conf
@@ -57,8 +57,6 @@
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
 --partition --lun=4 --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
 --partition --lun=4 --name=qupfw_a --size=80KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
 --partition --lun=4 --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
@@ -77,8 +75,6 @@
 --partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
 --partition --lun=4 --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=4 --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --lun=4 --name=mdtp_b --size=32768KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg.mbn
 --partition --lun=4 --name=qupfw_b --size=80KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C --filename=qupv3fw.elf
 --partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn

--- a/platforms/qcs615-adp-air/emmc/partitions.conf
+++ b/platforms/qcs615-adp-air/emmc/partitions.conf
@@ -28,8 +28,6 @@
 --partition --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
 --partition --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --name=secs2d_a --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c
 --partition --name=cmnlib_a --size=512KB --type-guid=73471795-AB54-43F9-A847-4F72EA5CBEF5

--- a/platforms/qcs6490-rb3gen2/ufs/partitions.conf
+++ b/platforms/qcs6490-rb3gen2/ufs/partitions.conf
@@ -57,8 +57,6 @@
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
 --partition --lun=4 --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
 --partition --lun=4 --name=qupfw_a --size=80KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
 --partition --lun=4 --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
@@ -77,8 +75,6 @@
 --partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
 --partition --lun=4 --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=4 --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --lun=4 --name=mdtp_b --size=32768KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg.mbn
 --partition --lun=4 --name=qupfw_b --size=80KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C --filename=qupv3fw.elf
 --partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn

--- a/platforms/qcs8300-ride-sx/ufs/partitions.conf
+++ b/platforms/qcs8300-ride-sx/ufs/partitions.conf
@@ -55,8 +55,6 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F

--- a/platforms/qcs9100-ride-sx/ufs/partitions.conf
+++ b/platforms/qcs9100-ride-sx/ufs/partitions.conf
@@ -55,8 +55,6 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F


### PR DESCRIPTION
Remove mdtp / mdtpsecapp partitions (Mobile Device Theft Prevention) from the KLMT targets as this feature is not available / used in Qualcomm Linux.