### PR TITLE
platforms: klmt: zero partitions without flashable content

### DIFF
--- a/platforms/iq-8275-evk/ufs/partitions.conf
+++ b/platforms/iq-8275-evk/ufs/partitions.conf
@@ -55,17 +55,17 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
+--partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
 --partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
---partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+--partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27 --filename=zeros_33sectors.bin
 # These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 --partition --lun=4 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
 --partition --lun=4 --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
@@ -75,35 +75,35 @@
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=4 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889
+--partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
 --partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
---partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003
+--partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003 --filename=zeros_33sectors.bin
 # These are non A/B partitions. In a A/B build these would not BE UPDATED VIA A OTA UPDATE
---partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
+--partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65 --filename=zeros_1sector.bin
 # - Below are PVM images
---partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
---partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
---partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
+--partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN

--- a/platforms/iq-9075-evk/ufs/partitions.conf
+++ b/platforms/iq-9075-evk/ufs/partitions.conf
@@ -55,17 +55,17 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
+--partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
 --partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
---partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+--partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27 --filename=zeros_33sectors.bin
 # These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 --partition --lun=4 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
 --partition --lun=4 --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
@@ -75,35 +75,35 @@
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=4 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889
+--partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
 --partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
---partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003
+--partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003 --filename=zeros_33sectors.bin
 # These are non A/B partitions. In a A/B build these would not BE UPDATED VIA A OTA UPDATE
---partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
+--partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65 --filename=zeros_1sector.bin
 # - Below are PVM images
---partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
---partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
---partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
+--partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN

--- a/platforms/qcm6490-idp/ufs/partitions.conf
+++ b/platforms/qcm6490-idp/ufs/partitions.conf
@@ -89,30 +89,30 @@
 --partition --lun=4 --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF
 
 #These are non A/B partitions. In a A/B build these would not be updated via a OTA update
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=questdatafv --size=16384KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
---partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --lun=4 --name=limits-cdsp --size=4KB --type-guid=545D3707-8329-40E8-8B5E-3E554CBDC786
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=questdatafv --size=16384KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --lun=4 --name=limits-cdsp --size=4KB --type-guid=545D3707-8329-40E8-8B5E-3E554CBDC786 --filename=zeros_1sector.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
---partition --lun=4 --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09
---partition --lun=4 --name=catecontentfv --size=1024KB  --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
---partition --lun=4 --name=vm-data --size=33424KB --type-guid=21ADB864-C9E7-4C76-BE68-568E20C58439
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
+--partition --lun=4 --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=catecontentfv --size=1024KB  --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=vm-data --size=33424KB --type-guid=21ADB864-C9E7-4C76-BE68-568E20C58439 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN
 #QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
---partition --lun=5 --name=modemst1 --size=3072KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
---partition --lun=5 --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
---partition --lun=5 --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
---partition --lun=5 --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB
+--partition --lun=5 --name=modemst1 --size=3072KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_33sectors.bin
+--partition --lun=5 --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_33sectors.bin
+--partition --lun=5 --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_33sectors.bin
+--partition --lun=5 --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_5sectors.bin
 --partition --lun=5 --name=persist --size=30720KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 --partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/qcs615-adp-air/emmc/partitions.conf
+++ b/platforms/qcs615-adp-air/emmc/partitions.conf
@@ -28,53 +28,53 @@
 --partition --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
 --partition --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
---partition --name=secs2d_a --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c
---partition --name=cmnlib_a --size=512KB --type-guid=73471795-AB54-43F9-A847-4F72EA5CBEF5
---partition --name=cmnlib64_a --size=512KB --type-guid=8EA64893-1267-4A1B-947C-7C362ACAAD2C
+--partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6 --filename=zeros_33sectors.bin
+--partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3 --filename=zeros_33sectors.bin
+--partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
+--partition --name=secs2d_a --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c --filename=zeros_1sector.bin
+--partition --name=cmnlib_a --size=512KB --type-guid=73471795-AB54-43F9-A847-4F72EA5CBEF5 --filename=zeros_33sectors.bin
+--partition --name=cmnlib64_a --size=512KB --type-guid=8EA64893-1267-4A1B-947C-7C362ACAAD2C --filename=zeros_33sectors.bin
 --partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
 --partition --name=qupfw_a --size=64KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
 --partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
 --partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
---partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
---partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C
---partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
---partition --name=rawdump --size=131072KB --type-guid=66C9B323-F7FC-48B6-BF96-6F32E335A428
---partition --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --name=logdump --size=65536KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --name=storsec --size=128KB --type-guid=02DB45FE-AD1B-4CB6-AECC-0042C637DEFA
---partition --name=multiimgoem --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8
---partition --name=multiimgqti --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
---partition --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
---partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C --filename=zeros_33sectors.bin
+--partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=zeros_33sectors.bin
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191 --filename=zeros_33sectors.bin
+--partition --name=rawdump --size=131072KB --type-guid=66C9B323-F7FC-48B6-BF96-6F32E335A428 --filename=zeros_33sectors.bin
+--partition --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665 --filename=zeros_33sectors.bin
+--partition --name=logdump --size=65536KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --name=storsec --size=128KB --type-guid=02DB45FE-AD1B-4CB6-AECC-0042C637DEFA --filename=zeros_1sector.bin
+--partition --name=multiimgoem --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=zeros_1sector.bin
+--partition --name=multiimgqti --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=zeros_1sector.bin
+--partition --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066 --filename=zeros_33sectors.bin
+--partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_1sector.bin
 --partition --name=aop_b --size=512KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
 --partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --name=hyp_b --size=8192KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=zeros_33sectors.bin
 --partition --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
 --partition --name=qupfw_b --size=64KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC --filename=qupv3fw.elf
 --partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
 --partition --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
---partition --name=secs2d_b --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c
---partition --name=cmnlib_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --name=cmnlib64_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=secs2d_b --size=64KB --type-guid=5f435fe2-5707-4fed-9719-853c2aa6d23c --filename=zeros_1sector.bin
+--partition --name=cmnlib_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=zeros_33sectors.bin
+--partition --name=cmnlib64_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=zeros_33sectors.bin
 --partition --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
 --partition --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
 --partition --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
 --partition --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E --filename=XblRamdump.elf
---partition --name=core_nhlos_a --size=174080KB --type-guid=6690b4ce-70e9-4817-b9f1-25d64d888357
---partition --name=core_nhlos_b --size=174080KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --name=quantumfv --size=512KB --type-guid=80c23c26-c3f9-4a19-bb38-1e457daceb09
---partition --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+--partition --name=core_nhlos_a --size=174080KB --type-guid=6690b4ce-70e9-4817-b9f1-25d64d888357 --filename=zeros_33sectors.bin
+--partition --name=core_nhlos_b --size=174080KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=zeros_33sectors.bin
+--partition --name=quantumfv --size=512KB --type-guid=80c23c26-c3f9-4a19-bb38-1e457daceb09 --filename=zeros_33sectors.bin
+--partition --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
 --partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
---partition --name=persist --size=131072KB --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+--partition --name=persist --size=131072KB --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4 --filename=zeros_33sectors.bin
 --partition --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img

--- a/platforms/qcs615-adp-air/ufs/partitions.conf
+++ b/platforms/qcs615-adp-air/ufs/partitions.conf
@@ -61,10 +61,10 @@
 --partition --lun=4 --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
 --partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
---partition --lun=4 --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F
+--partition --lun=4 --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
---partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
---partition --lun=4 --name=qweslicstore_a  --size=256KB --type-guid=7BAB3C93-5F73-4D02-B8CB-5B9F899D29A8
+--partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=zeros_5sectors.bin
+--partition --lun=4 --name=qweslicstore_a  --size=256KB --type-guid=7BAB3C93-5F73-4D02-B8CB-5B9F899D29A8 --filename=zeros_33sectors.bin
 
 #These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 #For convinience sake we keep all the B partitions with the same GUID
@@ -78,22 +78,22 @@
 --partition --lun=4 --name=uefi_b --size=8192KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
 --partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=FF608BF6-AEDF-4084-BEC5-C92AB4E4534D --filename=XblRamdump.elf
 --partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
---partition --lun=4 --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687
+--partition --lun=4 --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
---partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9
---partition --lun=4 --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF
+--partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=zeros_5sectors.bin
+--partition --lun=4 --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF --filename=zeros_33sectors.bin
 
 #These are non A/B partitions. In a A/B build these would not be updated via a OTA update
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/qcs6490-rb3gen2/ufs/partitions.conf
+++ b/platforms/qcs6490-rb3gen2/ufs/partitions.conf
@@ -89,30 +89,30 @@
 --partition --lun=4 --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF
 
 #These are non A/B partitions. In a A/B build these would not be updated via a OTA update
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=questdatafv --size=16384KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
---partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --lun=4 --name=limits-cdsp --size=4KB --type-guid=545D3707-8329-40E8-8B5E-3E554CBDC786
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=questdatafv --size=16384KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --lun=4 --name=limits-cdsp --size=4KB --type-guid=545D3707-8329-40E8-8B5E-3E554CBDC786 --filename=zeros_1sector.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
---partition --lun=4 --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09
---partition --lun=4 --name=catecontentfv --size=1024KB  --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
---partition --lun=4 --name=vm-data --size=33424KB --type-guid=21ADB864-C9E7-4C76-BE68-568E20C58439
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
+--partition --lun=4 --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=catecontentfv --size=1024KB  --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=vm-data --size=33424KB --type-guid=21ADB864-C9E7-4C76-BE68-568E20C58439 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN
 #QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
---partition --lun=5 --name=modemst1 --size=3072KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
---partition --lun=5 --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
---partition --lun=5 --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
---partition --lun=5 --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB
+--partition --lun=5 --name=modemst1 --size=3072KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_33sectors.bin
+--partition --lun=5 --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_33sectors.bin
+--partition --lun=5 --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_33sectors.bin
+--partition --lun=5 --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB --filename=zeros_5sectors.bin
 --partition --lun=5 --name=persist --size=30720KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
 --partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/qcs8300-ride-sx/ufs/partitions.conf
+++ b/platforms/qcs8300-ride-sx/ufs/partitions.conf
@@ -55,17 +55,17 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
+--partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
 --partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
---partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+--partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27 --filename=zeros_33sectors.bin
 # These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 --partition --lun=4 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
 --partition --lun=4 --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
@@ -75,35 +75,35 @@
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=4 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889
+--partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
 --partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
---partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003
+--partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003 --filename=zeros_33sectors.bin
 # These are non A/B partitions. In a A/B build these would not BE UPDATED VIA A OTA UPDATE
---partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
+--partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65 --filename=zeros_1sector.bin
 # - Below are PVM images
---partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
---partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
---partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
+--partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN

--- a/platforms/qcs9100-ride-sx/ufs/partitions.conf
+++ b/platforms/qcs9100-ride-sx/ufs/partitions.conf
@@ -55,17 +55,17 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
---partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
---partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
---partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
+--partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
 --partition --lun=4 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
---partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+--partition --lun=4 --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27 --filename=zeros_33sectors.bin
 # These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 --partition --lun=4 --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
 --partition --lun=4 --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
@@ -75,35 +75,35 @@
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --lun=4 --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
---partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889
+--partition --lun=4 --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
---partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --lun=4 --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC --filename=zeros_5sectors.bin
 --partition --lun=4 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
 --partition --lun=4 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
---partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003
+--partition --lun=4 --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003 --filename=zeros_33sectors.bin
 # These are non A/B partitions. In a A/B build these would not BE UPDATED VIA A OTA UPDATE
---partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
---partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
---partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
---partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
---partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
---partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
---partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
---partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7 --filename=zeros_1sector.bin
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03 --filename=zeros_1sector.bin
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB --filename=zeros_33sectors.bin
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C --filename=zeros_33sectors.bin
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B --filename=zeros_33sectors.bin
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794 --filename=zeros_1sector.bin
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93 --filename=zeros_5sectors.bin
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
+--partition --lun=4 --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65 --filename=zeros_1sector.bin
 # - Below are PVM images
---partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
---partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
---partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
---partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
+--partition --lun=4 --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD --filename=zeros_33sectors.bin
+--partition --lun=4 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598 --filename=zeros_33sectors.bin
+--partition --lun=4 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F --filename=zeros_1sector.bin
+--partition --lun=4 --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0 --filename=zeros_33sectors.bin
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 5 - Protected Read-write LUN


### PR DESCRIPTION
Only ddr_a/b (ddr training) and persist remains without being zeroed on a clean flash, required in order to be able to always reproduce the same flash state on clean flash.