### PR TITLE
add NVMe as a valid disk type in gen_partition.py

### DIFF
--- a/gen_partition.py
+++ b/gen_partition.py
@@ -207,7 +207,7 @@ def generate_multi_lun_xml (disk_params, partition_entries_dict, output_xml):
 def generate_partition_xml (disk_entry, partition_entries_dict, output_xml):
    parse_disk_entry(disk_entry)
    print("Generating %s XML %s" %(disk_params["type"].upper(), output_xml))
-   if disk_params["type"] == "emmc":
+   if disk_params["type"] in ("emmc", "nvme"):
       generate_single_disk_xml(disk_params, partition_entries_dict, output_xml)
    elif disk_params["type"] == "ufs":
       generate_multi_lun_xml(disk_params, partition_entries_dict, output_xml)


### PR DESCRIPTION
NVMe flashing follows the same process as eMMC. Add `nvme` as a valid
disk type to explicitly call out the supported storage options.