### PR TITLE
qcs6490-rb3gen2: add usb_fw partition

### DIFF
--- a/platforms/qcs6490-rb3gen2/ufs/partitions.conf
+++ b/platforms/qcs6490-rb3gen2/ufs/partitions.conf
@@ -43,6 +43,7 @@
 --partition --lun=3 --name=cdt --size=128KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
 --partition --lun=3 --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
 --partition --lun=3 --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
+--partition --lun=3 --name=usb_fw --size=1024KB --type-guid=3C3DDB5E-314A-44E7-93E3-62D519D7B4BB
 --partition --lun=3 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
 
 #This is LUN 4 - Protected Read-only LUN


### PR DESCRIPTION
add usb_fw partition to partition.conf for qcs6490-rb3gen2, required for USB type A port to work. usb_fw partition is part of [QLI 1.6 release](https://qartifactory-edge.qualcomm.com/ui/native/qsc_releases/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_public/r1.0_00100.0/qcm6490-le-1-0/common/build/ufs/bin/), adding it on qcom-ptool to align with QLI 1.0

How it is used on QLI 1.0:
- The firmware is flashed on the partition during factory testing
- Post that, user space will [mount ](https://github.com/qualcomm-linux/meta-qcom-hwe/blob/scarthgap/recipes-bsp/usb/files/var-usbfw.mount )the partition and copy the file to /lib/firmware ([Reference](https://github.com/qualcomm-linux/meta-qcom-hwe/blob/scarthgap/recipes-bsp/usb/usb.bb))
- When usb driver comes, it will load it over pcie