### PR TITLE
platforms: specify dtb file name in spinor partition conf

### DIFF
--- a/platforms/iq-x7181-evk/spinor/partitions.conf
+++ b/platforms/iq-x7181-evk/spinor/partitions.conf
@@ -83,8 +83,8 @@
 --partition --name=qweslicstore_a --size=256KB --type-guid=7BAB3C93-5F73-4D02-B8CB-5B9F899D29A8
 --partition --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF
 --partition --name=emac --size=512KB --type-guid=e7e5eff9-d224-4eb3-8f0b-1d2a4be18665
---partition --name=dtb_a --size=4096KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8
---partition --name=dtb_b --size=4096KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587
+--partition --name=dtb_a --size=4096KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=dtb_b --size=4096KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --name=uefi_dtb_a --size=64KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.xz
 --partition --name=uefi_dtb_a --size=64KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.xz
 --partition --name=uefisecapp_a --size=220KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn


### PR DESCRIPTION
Loading dtb from spinor is supported with latest external released boot binaries (release tag: r1.0.r1_00004.0).
Specify filename in the spinor partition table for IQ-X7181 EVK boards.