### PR TITLE
platforms: update product names for QLI mainline builds

### DIFF
--- a/platforms/iq-8275-evk/emmc/contents.xml.in
+++ b/platforms/iq-8275-evk/emmc/contents.xml.in
@@ -28,7 +28,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS8300.LE.1.0</product_name>
+    <product_name>QCS8300.LE.0.0</product_name>
     <chipid flavor="default" storage_type="emmc" flash_phase="1">QCS8300</chipid>
     <additional_chipid>QCS8275</additional_chipid>
     <meta_type>SPF</meta_type>

--- a/platforms/iq-8275-evk/ufs/contents.xml.in
+++ b/platforms/iq-8275-evk/ufs/contents.xml.in
@@ -35,7 +35,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS8300.LE.1.0</product_name>
+    <product_name>QCS8300.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS8300</chipid>
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS8300</chipid>
     <additional_chipid>QCS8275</additional_chipid>

--- a/platforms/iq-9075-evk/ufs/contents.xml.in
+++ b/platforms/iq-9075-evk/ufs/contents.xml.in
@@ -35,7 +35,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS9100.LE.1.0</product_name>
+    <product_name>QCS9100.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS9100</chipid>
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS9100</chipid>
     <additional_chipid>SA8775P,QCS9075</additional_chipid>

--- a/platforms/qcm6490-idp/ufs/contents.xml.in
+++ b/platforms/qcm6490-idp/ufs/contents.xml.in
@@ -28,7 +28,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCM6490.LE.1.0</product_name>
+    <product_name>QCM6490.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCM6490</chipid>
     <additional_chipid>SM7325,QCS6490</additional_chipid>
     <meta_type>SPF</meta_type>

--- a/platforms/qcs615-ride/emmc/contents.xml.in
+++ b/platforms/qcs615-ride/emmc/contents.xml.in
@@ -28,7 +28,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS615.LE.1.0</product_name>
+    <product_name>QCS615.LE.0.0</product_name>
     <chipid flavor="default" storage_type="emmc" flash_phase="1">QCS615</chipid>
     <additional_chipid>SA6155</additional_chipid>
     <meta_type>SPF</meta_type>

--- a/platforms/qcs615-ride/ufs/contents.xml.in
+++ b/platforms/qcs615-ride/ufs/contents.xml.in
@@ -28,7 +28,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS615.LE.1.0</product_name>
+    <product_name>QCS615.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS615</chipid>
     <additional_chipid>SA6155</additional_chipid>
     <meta_type>SPF</meta_type>

--- a/platforms/qcs6490-rb3gen2/ufs/contents.xml.in
+++ b/platforms/qcs6490-rb3gen2/ufs/contents.xml.in
@@ -28,7 +28,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCM6490.LE.1.0</product_name>
+    <product_name>QCM6490.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCM6490</chipid>
     <additional_chipid>SM7325,QCS6490</additional_chipid>
     <meta_type>SPF</meta_type>

--- a/platforms/qcs8300-ride-sx/ufs/contents.xml.in
+++ b/platforms/qcs8300-ride-sx/ufs/contents.xml.in
@@ -35,7 +35,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS8300.LE.1.0</product_name>
+    <product_name>QCS8300.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS8300</chipid>
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS8300</chipid>
     <additional_chipid>QCS8275</additional_chipid>

--- a/platforms/qcs9100-ride-sx/ufs/contents.xml.in
+++ b/platforms/qcs9100-ride-sx/ufs/contents.xml.in
@@ -35,7 +35,7 @@
     </pf>
   </product_flavors>
   <product_info>
-    <product_name>QCS9100.LE.1.0</product_name>
+    <product_name>QCS9100.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS9100</chipid>
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS9100</chipid>
     <additional_chipid>SA8775P,QCS9075</additional_chipid>


### PR DESCRIPTION
Update product names from 1.0 to 0.0 for QLI mainline builds

Resolves [issue#1607](https://github.com/qualcomm-linux/meta-qcom/issues/1607)