### PR TITLE
sm8750-mtp: update partition conf for sm8750-mtp

### DIFF
--- a/platforms/sm8750-mtp/ufs/partitions.conf
+++ b/platforms/sm8750-mtp/ufs/partitions.conf
@@ -46,7 +46,7 @@
 # If the partition you are adding is not expected to be OTA upgradable please add it after the 'B' partition list.
 # These are the 'A' partition's needed for the A/B boot/ota update feature.
 # If you add something to this section remember to add it to B as well
---partition --lun=4 --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl2esp-v7.elf
+--partition --lun=4 --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB
 --partition --lun=4 --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
 --partition --lun=4 --name=aop_config_a --size=512KB --type-guid=3D12F234-C882-4B46-A20C-17D52C8FC03D --filename=aop_devcfg.mbn
 --partition --lun=4 --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_1sector.bin
@@ -56,7 +56,7 @@
 --partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --lun=4 --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
 --partition --lun=4 --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
---partition --lun=4 --name=keymaster_a --size=10240KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=keymint.mbn
+--partition --lun=4 --name=keymaster_a --size=10240KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
 --partition --lun=4 --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
 --partition --lun=4 --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --lun=4 --name=pdp_a --size=256KB --type-guid=4D65EF4C-6B68-4563-80B5-2B079A9E649B --filename=pdp.elf
@@ -68,12 +68,13 @@
 --partition --lun=4 --name=soccp_debug_a --size=512KB --type-guid=95825EE7-01DD-4A7C-A9EE-8C37B997FEC4 --filename=sdi.mbn
 --partition --lun=4 --name=tz_a --size=5120KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
 --partition --lun=4 --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --lun=4 --name=uefi_dtb_a --size=2048KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
 --partition --lun=4 --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
 --partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
 
 #These are the 'B' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.
 #For convinience sake we keep all the B partitions with the same GUID
---partition --lun=4 --name=abl_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=abl2esp-v7.elf
+--partition --lun=4 --name=abl_b --size=1024KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --lun=4 --name=aop_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=aop.mbn
 --partition --lun=4 --name=aop_config_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=aop_devcfg.mbn
 --partition --lun=4 --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_1sector.bin
@@ -83,7 +84,7 @@
 --partition --lun=4 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --lun=4 --name=hyp_b --size=8192KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=hypvm.mbn
 --partition --lun=4 --name=imagefv_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=imagefv.elf
---partition --lun=4 --name=keymaster_b --size=10240KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=keymint.mbn
+--partition --lun=4 --name=keymaster_b --size=10240KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --lun=4 --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
 --partition --lun=4 --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --lun=4 --name=pdp_b --size=256KB --type-guid=23BC2066-6DF0-4869-B84D-84B6247E3C53 --filename=pdp.elf
@@ -95,6 +96,7 @@
 --partition --lun=4 --name=soccp_debug_b --size=512KB --type-guid=88CE4B5F-616E-4549-B875-565DAD984951 --filename=sdi.mbn
 --partition --lun=4 --name=tz_b --size=5120KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=tz.mbn
 --partition --lun=4 --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --lun=4 --name=uefi_dtb_b --size=2048KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
 --partition --lun=4 --name=uefisecapp_b --size=2048KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=uefi_sec.mbn
 --partition --lun=4 --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E --filename=XblRamdump.elf
 
@@ -103,7 +105,7 @@
 --partition --lun=4 --name=questdatafv --size=16384KB --type-guid=7f86d79a-7c83-4fc8-bef2-7d0a7a97af23
 --partition --lun=4 --name=qmcs --size=30720KB --type-guid=358740b1-34bd-4e4c-9656-3454f0a8fdd9
 --partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
---partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=logfs_ufs_8mb.bin
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
 --partition --lun=4 --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
 --partition --lun=4 --name=secdata --size=25KB --type-guid=76cfc7ef-039d-4e2c-b81e-4dd8c2cb2a93
 --partition --lun=4 --name=quantumcontentfv --size=1024KB --type-guid=e12d830b-7f62-4f0b-b48a-8178c5bf3ac1

--- a/tests/integration/check-missing-files
+++ b/tests/integration/check-missing-files
@@ -87,6 +87,7 @@ for xml in "$@"; do
           tz.mbn) ;;
           tzapps.bin) ;;
           uefi.elf) ;;
+          uefi_dtbs.elf) ;;
           uefi_dtbs.xz) ;;
           uefi_sec.mbn) ;;
           userdata.img) ;;


### PR DESCRIPTION
With boot binaries released for SM8750-MTP, need few changes in partition.conf in order to boot to shell:

- Drop keymint.mbn as it is not required for boot.
- SM8750-MTP was using abl as bootloader so we used abl2esp.elf to boot, but with systemd-boot now enabled, it is no longer needed.
- Add uefi_dtbs partition entry to the partition conf.