### PR TITLE
Set meta_type to FULL_STACK and build_type to K2L in contents.xml

### DIFF
--- a/platforms/iq-8275-evk/emmc/contents.xml.in
+++ b/platforms/iq-8275-evk/emmc/contents.xml.in
@@ -32,6 +32,7 @@
     <chipid flavor="default" storage_type="emmc" flash_phase="1">QCS8300</chipid>
     <additional_chipid>QCS8275</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/iq-8275-evk/ufs/contents.xml.in
+++ b/platforms/iq-8275-evk/ufs/contents.xml.in
@@ -40,6 +40,7 @@
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS8300</chipid>
     <additional_chipid>QCS8275</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/iq-9075-evk/ufs/contents.xml.in
+++ b/platforms/iq-9075-evk/ufs/contents.xml.in
@@ -40,6 +40,7 @@
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS9100</chipid>
     <additional_chipid>SA8775P,QCS9075</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/iq-x7181-evk/spinor/contents.xml.in
+++ b/platforms/iq-x7181-evk/spinor/contents.xml.in
@@ -40,6 +40,7 @@
     <chipid flavor="ub_qcom_server" storage_type="NVME" flash_phase="2">HAMOA</chipid>
     <additional_chipid>HAMOA,Hamoa_IOT,Purwa_IoT</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/qcm6490-idp/ufs/contents.xml.in
+++ b/platforms/qcm6490-idp/ufs/contents.xml.in
@@ -32,6 +32,7 @@
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCM6490</chipid>
     <additional_chipid>SM7325,QCS6490</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/qcs615-ride/emmc/contents.xml.in
+++ b/platforms/qcs615-ride/emmc/contents.xml.in
@@ -32,6 +32,7 @@
     <chipid flavor="default" storage_type="emmc" flash_phase="1">QCS615</chipid>
     <additional_chipid>SA6155</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/qcs615-ride/ufs/contents.xml.in
+++ b/platforms/qcs615-ride/ufs/contents.xml.in
@@ -32,6 +32,7 @@
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS615</chipid>
     <additional_chipid>SA6155</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/qcs6490-rb3gen2/ufs/contents.xml.in
+++ b/platforms/qcs6490-rb3gen2/ufs/contents.xml.in
@@ -32,6 +32,7 @@
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCM6490</chipid>
     <additional_chipid>SM7325,QCS6490</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/qcs8300-ride-sx/ufs/contents.xml.in
+++ b/platforms/qcs8300-ride-sx/ufs/contents.xml.in
@@ -40,6 +40,7 @@
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS8300</chipid>
     <additional_chipid>QCS8275</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/qcs9100-ride-sx/ufs/contents.xml.in
+++ b/platforms/qcs9100-ride-sx/ufs/contents.xml.in
@@ -40,6 +40,7 @@
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS9100</chipid>
     <additional_chipid>SA8775P,QCS9075</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>

--- a/platforms/sm8750-mtp/ufs/contents.xml.in
+++ b/platforms/sm8750-mtp/ufs/contents.xml.in
@@ -32,6 +32,7 @@
     <chipid flavor="default" storage_type="ufs" flash_phase="1">PAKALA</chipid>
     <additional_chipid>SM8750</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>


### PR DESCRIPTION
Update the meta_type from `SPF` to `FULL_STACK` to allow Axiom to detect that the published images belong to a single, complete product release. Also set the `build_type` to `K2L` in contents.xml for Axiom to correctly classify the build as Qualcomm Linux.