### PR TITLE
Remaining Python3 refactoring

### DIFF
--- a/msp.py
+++ b/msp.py
@@ -347,20 +347,19 @@ def DoubleCheckDiskSize():
 
         count = 0
         # Windows workaround to get the correct number of sectors
-        fp = open(Filename, 'rb')
-        fp.seek(int(Size))
-        try:
-            while True:
-                fp.read(SECTOR_SIZE)
+        with open(Filename, 'rb') as fp:
+            fp.seek(int(Size))
+            try:
+                while True:
+                    fp.read(SECTOR_SIZE)
 
-                if count % 128 == 0:
-                    sys.stdout.write(".")
+                    if count % 128 == 0:
+                        sys.stdout.write(".")
 
-                count += 1
+                    count += 1
 
-        except Exception as x:
-            TrueSize = fp.tell()
-        fp.close()
+            except Exception as x:
+                TrueSize = fp.tell()
 
         if TrueSize != Size and Size<=(64*1024*1024*1024):
             PrintBigWarning(" ")
@@ -464,48 +463,30 @@ def PerformRead():
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit(1)
 
-        try:
-            opfile.seek(int(ReadCmd['start_sector']*SECTOR_SIZE))
-        except:
-            PrintBigError("Could not move to sector %d on %s" % (ReadCmd['start_sector'],Filename))
+        with opfile:
+            try:
+                opfile.seek(int(ReadCmd['start_sector']*SECTOR_SIZE))
+            except OSError:
+                PrintBigError("Could not move to sector %d on %s" % (ReadCmd['start_sector'],Filename))
 
-        device_log("\tMoved to sector %d on %s" % (ReadCmd['start_sector'],Filename))
+            device_log("\tMoved to sector %d on %s" % (ReadCmd['start_sector'],Filename))
 
-        size = int(ReadCmd['num_partition_sectors']*SECTOR_SIZE)
-        device_log("\tAttempting to read %i bytes" % (size))
-        try:
-            bytes_read = opfile.read(size)
-        except:
-            PrintBigError("Could not read %d bytes in %s" % (size,ReadCmd['filename']))
-            device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
-            sys.exit()
-
-        try:
-            opfile.close()
-        except:
-            device_log("\tWARNING: Can't close the file?")
-            #sys.exit()
-            pass
+            size = int(ReadCmd['num_partition_sectors']*SECTOR_SIZE)
+            device_log("\tAttempting to read %i bytes" % (size))
+            try:
+                bytes_read = opfile.read(size)
+            except OSError:
+                PrintBigError("Could not read %d bytes in %s" % (size,ReadCmd['filename']))
+                device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
+                sys.exit()
 
         try:
-            ipfile = open(ReadCmd['filename'], "wb")
-        except:
-            PrintBigError("Could not create filename=%s, cwd=%s" % (ReadCmd['filename'], os.getcwd() ))
-            sys.exit(1)
-
-        try:
-            ipfile.write(bytes_read)
-        except:
-            PrintBigError("")
+            with open(ReadCmd['filename'], "wb") as ipfile:
+                ipfile.write(bytes_read)
+        except OSError:
+            PrintBigError("Could not create or write filename=%s, cwd=%s" % (ReadCmd['filename'], os.getcwd() ))
             device_log("Could not write to %s" % (ReadCmd['filename']))
             sys.exit(1)
-
-        try:
-            ipfile.close()
-        except:
-            device_log("\tWARNING: Can't close the file?")
-            #sys.exit()
-            pass
 
 
     device_log("\nDone Reading Files\n")
@@ -902,8 +883,8 @@ def GetPartitions():
         device_log("-"*78+"\n")
 
         os.system("cat /proc/partitions > temp_partitions.txt")
-        IN = open("temp_partitions.txt")
-        output = IN.readlines()
+        with open("temp_partitions.txt") as IN:
+            output = IN.readlines()
         for line in output:
             #print line
 
@@ -1715,12 +1696,11 @@ if (Operation & OPERATION_PROGRAM) > 0:
     if os.path.basename(Filename)=="singleimage.bin":
         ## Wipe out any old singleimage
         try:
-            opfile = open(Filename, "wb")
+            open(Filename, "wb").close()
         except Exception as x:
             print("REASON: %s" % x)
             print("\nERROR: Can't delete old singleimage.bin. Is it open??")
             sys.exit()
-        opfile.close()
 
         device_log("\nProgramming %s of size %s" % (Filename,ReturnSizeString(DiskSizeInBytes)))
 

--- a/ptool.py
+++ b/ptool.py
@@ -273,36 +273,32 @@ def WriteGPT(GPTMAIN, GPTBACKUP, GPTEMPTY):
     #for b in BackupGPT:
     #    opfile.write(struct.pack("B", b))
 
-    ofile = open(GPTMAIN, "wb")
-    for b in PrimaryGPT:
-        ofile.write(struct.pack("B", b))
-    ofile.close()
+    with open(GPTMAIN, "wb") as ofile:
+        for b in PrimaryGPT:
+            ofile.write(struct.pack("B", b))
 
     print("\nCreated \"%s\"\t\t\t<-- Primary GPT partition tables + protective MBR" % GPTMAIN)
 
-    ofile = open(GPTBACKUP, "wb")
-    for b in BackupGPT:
-        ofile.write(struct.pack("B", b))
-    ofile.close()
+    with open(GPTBACKUP, "wb") as ofile:
+        for b in BackupGPT:
+            ofile.write(struct.pack("B", b))
 
     print("Created \"%s\"\t\t<-- Backup GPT partition tables" % GPTBACKUP)
 
-    ofile = open(GPTBOTH, "wb")
-    for b in PrimaryGPT:
-        ofile.write(struct.pack("B", b))
-    for b in BackupGPT:
-        ofile.write(struct.pack("B", b))
-    ofile.close()
+    with open(GPTBOTH, "wb") as ofile:
+        for b in PrimaryGPT:
+            ofile.write(struct.pack("B", b))
+        for b in BackupGPT:
+            ofile.write(struct.pack("B", b))
 
     print("Created \"%s\" \t\t<-- you can run 'perl parseGPT.pl %s'" % (GPTBOTH,GPTBOTH))
 
     ## EmptyGPT is just all 0's, let's fill in the correct data
     FillInEmptyGPT()
 
-    ofile = open(GPTEMPTY, "wb")
-    for b in EmptyGPT:
-        ofile.write(struct.pack("B", b))
-    ofile.close()
+    with open(GPTEMPTY, "wb") as ofile:
+        for b in EmptyGPT:
+            ofile.write(struct.pack("B", b))
 
     print("Created \"%s\"\t\t<-- Empty GPT partition table, use to force EDL mode (very useful)" % GPTEMPTY)
 
@@ -358,27 +354,15 @@ def ShowBackupGPT(sector):
 def CreateFileOfZeros(filename,num_total_sectors):
     if OutputFolder:
         filename = os.path.join(OutputFolder, filename)
-    try:
-        opfile = open(filename, "w+b")
-    except Exception as x:
-        print("ERROR: Could not create '%s', cwd=%s" % (filename,os.getcwd() ))
-        print("REASON: %s" % (x))
-        sys.exit(1)
-
     num_sectors = int(num_total_sectors)
     temp = [0]*(SECTOR_SIZE_IN_BYTES*num_sectors)
     zeros = struct.pack("%iB"%(SECTOR_SIZE_IN_BYTES*num_sectors),*temp)
     try:
-        opfile.write(zeros)
+        with open(filename, "w+b") as opfile:
+            opfile.write(zeros)
     except Exception as x:
-        print("ERROR: Could not write zeros to '%s'\nREASON: %s" % (filename,x))
+        print("ERROR: Could not create or write '%s', cwd=%s\nREASON: %s" % (filename, os.getcwd(), x))
         sys.exit(1)
-
-    try:
-        opfile.close()
-    except Exception as x:
-        print("\tWARNING: Could not close %s" % filename)
-        print("REASON: %s" % (x))
 
     print("Created \"%s\"\t\t<-- full of binary zeros - used by \"wipe\" rawprogram files" % filename)
 
@@ -405,9 +389,8 @@ def CreateErasingRawProgramFiles():
 
         RAW_PROGRAM = '%swipe_rawprogram_PHY%d.xml' % (OutputFolder,i)
 
-        opfile = open(RAW_PROGRAM, "w")
-        opfile.write( prettify(temp) )
-        opfile.close()
+        with open(RAW_PROGRAM, "w") as opfile:
+            opfile.write( prettify(temp) )
         print("Created \"%s\"\t<-- Used to *wipe/erase* partition information" % RAW_PROGRAM)
 
 
@@ -1015,24 +998,20 @@ def CreateGPTPartitionTable(PhysicalPartitionNumber,UserProvided=False):
 
     WriteGPT(GPTMAIN, GPTBACKUP, GPTEMPTY)
 
-    opfile = open(RAW_PROGRAM, "w")
-    opfile.write( prettify(RawProgramXML) )
-    opfile.close()
+    with open(RAW_PROGRAM, "w") as opfile:
+        opfile.write( prettify(RawProgramXML) )
     print("\nCreated \"%s\"\t\t\t<-- YOUR partition information is HERE" % RAW_PROGRAM)
 
-    opfile = open(RAW_PROGRAM_WIPE_PARTITIONS, "w")
-    opfile.write( prettify(RawProgramXML_Wipe) )
-    opfile.close()
+    with open(RAW_PROGRAM_WIPE_PARTITIONS, "w") as opfile:
+        opfile.write( prettify(RawProgramXML_Wipe) )
     print("Created \"%s\"\t<-- Wipe out your images with this file (if needed for testing)" % RAW_PROGRAM_WIPE_PARTITIONS)
 
-    opfile = open(RAW_PROGRAM_BLANK_GPT, "w")
-    opfile.write( prettify(RawProgramXML_Blank) )
-    opfile.close()
+    with open(RAW_PROGRAM_BLANK_GPT, "w") as opfile:
+        opfile.write( prettify(RawProgramXML_Blank) )
     print("Created \"%s\"\t\t<-- Valid empty GPT partition table (to force to EDL)" % RAW_PROGRAM_BLANK_GPT)
 
-    opfile = open(PATCHES, "w")             # gpt
-    opfile.write( prettify(PatchesXML) )
-    opfile.close()
+    with open(PATCHES, "w") as opfile:             # gpt
+        opfile.write( prettify(PatchesXML) )
     print("Created \"%s\"\t\t\t\t<-- Tailor your partition tables to YOUR device with this file\n" % PATCHES)
 
 
@@ -1728,26 +1707,22 @@ def ShowUsage():
 def CreateFinalPartitionBin():
     global OutputFolder
 
-    opfile = open("%spartition.bin" % OutputFolder, "wb")
+    with open("%spartition.bin" % OutputFolder, "wb") as opfile:
+        for i in range(3):
+            FileName = "%spartition%i.bin" % (OutputFolder,i);
+            size     = 0
 
-    for i in range(3):
-        FileName = "%spartition%i.bin" % (OutputFolder,i);
-        size     = 0
+            if os.path.isfile(FileName):
+                size = os.path.getsize(FileName)
 
-        if os.path.isfile(FileName):
-            size = os.path.getsize(FileName)
+                with open(FileName, "rb") as ipfile:
+                    temp = ipfile.read()
+                opfile.write(temp)
 
-            ipfile = open(FileName, "rb")
-            temp = ipfile.read()
-            opfile.write(temp)
-            ipfile.close()
-
-        if size < 8192:
-            MyArray = [0]*(8192-size)
-            for b in MyArray:
-                opfile.write(struct.pack("B", b))
-
-    opfile.close()
+            if size < 8192:
+                MyArray = [0]*(8192-size)
+                for b in MyArray:
+                    opfile.write(struct.pack("B", b))
 
 
 
@@ -1835,30 +1810,25 @@ def CreateMBRPartitionTable(PhysicalPartitionNumber):
 
     print("\nptool.py is running from CWD: ", os.getcwd(), "\n")
 
-    opfile = open(PARTITIONBIN, "wb")
-    WriteMBR()
-    WriteEBR()
-    opfile.close()
+    with open(PARTITIONBIN, "wb") as opfile:
+        WriteMBR()
+        WriteEBR()
     print("Created \"%s\"" % PARTITIONBIN)
 
-    opfile = open(MBRBIN, "wb")
-    WriteMBR()
-    opfile.close()
+    with open(MBRBIN, "wb") as opfile:
+        WriteMBR()
     print("Created \"%s\"" % MBRBIN)
 
-    opfile = open(EBRBIN, "wb")
-    WriteEBR()
-    opfile.close()
+    with open(EBRBIN, "wb") as opfile:
+        WriteEBR()
     print("Created \"%s\"" % EBRBIN)
 
-    opfile = open(RAW_PROGRAM, "w")
-    opfile.write( prettify(RawProgramXML) )
-    opfile.close()
+    with open(RAW_PROGRAM, "w") as opfile:
+        opfile.write( prettify(RawProgramXML) )
     print("Created \"%s\"" % RAW_PROGRAM)
 
-    opfile = open(PATCHES, "w")
-    opfile.write( prettify(PatchesXML) )
-    opfile.close()
+    with open(PATCHES, "w") as opfile:
+        opfile.write( prettify(PatchesXML) )
     print("Created \"%s\"" % PATCHES)
 
     for mydict in hash_w:
@@ -1872,10 +1842,8 @@ def CreateMBRPartitionTable(PhysicalPartitionNumber):
 
     SubElement(EmmcLockRegionsXML, 'information', {'WRITE_PROTECT_BOUNDARY_IN_KB':str(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']) })
 
-    opfile = open("%semmc_lock_regions.xml" % OutputFolder, "w")
-
-    opfile.write( prettify(EmmcLockRegionsXML) )
-    opfile.close()
+    with open("%semmc_lock_regions.xml" % OutputFolder, "w") as opfile:
+        opfile.write( prettify(EmmcLockRegionsXML) )
     print("Created \"%semmc_lock_regions.xml\"" % OutputFolder)
 
     print("\nUse msp tool to write this information to SD/eMMC card")


### PR DESCRIPTION
Fixes four classes of Python 3 bugs that cause silent data corruption
or runtime crashes: float division passed to range()/struct/XML,
bare except clauses hiding real errors, type() checks that break on
subclasses, and file handles left open when sys.exit() is called from
error paths.