### PR TITLE
refactor: code style and linting cleanup

### DIFF
--- a/gen_contents.py
+++ b/gen_contents.py
@@ -9,7 +9,12 @@ from xml.etree import ElementTree as ET
 
 
 def usage():
-    print(("\n\tUsage: %s -t <template> -p <partitions_xml_path> -o <output> \n\tVersion 0.1\n" % (sys.argv[0])))
+    print(
+        (
+            "\n\tUsage: %s -t <template> -p <partitions_xml_path> -o <output> \n\tVersion 0.1\n"
+            % (sys.argv[0])
+        )
+    )
     sys.exit(1)
 
 
@@ -27,22 +32,22 @@ def ParseXML(XMLFile):
 
 
 def UpdateMetaData(TemplateRoot, PartitionRoot, BuildId):
-    ChipIdList = TemplateRoot.findall('product_info/chipid')
+    ChipIdList = TemplateRoot.findall("product_info/chipid")
     DefaultStorageType = None
     for ChipId in ChipIdList:
-        Flavor = ChipId.get('flavor')
-        StorageType = ChipId.get('storage_type')
+        Flavor = ChipId.get("flavor")
+        StorageType = ChipId.get("storage_type")
         print(f"Chipid Flavor: {Flavor} Storage Type: {StorageType}")
         if Flavor == "default":
-            DefaultStorageType = ChipId.get('storage_type')
+            DefaultStorageType = ChipId.get("storage_type")
 
-    PhyPartition = PartitionRoot.findall('physical_partition')
+    PhyPartition = PartitionRoot.findall("physical_partition")
     Partitions = []
-    for partition in PartitionRoot.findall('physical_partition/partition'):
-        label = partition.get('label')
-        filename = partition.get('filename')
+    for partition in PartitionRoot.findall("physical_partition/partition"):
+        label = partition.get("label")
+        filename = partition.get("filename")
         if label and filename:
-            Partitions.append({'label': label, 'filename': filename})
+            Partitions.append({"label": label, "filename": filename})
     print(f"Partitions: {Partitions}")
 
     def _add_file_elements(parent_element, pathname, file_path_flavor=None):
@@ -59,48 +64,61 @@ def UpdateMetaData(TemplateRoot, PartitionRoot, BuildId):
             new_file_path.set("flavor", file_path_flavor)
         new_file_path.text = file_path_text
 
-    builds = TemplateRoot.findall('builds_flat/build')
+    builds = TemplateRoot.findall("builds_flat/build")
     for build in builds:
-        Name = build.find('name')
+        Name = build.find("name")
         print(f"Build Name: {Name.text}")
         new_build_id = ET.SubElement(build, "build_id")
         new_build_id.text = BuildId
         if Name.text != "common":
             continue
-        DownloadFile = build.find('download_file')
+        DownloadFile = build.find("download_file")
         if DownloadFile is not None:
             build.remove(DownloadFile)
             # Partition entires
             for Partition in Partitions:
                 new_download_file = ET.SubElement(build, "download_file")
-                new_download_file.set("fastboot_complete", Partition['label'])
-                _add_file_elements(new_download_file, Partition['filename'])
+                new_download_file.set("fastboot_complete", Partition["label"])
+                _add_file_elements(new_download_file, Partition["filename"])
             # GPT Main & GPT Backup entries
             for PhysicalPartitionNumber in range(0, len(PhyPartition)):
                 new_download_file = ET.SubElement(build, "download_file")
                 new_download_file.set("storage_type", DefaultStorageType)
-                _add_file_elements(new_download_file, 'gpt_main%d.bin' % (PhysicalPartitionNumber))
+                _add_file_elements(
+                    new_download_file, "gpt_main%d.bin" % (PhysicalPartitionNumber)
+                )
                 new_download_file = ET.SubElement(build, "download_file")
                 new_download_file.set("storage_type", DefaultStorageType)
-                _add_file_elements(new_download_file, 'gpt_backup%d.bin' % (PhysicalPartitionNumber))
+                _add_file_elements(
+                    new_download_file, "gpt_backup%d.bin" % (PhysicalPartitionNumber)
+                )
 
-        PartitionFile = build.find('partition_file')
+        PartitionFile = build.find("partition_file")
         if PartitionFile is not None:
             build.remove(PartitionFile)
             # Rawprogram entries
             for PhysicalPartitionNumber in range(0, len(PhyPartition)):
                 new_partition_file = ET.SubElement(build, "partition_file")
                 new_partition_file.set("storage_type", DefaultStorageType)
-                _add_file_elements(new_partition_file, 'rawprogram%d.xml' % (PhysicalPartitionNumber), "default")
+                _add_file_elements(
+                    new_partition_file,
+                    "rawprogram%d.xml" % (PhysicalPartitionNumber),
+                    "default",
+                )
 
-        PartitionPatchFile = build.find('partition_patch_file')
+        PartitionPatchFile = build.find("partition_patch_file")
         if PartitionPatchFile is not None:
             build.remove(PartitionPatchFile)
             # Patch entries
             for PhysicalPartitionNumber in range(0, len(PhyPartition)):
                 new_partition_patch_file = ET.SubElement(build, "partition_patch_file")
                 new_partition_patch_file.set("storage_type", DefaultStorageType)
-                _add_file_elements(new_partition_patch_file, 'patch%d.xml' % (PhysicalPartitionNumber), "default")
+                _add_file_elements(
+                    new_partition_patch_file,
+                    "patch%d.xml" % (PhysicalPartitionNumber),
+                    "default",
+                )
+
 
 ###############################################################################
 # main
@@ -116,7 +134,7 @@ try:
     try:
         build_id = ""
         opts, rem = getopt.getopt(sys.argv[1:], "t:p:o:b:")
-        for (opt, arg) in opts:
+        for opt, arg in opts:
             if opt in ["-t"]:
                 template = arg
             elif opt in ["-p"]:
@@ -141,7 +159,9 @@ try:
 
     OutputTree = ET.ElementTree(xml_root)
     ET.indent(OutputTree, space="\t", level=0)
-    OutputTree.write(output_xml, encoding="utf-8", xml_declaration=True, short_empty_elements=False)
+    OutputTree.write(
+        output_xml, encoding="utf-8", xml_declaration=True, short_empty_elements=False
+    )
 except Exception as e:
     print(("Error: ", e))
     sys.exit(1)

--- a/gen_partition.py
+++ b/gen_partition.py
@@ -36,29 +36,35 @@ from xml.dom import minidom
 
 
 def usage():
-   print("\n\tUsage: %s -i <input> -o <output> -m [partition_name1=image_filename1,partition_name2=image_filename2,...]\n\tVersion 1.0\n" %(sys.argv[0]))
-   sys.exit(1)
+    print(
+        "\n\tUsage: %s -i <input> -o <output> -m [partition_name1=image_filename1,partition_name2=image_filename2,...]\n\tVersion 1.0\n"
+        % (sys.argv[0])
+    )
+    sys.exit(1)
+
 
 ##################################################################
 # defaults to be used
-disk_params_defaults = OrderedDict({
-   "type": "",
-   "size": "",
-   "SECTOR_SIZE_IN_BYTES": "512",
-   "WRITE_PROTECT_BOUNDARY_IN_KB": "65536",
-   "GROW_LAST_PARTITION_TO_FILL_DISK": "false",
-   "ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY": "true",
-   "PERFORMANCE_BOUNDARY_IN_KB": "4"
-})
+disk_params_defaults = OrderedDict(
+    {
+        "type": "",
+        "size": "",
+        "SECTOR_SIZE_IN_BYTES": "512",
+        "WRITE_PROTECT_BOUNDARY_IN_KB": "65536",
+        "GROW_LAST_PARTITION_TO_FILL_DISK": "false",
+        "ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY": "true",
+        "PERFORMANCE_BOUNDARY_IN_KB": "4",
+    }
+)
 
 partition_entry_defaults = {
-   "label": "",
-   "size_in_kb": "",
-   "type": "00000000-0000-0000-0000-000000000000",
-   "bootable": "false",
-   "readonly": "true",
-   "filename": "",
-   "sparse" : "false",
+    "label": "",
+    "size_in_kb": "",
+    "type": "00000000-0000-0000-0000-000000000000",
+    "bootable": "false",
+    "readonly": "true",
+    "filename": "",
+    "sparse": "false",
 }
 
 ##################################################################
@@ -70,179 +76,208 @@ partition_image_map = {}
 input_file = None
 output_xml = None
 
+
 def disk_options(argv):
-   disk_params = disk_params_defaults.copy()
-   for (opt, arg) in argv:
-      if opt in ['--type']:
-         disk_params["type"] = arg
-      elif opt in ['--size']:
-         disk_params["size"] = arg
-      elif opt in ['--sector-size-in-bytes']:
-         disk_params["SECTOR_SIZE_IN_BYTES"] = arg
-      elif opt in ['--write-protect-boundary']:
-         disk_params["WRITE_PROTECT_BOUNDARY_IN_KB"] = arg
-      elif opt in ['--grow-last-partition']:
-         disk_params["GROW_LAST_PARTITION_TO_FILL_DISK"] = "true"
-      elif opt in ['--align-partitions']:
-         disk_params["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = "true"
-         disk_params["PERFORMANCE_BOUNDARY_IN_KB"] = (int(arg)//1024)
-   return disk_params
+    disk_params = disk_params_defaults.copy()
+    for opt, arg in argv:
+        if opt in ["--type"]:
+            disk_params["type"] = arg
+        elif opt in ["--size"]:
+            disk_params["size"] = arg
+        elif opt in ["--sector-size-in-bytes"]:
+            disk_params["SECTOR_SIZE_IN_BYTES"] = arg
+        elif opt in ["--write-protect-boundary"]:
+            disk_params["WRITE_PROTECT_BOUNDARY_IN_KB"] = arg
+        elif opt in ["--grow-last-partition"]:
+            disk_params["GROW_LAST_PARTITION_TO_FILL_DISK"] = "true"
+        elif opt in ["--align-partitions"]:
+            disk_params["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = "true"
+            disk_params["PERFORMANCE_BOUNDARY_IN_KB"] = int(arg) // 1024
+    return disk_params
+
 
 def partition_size_in_kb(size):
-    if not re.search('[a-zA-Z]+', size):
-        return int(size)//1024
-    if re.search('([0-9])*(?=([Kk]([Bb])*))', size):
-        return int(re.search('([0-9])*(?=([Kk]([Bb])*))', size).group(0))
-    if re.search('([0-9])*(?=([Mm]([Bb])*))', size):
-        return (int(re.search('([0-9])*(?=([Mm]([Bb])*))', size).group(0)) * 1024)
-    if re.search('([0-9])*(?=([Gg]([Bb])*))', size):
-        return (int(re.search('([0-9])*(?=([Gg]([Bb])*))', size).group(0)) * 1024 * 1024)
+    if not re.search("[a-zA-Z]+", size):
+        return int(size) // 1024
+    if re.search("([0-9])*(?=([Kk]([Bb])*))", size):
+        return int(re.search("([0-9])*(?=([Kk]([Bb])*))", size).group(0))
+    if re.search("([0-9])*(?=([Mm]([Bb])*))", size):
+        return int(re.search("([0-9])*(?=([Mm]([Bb])*))", size).group(0)) * 1024
+    if re.search("([0-9])*(?=([Gg]([Bb])*))", size):
+        return int(re.search("([0-9])*(?=([Gg]([Bb])*))", size).group(0)) * 1024 * 1024
+
 
 def partition_options(argv):
-   partition_entry = partition_entry_defaults.copy()
-   phys_part = "0"
-   for (opt, arg) in argv:
-      if opt in ['--lun', '--phys-part']:
-         phys_part = arg
-      elif opt in ['--name']:
-         partition_entry["label"] = arg
-      elif opt in ['--size']:
-         kbytes = partition_size_in_kb(arg)
-         partition_entry["size_in_kb"] = str(kbytes)
-      elif opt in ['--type-guid']:
-         partition_entry["type"] = arg
-      elif opt in ['--attributes']:
-         attribute_bits = int(arg,16)
-         if attribute_bits & (1<<2):
-            partition_entry["bootable"] = "true"
-         else:
-            partition_entry["bootable"] = "false"
-         if attribute_bits & (1<<60):
-            partition_entry["readonly"] = "true"
-         else:
-            partition_entry["readonly"] = "false"
-      elif opt in ['--filename']:
-         partition_entry["filename"] = arg
-      elif opt in ['--sparse']:
-         partition_entry["sparse"] = arg
-      if partition_entry["label"] in partition_image_map.keys():
-         partition_entry["filename"] = partition_image_map[partition_entry["label"]]
-   return phys_part, partition_entry
+    partition_entry = partition_entry_defaults.copy()
+    phys_part = 0
+    for opt, arg in argv:
+        if opt in ["--lun", "--phys-part"]:
+            phys_part = arg
+        elif opt in ["--name"]:
+            partition_entry["label"] = arg
+        elif opt in ["--size"]:
+            kbytes = partition_size_in_kb(arg)
+            partition_entry["size_in_kb"] = str(kbytes)
+        elif opt in ["--type-guid"]:
+            partition_entry["type"] = arg
+        elif opt in ["--attributes"]:
+            attribute_bits = int(arg, 16)
+            if attribute_bits & (1 << 2):
+                partition_entry["bootable"] = "true"
+            else:
+                partition_entry["bootable"] = "false"
+            if attribute_bits & (1 << 60):
+                partition_entry["readonly"] = "true"
+            else:
+                partition_entry["readonly"] = "false"
+        elif opt in ["--filename"]:
+            partition_entry["filename"] = arg
+        elif opt in ["--sparse"]:
+            partition_entry["sparse"] = arg
+        if partition_entry["label"] in partition_image_map.keys():
+            partition_entry["filename"] = partition_image_map[partition_entry["label"]]
+    return phys_part, partition_entry
+
 
 def parse_partition_entries(partition_entries):
-   partitions_params = {}
+    partitions_params = {}
 
-   for partition_entry in partition_entries:
-      opts_list = list(partition_entry.split(' '))
-      if opts_list[0] == "--partition":
-         try:
-            options, remainders = getopt.gnu_getopt(opts_list[1:], '',
-                                 ['lun=', 'phys-part=', 'name=', 'size=','type-guid=',
-                                  'filename=', 'attributes=', 'sparse='])
-            phys_part, partition = partition_options(options)
-            partitions_params.setdefault(phys_part, []).append(partition)
-         except Exception as e:
-            print (str(e))
-            usage()
+    for partition_entry in partition_entries:
+        opts_list = list(partition_entry.split(" "))
+        if opts_list[0] == "--partition":
+            try:
+                options, remainders = getopt.gnu_getopt(
+                    opts_list[1:],
+                    "",
+                    [
+                        "lun=",
+                        "phys-part=",
+                        "name=",
+                        "size=",
+                        "type-guid=",
+                        "filename=",
+                        "attributes=",
+                        "sparse=",
+                    ],
+                )
+                phys_part, partition = partition_options(options)
+                partitions_params.setdefault(phys_part, []).append(partition)
+            except Exception as e:
+                print(str(e))
+                usage()
 
-   return partitions_params
+    return partitions_params
+
 
 def parse_disk_entry(disk_entry):
-   opts_list = list(disk_entry.split(' '))
-   if opts_list[0] == "--disk":
-      try:
-         options, remainders = getopt.gnu_getopt(opts_list[1:], '',
-                                 ['type=', 'size=','sector-size-in-bytes=', 'write-protect-boundary=',
-                                  'grow-last-partition', 'align-partitions='])
-         return disk_options(options)
-      except Exception as e:
-         print (str(e))
-         usage()
+    opts_list = list(disk_entry.split(" "))
+    if opts_list[0] == "--disk":
+        try:
+            options, remainders = getopt.gnu_getopt(
+                opts_list[1:],
+                "",
+                [
+                    "type=",
+                    "size=",
+                    "sector-size-in-bytes=",
+                    "write-protect-boundary=",
+                    "grow-last-partition",
+                    "align-partitions=",
+                ],
+            )
+            return disk_options(options)
+        except Exception as e:
+            print(str(e))
+            usage()
 
-def generate_multi_lun_xml (disk_params, partitions, output_xml):
-   root = ET.Element("configuration")
-   parser_instruction_text = ""
 
-   for key, value in disk_params.items():
-      if not key == 'size' and not key == 'type':
-         parser_instruction_text += '\n\t' + str(key) + '=' + str(value) + '\n\t'
+def generate_multi_lun_xml(disk_params, partitions, output_xml):
+    root = ET.Element("configuration")
+    parser_instruction_text = ""
 
-   ET.SubElement(root,"parser_instructions").text = (
-      parser_instruction_text
-   )
+    for key, value in disk_params.items():
+        if not key == "size" and not key == "type":
+            parser_instruction_text += "\n\t" + str(key) + "=" + str(value) + "\n\t"
 
-   for phys_part, entries in sorted(partitions.items(), key=lambda item: int(item[0])):
-      found = False
-      for part_entry in entries:
+    ET.SubElement(root, "parser_instructions").text = parser_instruction_text
 
-         # if there is no partition in the LUN, skip the physical_partition in XML
-         # only create the physical_partition once we have at least one partition
-         if not found:
-            phy_part = ET.SubElement(root, "physical_partition")
-         ET.SubElement(phy_part, "partition", attrib=part_entry)
-         found = True
+    for phys_part, entries in sorted(partitions.items(), key=lambda item: int(item[0])):
+        found = False
+        for part_entry in entries:
 
-   xmlstr = minidom.parseString(ET.tostring(root)).toprettyxml()
-   with open(output_xml, "w") as f:
-      f.write(xmlstr)
+            # if there is no partition in the LUN, skip the physical_partition in XML
+            # only create the physical_partition once we have at least one partition
+            if not found:
+                phy_part = ET.SubElement(root, "physical_partition")
+            ET.SubElement(phy_part, "partition", attrib=part_entry)
+            found = True
 
-def generate_partition_xml (disk_params, partitions, output_xml):
-   print("Generating %s XML %s" %(disk_params["type"].upper(), output_xml))
-   
-   if disk_params["type"] in ("emmc", "nvme", "spinor", "ufs"):
-      generate_multi_lun_xml(disk_params, partitions, output_xml)
-   else:
-      print("%s XML generation is curently not supported." %(disk_params["type"].upper()))
+    xmlstr = minidom.parseString(ET.tostring(root)).toprettyxml()
+    with open(output_xml, "w") as f:
+        f.write(xmlstr)
+
+
+def generate_partition_xml(disk_params, partitions, output_xml):
+    print("Generating %s XML %s" % (disk_params["type"].upper(), output_xml))
+
+    if disk_params["type"] in ("emmc", "nvme", "spinor", "ufs"):
+        generate_multi_lun_xml(disk_params, partitions, output_xml)
+    else:
+        print(
+            "%s XML generation is curently not supported."
+            % (disk_params["type"].upper())
+        )
+
 
 ###############################################################################
 # main
 disk_entry_err_msg = "contains more than one --disk entries"
 
 if len(sys.argv) < 3:
-   usage()
+    usage()
 
 try:
-   if sys.argv[1] == "-h" or sys.argv[1] == "--help":
-      usage()
-   try:
-      opts, rem = getopt.getopt(sys.argv[1:], "i:o:m:")
-      for (opt, arg) in opts:
-        if opt in ["-i"]:
-          input_file=arg
-        elif opt in ["-o"]:
-          output_xml=arg
-        elif opt in ["-m"]:
-          for mapping in arg.split(','):
-            tags=mapping.split("=")
-            if len(tags) > 1:
-              partition_image_map[tags[0]]=tags[1]
-        else:
-          usage()
-
-   except Exception as argerr:
-      print (str(argerr))
-      usage()
-   f = open(input_file)
-   line = f.readline()
-   while line:
-      if not re.search(r'^\s*#', line) and not re.search(r'^\s*$', line):
-         line = line.strip()
-         if re.search("^--disk", line):
-            if disk_entry is None:
-               disk_entry = line
+    if sys.argv[1] == "-h" or sys.argv[1] == "--help":
+        usage()
+    try:
+        opts, rem = getopt.getopt(sys.argv[1:], "i:o:m:")
+        for opt, arg in opts:
+            if opt in ["-i"]:
+                input_file = arg
+            elif opt in ["-o"]:
+                output_xml = arg
+            elif opt in ["-m"]:
+                for mapping in arg.split(","):
+                    tags = mapping.split("=")
+                    if len(tags) > 1:
+                        partition_image_map[tags[0]] = tags[1]
             else:
-               print("%s %s" %(sys.argv[1], disk_entry_err_msg))
-               print("%s\n%s" %(disk_entry, line))
-               sys.exit(1)
-         elif re.search("^--partition", line):
-            partition_entries.append(line)
-         else:
-            print("Ignoring %s" %(line))
-      line = f.readline()
-   f.close()
+                usage()
+
+    except Exception as argerr:
+        print(str(argerr))
+        usage()
+    f = open(input_file)
+    line = f.readline()
+    while line:
+        if not re.search(r"^\s*#", line) and not re.search(r"^\s*$", line):
+            line = line.strip()
+            if re.search("^--disk", line):
+                if disk_entry is None:
+                    disk_entry = line
+                else:
+                    print("%s %s" % (sys.argv[1], disk_entry_err_msg))
+                    print("%s\n%s" % (disk_entry, line))
+                    sys.exit(1)
+            elif re.search("^--partition", line):
+                partition_entries.append(line)
+            else:
+                print("Ignoring %s" % (line))
+        line = f.readline()
+    f.close()
 except Exception as e:
-   print("Error: ", e)
-   sys.exit(1)
+    print("Error: ", e)
+    sys.exit(1)
 
 disk_params = parse_disk_entry(disk_entry)
 partitions = parse_partition_entries(partition_entries)

--- a/msp.py
+++ b/msp.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # ===========================================================================*/
-#Copyright (c) 2015, The Linux Foundation. All rights reserved.
+# Copyright (c) 2015, The Linux Foundation. All rights reserved.
 
-#Redistribution and use in source and binary forms, with or without
-#modification, are permitted provided that the following conditions are
-#met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
 #    * Redistributions of source code must retain the above copyright
 #      notice, this list of conditions and the following disclaimer.
 #    * Redistributions in binary form must reproduce the above
@@ -15,17 +15,17 @@
 #      contributors may be used to endorse or promote products derived
 #      from this software without specific prior written permission.
 #
-#THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
-#WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
-#ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
-#BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-#CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-#SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-#BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-#WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-#OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-#IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ===========================================================================*/
 
 
@@ -37,27 +37,28 @@ import subprocess as sub
 import sys
 from time import localtime, sleep, strftime
 from xml.etree import ElementTree as ET
-#from elementtree.ElementTree import ElementTree
+
+# from elementtree.ElementTree import ElementTree
 
 from utils import CalcCRC32, EnsureDirectoryExists
 from utils import PrintBigError as _PrintBigError
 from utils import PrintBigWarning as _PrintBigWarning
 
-DiskSectors         =      0
+DiskSectors = 0
 
-BLOCK_SIZE          =      0x200
-TABLE_ENTRY_0       =      0x1BE
-TABLE_ENTRY_1       =      0x1CE
-TABLE_ENTRY_2       =      0x1DE
-TABLE_ENTRY_3       =      0x1EE
+BLOCK_SIZE = 0x200
+TABLE_ENTRY_0 = 0x1BE
+TABLE_ENTRY_1 = 0x1CE
+TABLE_ENTRY_2 = 0x1DE
+TABLE_ENTRY_3 = 0x1EE
 
-EMMCBLD_MAX_DISK_SIZE_IN_BYTES   = (64*1024*1024*1024*1024) # 64TB - Terabytes
+EMMCBLD_MAX_DISK_SIZE_IN_BYTES = 64 * 1024 * 1024 * 1024 * 1024  # 64TB - Terabytes
 
-MAX_FILE_SIZE_BEFORE_SPLIT = (10*1024*1024)
-#MAX_FILE_SIZE_BEFORE_SPLIT = (2048) # testing purposes
+MAX_FILE_SIZE_BEFORE_SPLIT = 10 * 1024 * 1024
+# MAX_FILE_SIZE_BEFORE_SPLIT = (2048) # testing purposes
 
 ExtendedPartitionBegins = 0
-bytes_read              = 0
+bytes_read = 0
 FileNotFoundShowWarning = 0
 
 SECTOR_SIZE = 512
@@ -66,7 +67,7 @@ disk_size = None
 
 def reset_device_log():
     try:
-        log_fp = open('log_msp.txt', 'w')
+        log_fp = open("log_msp.txt", "w")
     except Exception as x:
         print("\nERROR: Can't create the file log_msp.txt")
         print("REASON: %s" % x)
@@ -77,33 +78,35 @@ def reset_device_log():
     print("\nCREATED log_msp.txt\n")
     log_fp.close()
 
+
 def device_log(message, display=1):
     try:
-        log_fp = open('log_msp.txt', 'a')
+        log_fp = open("log_msp.txt", "a")
     except Exception as x:
         print("ERROR: could not open 'log_msp.txt'")
         print("REASON: %s" % x)
         return
 
     try:
-        log_fp.write("%s %s\n" % (strftime("%H:%M:%S", localtime()),message))
+        log_fp.write("%s %s\n" % (strftime("%H:%M:%S", localtime()), message))
     except Exception as x:
         print("ERROR: could not write to 'log_msp.txt'")
         print("REASON: %s" % x)
         return
 
-
-    if display==1:
+    if display == 1:
         print(message)
 
     log_fp.close()
 
-def ReadSectors(opfile,NumSectors):
+
+def ReadSectors(opfile, NumSectors):
     try:
-        return opfile.read(NumSectors*SECTOR_SIZE)
+        return opfile.read(NumSectors * SECTOR_SIZE)
     except Exception as x:
         PrintBigError("Could not complete the read")
         device_log("REASON: %s" % (x))
+
 
 reset_device_log()
 device_log("\nmsp.py is running from CWD: %s\n" % os.getcwd())
@@ -112,24 +115,27 @@ device_log("\nmsp.py is running from CWD: %s\n" % os.getcwd())
 def PrintBigWarning(sz):
     _PrintBigWarning(sz, log_func=device_log)
 
+
 def PrintBigError(sz):
     _PrintBigError(sz, log_func=device_log)
 
-def PrettyPrintArray(bytes_read):
-    Bytes = struct.unpack("%dB" % len(bytes_read),bytes_read)
 
-    for k in range(len(Bytes)//SECTOR_SIZE):
-        print("-"*78)
+def PrettyPrintArray(bytes_read):
+    Bytes = struct.unpack("%dB" % len(bytes_read), bytes_read)
+
+    for k in range(len(Bytes) // SECTOR_SIZE):
+        print("-" * 78)
         for j in range(32):
             for i in range(16):
-                sys.stdout.write("%.2X " % Bytes[i+j*16])
+                sys.stdout.write("%.2X " % Bytes[i + j * 16])
 
             sys.stdout.write("\t")
 
             for i in range(16):
-                sys.stdout.write("%c" % Bytes[i+j*16])
+                sys.stdout.write("%c" % Bytes[i + j * 16])
             print(" ")
     print(" ")
+
 
 def external_call(command, capture_output=True):
     errors = None
@@ -146,37 +152,42 @@ def external_call(command, capture_output=True):
     except Exception as e:
         print(output)
         device_log("Error executing command '%s' (%s)" % (str(command), e))
-        #clean_up()
+        # clean_up()
         device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
         sys.exit(1)
     finally:
-        #if not output is None:
+        # if not output is None:
         #    device_log("Result: %s" % output)
         if (errors is not None) and (not errors == ""):
             device_log("Process stderr: %s" % errors)
     return output
 
+
 def HandleNUM_DISK_SECTORS(field):
     if not isinstance(field, str):
-        #print "returning since this is not a string"
+        # print "returning since this is not a string"
         return field
 
-    m = re.search(r'NUM_DISK_SECTORS-(\d+)', field)
+    m = re.search(r"NUM_DISK_SECTORS-(\d+)", field)
     if m is not None:
-        if DiskSizeInBytes > 0 :
-            field           = (DiskSizeInBytes//SECTOR_SIZE)-int(m.group(1))   # here I know DiskSizeInBytes
+        if DiskSizeInBytes > 0:
+            field = (DiskSizeInBytes // SECTOR_SIZE) - int(
+                m.group(1)
+            )  # here I know DiskSizeInBytes
         else:
-            field           = (EMMCBLD_MAX_DISK_SIZE_IN_BYTES//SECTOR_SIZE)+int(m.group(1))  # I make this a gigantic number for sorting (PLUS not MINUS here)
+            field = (EMMCBLD_MAX_DISK_SIZE_IN_BYTES // SECTOR_SIZE) + int(
+                m.group(1)
+            )  # I make this a gigantic number for sorting (PLUS not MINUS here)
 
     if not isinstance(field, str):
         return field
 
     m = re.search("NUM_DISK_SECTORS", field)
     if m is not None:
-        if DiskSizeInBytes > 0 :
-            field           = DiskSizeInBytes//SECTOR_SIZE
+        if DiskSizeInBytes > 0:
+            field = DiskSizeInBytes // SECTOR_SIZE
         else:
-            field           = EMMCBLD_MAX_DISK_SIZE_IN_BYTES//SECTOR_SIZE
+            field = EMMCBLD_MAX_DISK_SIZE_IN_BYTES // SECTOR_SIZE
 
     if not isinstance(field, str):
         return field
@@ -185,124 +196,153 @@ def HandleNUM_DISK_SECTORS(field):
 
     return field
 
+
 def ReturnParsedValues(element):
     global SECTOR_SIZE
-    MyDict = {  'filename':'','file_sector_offset':'0','label':'','num_partition_sectors':'0',
-                'physical_partition_number':'0','size_in_KB':'0','sparse':'false','start_byte_hex':'0x0','start_sector':'0',
-                'function':'none','arg0':'0','arg1':'0','value':'0','byte_offset':'0','size_in_bytes':'4','SECTOR_SIZE_IN_BYTES':'512'    }
+    MyDict = {
+        "filename": "",
+        "file_sector_offset": "0",
+        "label": "",
+        "num_partition_sectors": "0",
+        "physical_partition_number": "0",
+        "size_in_KB": "0",
+        "sparse": "false",
+        "start_byte_hex": "0x0",
+        "start_sector": "0",
+        "function": "none",
+        "arg0": "0",
+        "arg1": "0",
+        "value": "0",
+        "byte_offset": "0",
+        "size_in_bytes": "4",
+        "SECTOR_SIZE_IN_BYTES": "512",
+    }
 
     for name, value in list(element.items()):
         ##device_log("\t\tName: '%s'=>'%s' " % (name,value))
-        MyDict[name]=value
+        MyDict[name] = value
 
-    if 'SECTOR_SIZE_IN_BYTES' in MyDict:
-        SECTOR_SIZE = int(MyDict['SECTOR_SIZE_IN_BYTES'])
+    if "SECTOR_SIZE_IN_BYTES" in MyDict:
+        SECTOR_SIZE = int(MyDict["SECTOR_SIZE_IN_BYTES"])
 
-    if 'num_sectors' in MyDict: ## Legacy name used in original partition.xml
-        MyDict['num_partition_sectors'] = MyDict['num_sectors']
-    if 'offset' in MyDict: ## Legacy name used in original partition.xml
-        MyDict['file_sector_offset'] = MyDict['offset']
+    if "num_sectors" in MyDict:  ## Legacy name used in original partition.xml
+        MyDict["num_partition_sectors"] = MyDict["num_sectors"]
+    if "offset" in MyDict:  ## Legacy name used in original partition.xml
+        MyDict["file_sector_offset"] = MyDict["offset"]
 
-    MyDict['num_partition_sectors'] = HandleNUM_DISK_SECTORS(MyDict['num_partition_sectors'])   # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
-    MyDict['start_sector']          = HandleNUM_DISK_SECTORS(MyDict['start_sector'])            # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
-    MyDict['file_sector_offset']    = HandleNUM_DISK_SECTORS(MyDict['file_sector_offset'])      # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
+    MyDict["num_partition_sectors"] = HandleNUM_DISK_SECTORS(
+        MyDict["num_partition_sectors"]
+    )  # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
+    MyDict["start_sector"] = HandleNUM_DISK_SECTORS(
+        MyDict["start_sector"]
+    )  # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
+    MyDict["file_sector_offset"] = HandleNUM_DISK_SECTORS(
+        MyDict["file_sector_offset"]
+    )  # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
 
-    MyDict['physical_partition_number'] = int(MyDict['physical_partition_number'])
-    MyDict['byte_offset']               = int(float(MyDict['byte_offset']))
-    MyDict['size_in_bytes']             = int(float(MyDict['size_in_bytes']))
+    MyDict["physical_partition_number"] = int(MyDict["physical_partition_number"])
+    MyDict["byte_offset"] = int(float(MyDict["byte_offset"]))
+    MyDict["size_in_bytes"] = int(float(MyDict["size_in_bytes"]))
 
     # These only affect patching
-    m = re.search(r'CRC32\((\d+).?,(\d+).?\)', MyDict['value'])
+    m = re.search(r"CRC32\((\d+).?,(\d+).?\)", MyDict["value"])
     if m is not None:
-        MyDict['value']          = 0
-        MyDict['function']       = "CRC32"
-        MyDict['arg0']           = int(float(m.group(1)))   # start_sector
-        MyDict['arg1']           = int(float(m.group(2)))   # len_in_bytes
+        MyDict["value"] = 0
+        MyDict["function"] = "CRC32"
+        MyDict["arg0"] = int(float(m.group(1)))  # start_sector
+        MyDict["arg1"] = int(float(m.group(2)))  # len_in_bytes
     else:
         ## above didn't match, so try this
-        m = re.search(r'CRC32\((NUM_DISK_SECTORS-\d+).?,(\d+).?\)', MyDict['value'])
+        m = re.search(r"CRC32\((NUM_DISK_SECTORS-\d+).?,(\d+).?\)", MyDict["value"])
         if m is not None:
-            MyDict['value']          = 0
-            MyDict['function']       = "CRC32"
-            MyDict['arg0']           = int(float( HandleNUM_DISK_SECTORS(m.group(1)) ))   # start_sector
-            MyDict['arg1']           = int(float(m.group(2)))   # len_in_bytes
+            MyDict["value"] = 0
+            MyDict["function"] = "CRC32"
+            MyDict["arg0"] = int(
+                float(HandleNUM_DISK_SECTORS(m.group(1)))
+            )  # start_sector
+            MyDict["arg1"] = int(float(m.group(2)))  # len_in_bytes
 
-    MyDict['value']              = HandleNUM_DISK_SECTORS(MyDict['value'])                      # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
+    MyDict["value"] = HandleNUM_DISK_SECTORS(
+        MyDict["value"]
+    )  # Means field can have 'NUM_DISK_SECTORS-5.' type of contents
 
     return MyDict
 
-def ParseXML(xml_filename):     ## this function updates all the global arrays
-    global WriteArray,PatchArray,ReadArray,MinDiskSizeInSectors
 
-    root = ET.parse( xml_filename )
+def ParseXML(xml_filename):  ## this function updates all the global arrays
+    global WriteArray, PatchArray, ReadArray, MinDiskSizeInSectors
+
+    root = ET.parse(xml_filename)
     for element in root.iter():
-        #device_log("\nElement: %s" % element.tag)
+        # device_log("\nElement: %s" % element.tag)
         # Parse out include files
 
-        if element.tag=="read":
+        if element.tag == "read":
             if list(element.keys()):
-                ReadArray.append( ReturnParsedValues(element) )
+                ReadArray.append(ReturnParsedValues(element))
             else:
                 print("ERROR: Your <read> tag is not formed correctly\n")
                 sys.exit(1)
 
-        elif element.tag=="program":
+        elif element.tag == "program":
             if list(element.keys()):
-                WriteArray.append( ReturnParsedValues(element) )
+                WriteArray.append(ReturnParsedValues(element))
             else:
                 print("ERROR: Your <program> tag is not formed correctly\n")
                 sys.exit(1)
 
-        elif element.tag=="patch":
+        elif element.tag == "patch":
             if list(element.keys()):
-                PatchArray.append( ReturnParsedValues(element) )
+                PatchArray.append(ReturnParsedValues(element))
             else:
                 print("ERROR: Your <patch> tag is not formed correctly\n")
                 sys.exit(1)
 
-
-    #print "\n\n-------------READ -----------------------------------\n\n\n"
-    #for Read in ReadArray:
+    # print "\n\n-------------READ -----------------------------------\n\n\n"
+    # for Read in ReadArray:
     #    print Read
-    #print "\n\n-------------WRITE -----------------------------------\n\n\n"
-    #for Write in WriteArray:
+    # print "\n\n-------------WRITE -----------------------------------\n\n\n"
+    # for Write in WriteArray:
     #    print Write
-    #print "\n\n-------------PATCH -----------------------------------\n\n\n"
-    #for Patch in PatchArray:
+    # print "\n\n-------------PATCH -----------------------------------\n\n\n"
+    # for Patch in PatchArray:
     #    print Patch
-    #print "------------------------------------------------\n\n\n"
+    # print "------------------------------------------------\n\n\n"
 
 
 def ReturnArrayFromCommaSeparatedList(sz):
-    temp = re.sub(r'\s+|\n'," ",sz)
-    temp = re.sub(r'^\s+',"",temp)
-    temp = re.sub(r'\s+$',"",temp)
-    return temp.split(',')
+    temp = re.sub(r"\s+|\n", " ", sz)
+    temp = re.sub(r"^\s+", "", temp)
+    temp = re.sub(r"\s+$", "", temp)
+    return temp.split(",")
+
 
 def find_file(filename, search_paths):
-    device_log("\n\n\tLooking for '%s'"%filename)
-    device_log("\t"+"-"*40)
+    device_log("\n\n\tLooking for '%s'" % filename)
+    device_log("\t" + "-" * 40)
     for x in search_paths:
-        #device_log("\tSearching '%s'"%x)
+        # device_log("\tSearching '%s'"%x)
         temp = os.path.join(x, filename)
         device_log("\tSearching for **%s**" % temp)
         if os.path.exists(temp):
-            device_log("\n\t**Found %s (%i bytes)" % (temp,os.path.getsize(temp)))
+            device_log("\n\t**Found %s (%i bytes)" % (temp, os.path.getsize(temp)))
             return temp
 
     ## search cwd last
-    device_log("\tSearching '%s'"%os.getcwd())
+    device_log("\tSearching '%s'" % os.getcwd())
     if os.path.exists(filename):
-        device_log("\n\t**Found %s (%i bytes)" % (filename,os.path.getsize(filename)))
+        device_log("\n\t**Found %s (%i bytes)" % (filename, os.path.getsize(filename)))
         return filename
 
-    device_log("\tCound't find file OR perhaps you don't have permission to run os.stat() on this file\n")
+    device_log(
+        "\tCound't find file OR perhaps you don't have permission to run os.stat() on this file\n"
+    )
     return None
 
 
 def DoubleCheckDiskSize():
 
-    if os.path.basename(Filename)=="singleimage.bin":
+    if os.path.basename(Filename) == "singleimage.bin":
         return
 
     if noprompt is True:
@@ -317,7 +357,7 @@ def DoubleCheckDiskSize():
 
         count = 0
         # Windows workaround to get the correct number of sectors
-        with open(Filename, 'rb') as fp:
+        with open(Filename, "rb") as fp:
             fp.seek(int(Size))
             try:
                 while True:
@@ -331,16 +371,30 @@ def DoubleCheckDiskSize():
             except Exception:
                 TrueSize = fp.tell()
 
-        if TrueSize != Size and Size<=(64*1024*1024*1024):
+        if TrueSize != Size and Size <= (64 * 1024 * 1024 * 1024):
             PrintBigWarning(" ")
             device_log("NOTE: This OS has *not* detected the correct size of the disk")
-            device_log("\nSECTORS: Size=%i, TrueSize=%i, Difference=%i sectors (%s)" % (Size/SECTOR_SIZE,TrueSize/SECTOR_SIZE,(TrueSize-Size)/SECTOR_SIZE,ReturnSizeString(TrueSize-Size)))
-            device_log("This means the backup GPT header will *not* be located at the true last sector")
-            device_log("This is only an issue if you care :) It will be off by %s" % ReturnSizeString(TrueSize-Size))
-            device_log("\nNOTE: This program *can't* write to the end of the disk, OS limitation")
+            device_log(
+                "\nSECTORS: Size=%i, TrueSize=%i, Difference=%i sectors (%s)"
+                % (
+                    Size / SECTOR_SIZE,
+                    TrueSize / SECTOR_SIZE,
+                    (TrueSize - Size) / SECTOR_SIZE,
+                    ReturnSizeString(TrueSize - Size),
+                )
+            )
+            device_log(
+                "This means the backup GPT header will *not* be located at the true last sector"
+            )
+            device_log(
+                "This is only an issue if you care :) It will be off by %s"
+                % ReturnSizeString(TrueSize - Size)
+            )
+            device_log(
+                "\nNOTE: This program *can't* write to the end of the disk, OS limitation"
+            )
         else:
             device_log("\n\nAll is well\n")
-
 
 
 def PerformRead():
@@ -357,39 +411,52 @@ def PerformRead():
 
     for ReadCmd in ReadArray:
         ##<read filename="dump0.bin" physical_partition_number="0" start_sector="0" num_partition_sectors="34"/>
-        device_log("\nRead %d sectors (%s) from sector %d and save to '%s'\n" % (ReadCmd['num_partition_sectors'],ReturnSizeString(ReadCmd['num_partition_sectors']*SECTOR_SIZE),ReadCmd['start_sector'],ReadCmd['filename']))
+        device_log(
+            "\nRead %d sectors (%s) from sector %d and save to '%s'\n"
+            % (
+                ReadCmd["num_partition_sectors"],
+                ReturnSizeString(ReadCmd["num_partition_sectors"] * SECTOR_SIZE),
+                ReadCmd["start_sector"],
+                ReadCmd["filename"],
+            )
+        )
 
-        if ReadCmd['physical_partition_number']!=0:   ## msp tool can only write to PHY partition 0
-            device_log("WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL" % (ReadCmd['filename'],ReadCmd['physical_partition_number']))
-        if len(ReadCmd['filename'])==0:
+        if (
+            ReadCmd["physical_partition_number"] != 0
+        ):  ## msp tool can only write to PHY partition 0
+            device_log(
+                "WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL"
+                % (ReadCmd["filename"], ReadCmd["physical_partition_number"])
+            )
+        if len(ReadCmd["filename"]) == 0:
             device_log("WARNING filename was not specified, skipping this read")
             continue
-        if ReadCmd['num_partition_sectors']==0:
+        if ReadCmd["num_partition_sectors"] == 0:
             device_log("WARNING num_partition_sectors was 0, skipping this read")
             continue
 
         if interactive is True:
-            device_log("Do you want to perform this read? (Y|n|q)",0)
+            device_log("Do you want to perform this read? (Y|n|q)", 0)
             loadfile = input("Do you want to perform this read? (Y|n|q)")
-            if loadfile=='Y' or loadfile=='y' or loadfile=='':
+            if loadfile == "Y" or loadfile == "y" or loadfile == "":
                 pass
-            elif loadfile=='q' or loadfile=='Q':
-                device_log("\nmsp.py exiting by user pressing Q (quit) - Log is log_msp.txt\n\n")
+            elif loadfile == "q" or loadfile == "Q":
+                device_log(
+                    "\nmsp.py exiting by user pressing Q (quit) - Log is log_msp.txt\n\n"
+                )
                 sys.exit()
             else:
                 continue
 
-
-
         try:
-            if os.path.basename(Filename)=="singleimage.bin":
-                Filename = OutputFolder+os.path.basename(Filename)
+            if os.path.basename(Filename) == "singleimage.bin":
+                Filename = OutputFolder + os.path.basename(Filename)
 
             opfile = open(Filename, "r+b")  ## Filename = '\\.\PHYSICALDRIVE1'
-            #device_log("Opened '%s', cwd=%s" % (Filename, os.getcwd() ))
+            # device_log("Opened '%s', cwd=%s" % (Filename, os.getcwd() ))
         except OSError:
             PrintBigError("")
-            device_log("Could not open Filename=%s, cwd=%s" % (Filename, os.getcwd() ))
+            device_log("Could not open Filename=%s, cwd=%s" % (Filename, os.getcwd()))
 
             if sys.platform.startswith("linux"):
                 print("\t               _      ___")
@@ -399,67 +466,97 @@ def PerformRead():
                 print("\t\\__ \\ |_| | (_| | (_) |_|")
                 print("\t|___/\\__,_|\\__,_|\\___/(_)\n")
                 device_log("\tDon't forget you need SUDO with this program")
-                device_log("\tsudo python msp.py partition.xml /dev/sdx (where x is the device node)")
+                device_log(
+                    "\tsudo python msp.py partition.xml /dev/sdx (where x is the device node)"
+                )
             else:
-                device_log("\t  ___      _           _       _     _             _                ___  ")
-                device_log("\t / _ \\    | |         (_)     (_)   | |           | |              |__ \\ ")
-                device_log("\t/ /_\\ \\ __| |_ __ ___  _ _ __  _ ___| |_ _ __ __ _| |_  ___  _ __     ) |")
-                device_log("\t|  _  |/ _` | '_ ` _ \\| | '_ \\| / __| __| '__/ _` | __|/ _ \\| '__|   / / ")
-                device_log("\t| | | | (_| | | | | | | | | | | \\__ \\ |_| | | (_| | |_| (_) | |     |_|  ")
-                device_log("\t\\_| |_/\\__,_|_| |_| |_|_|_| |_|_|___/\\__|_|  \\__,_|\\__|\\___/|_|     (_)  \n\n")
+                device_log(
+                    "\t  ___      _           _       _     _             _                ___  "
+                )
+                device_log(
+                    "\t / _ \\    | |         (_)     (_)   | |           | |              |__ \\ "
+                )
+                device_log(
+                    "\t/ /_\\ \\ __| |_ __ ___  _ _ __  _ ___| |_ _ __ __ _| |_  ___  _ __     ) |"
+                )
+                device_log(
+                    "\t|  _  |/ _` | '_ ` _ \\| | '_ \\| / __| __| '__/ _` | __|/ _ \\| '__|   / / "
+                )
+                device_log(
+                    "\t| | | | (_| | | | | | | | | | | \\__ \\ |_| | | (_| | |_| (_) | |     |_|  "
+                )
+                device_log(
+                    "\t\\_| |_/\\__,_|_| |_| |_|_|_| |_|_|___/\\__|_|  \\__,_|\\__|\\___/|_|     (_)  \n\n"
+                )
 
-                device_log("\n"+"-"*78)
+                device_log("\n" + "-" * 78)
                 device_log("\tThis program needs to be run as Administrator!!")
-                device_log("-"*78+"\n")
-                device_log("-"*78)
-                device_log("\tTo fix, you must open a CMD prompt with \"Run as administrator\"")
-                device_log("-"*78+"\n")
+                device_log("-" * 78 + "\n")
+                device_log("-" * 78)
+                device_log(
+                    '\tTo fix, you must open a CMD prompt with "Run as administrator"'
+                )
+                device_log("-" * 78 + "\n")
 
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit()
 
         device_log("\n\tOpened %s" % Filename)
 
-
-        if ReadCmd['start_sector'] < 0:
-            device_log("start sector is less than 0 - skipping this instruction, most likely for GPT HACK")
+        if ReadCmd["start_sector"] < 0:
+            device_log(
+                "start sector is less than 0 - skipping this instruction, most likely for GPT HACK"
+            )
             continue
 
-        if ReadCmd['start_sector'] > int(DiskSizeInBytes/SECTOR_SIZE):
+        if ReadCmd["start_sector"] > int(DiskSizeInBytes / SECTOR_SIZE):
             PrintBigError("")
-            device_log("\nERROR: Start sector (%i) is BIGGER than the disk (%i sectors)" % (ReadCmd['start_sector'],int(DiskSizeInBytes/SECTOR_SIZE)))
-            device_log("\nERROR: Your device is TOO SMALL to handle this partition info")
+            device_log(
+                "\nERROR: Start sector (%i) is BIGGER than the disk (%i sectors)"
+                % (ReadCmd["start_sector"], int(DiskSizeInBytes / SECTOR_SIZE))
+            )
+            device_log(
+                "\nERROR: Your device is TOO SMALL to handle this partition info"
+            )
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit(1)
 
         with opfile:
             try:
-                opfile.seek(int(ReadCmd['start_sector']*SECTOR_SIZE))
+                opfile.seek(int(ReadCmd["start_sector"] * SECTOR_SIZE))
             except OSError:
-                PrintBigError("Could not move to sector %d on %s" % (ReadCmd['start_sector'],Filename))
+                PrintBigError(
+                    "Could not move to sector %d on %s"
+                    % (ReadCmd["start_sector"], Filename)
+                )
 
-            device_log("\tMoved to sector %d on %s" % (ReadCmd['start_sector'],Filename))
+            device_log(
+                "\tMoved to sector %d on %s" % (ReadCmd["start_sector"], Filename)
+            )
 
-            size = int(ReadCmd['num_partition_sectors']*SECTOR_SIZE)
+            size = int(ReadCmd["num_partition_sectors"] * SECTOR_SIZE)
             device_log("\tAttempting to read %i bytes" % (size))
             try:
                 bytes_read = opfile.read(size)
             except OSError:
-                PrintBigError("Could not read %d bytes in %s" % (size,ReadCmd['filename']))
+                PrintBigError(
+                    "Could not read %d bytes in %s" % (size, ReadCmd["filename"])
+                )
                 device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
                 sys.exit()
 
         try:
-            with open(ReadCmd['filename'], "wb") as ipfile:
+            with open(ReadCmd["filename"], "wb") as ipfile:
                 ipfile.write(bytes_read)
         except OSError:
-            PrintBigError("Could not create or write filename=%s, cwd=%s" % (ReadCmd['filename'], os.getcwd() ))
-            device_log("Could not write to %s" % (ReadCmd['filename']))
+            PrintBigError(
+                "Could not create or write filename=%s, cwd=%s"
+                % (ReadCmd["filename"], os.getcwd())
+            )
+            device_log("Could not write to %s" % (ReadCmd["filename"]))
             sys.exit(1)
 
-
     device_log("\nDone Reading Files\n")
-
 
 
 def PerformWrite():
@@ -470,53 +567,79 @@ def PerformWrite():
     device_log("\t                                                     _            ")
     device_log("\t                                                    (_)            ")
     device_log("\t _ __  _ __ ___   __ _ _ __ __ _ _ __ ___  _ __ ___  _ _ __   __ _ ")
-    device_log("\t| '_ \\| '__/ _ \\ / _` | '__/ _` | '_ ` _ \\| '_ ` _ \\| | '_ \\ / _` |")
+    device_log(
+        "\t| '_ \\| '__/ _ \\ / _` | '__/ _` | '_ ` _ \\| '_ ` _ \\| | '_ \\ / _` |"
+    )
     device_log("\t| |_) | | | (_) | (_| | | | (_| | | | | | | | | | | | | | | | (_| |")
-    device_log("\t| .__/|_|  \\___/ \\__, |_|  \\__,_|_| |_| |_|_| |_| |_|_|_| |_|\\__, |")
+    device_log(
+        "\t| .__/|_|  \\___/ \\__, |_|  \\__,_|_| |_| |_|_| |_| |_|_|_| |_|\\__, |"
+    )
     device_log("\t| |               __/ |                                       __/ |")
     device_log("\t|_|              |___/                                       |___/ ")
 
     CurrentSector = 0
-    for Write in WriteSorted:   # Here Write is a *sorted* entry from rawprogram.xml
-        if Write['physical_partition_number']!=0:   ## msp tool can only write to PHY partition 0
-            PrintBigWarning("WARNING: '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL" % (Write['filename'],Write['physical_partition_number']))
-            device_log("WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL" % (Write['filename'],Write['physical_partition_number']))
-            device_log("WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL" % (Write['filename'],Write['physical_partition_number']))
-            device_log("WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL" % (Write['filename'],Write['physical_partition_number']))
+    for Write in WriteSorted:  # Here Write is a *sorted* entry from rawprogram.xml
+        if (
+            Write["physical_partition_number"] != 0
+        ):  ## msp tool can only write to PHY partition 0
+            PrintBigWarning(
+                "WARNING: '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL"
+                % (Write["filename"], Write["physical_partition_number"])
+            )
+            device_log(
+                "WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL"
+                % (Write["filename"], Write["physical_partition_number"])
+            )
+            device_log(
+                "WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL"
+                % (Write["filename"], Write["physical_partition_number"])
+            )
+            device_log(
+                "WARNING '%s' for physical_partition_number=%d (only 0 is accessible) THIS MIGHT FAIL"
+                % (Write["filename"], Write["physical_partition_number"])
+            )
 
-        if len(Write['filename'])==0:
+        if len(Write["filename"]) == 0:
             continue
 
         if LoadSubsetOfFiles is True:
             # To be here means user only wants some of the files loaded from rawprogram0.xml
-            if Write['filename'] in file_list:
-                #device_log("LOAD: '%s' was specified to be programmed" % Write['filename'])
+            if Write["filename"] in file_list:
+                # device_log("LOAD: '%s' was specified to be programmed" % Write['filename'])
                 pass
             else:
-                #device_log("SKIPPING: '%s', it was not specified to be programmed" % Write['filename'])
+                # device_log("SKIPPING: '%s', it was not specified to be programmed" % Write['filename'])
                 continue
 
+        device_log("\n" + "=" * 78)
+        device_log("=" * 78)
+        FileWithPath = find_file(Write["filename"], search_paths)
 
-        device_log("\n"+"="*78)
-        device_log("="*78)
-        FileWithPath = find_file(Write['filename'], search_paths)
-
-        size=0
+        size = 0
         if FileWithPath is not None:
             size = os.path.getsize(FileWithPath)
 
-
         # to be here the rawprogram.xml file had to have a "filename" entry
-        device_log("\n'%s' (%s) to partition '%s' at sector %d (at %s)\n" % (Write['filename'],ReturnSizeString(size),Write['label'],Write['start_sector'],ReturnSizeString(Write['start_sector']*SECTOR_SIZE)))
-
+        device_log(
+            "\n'%s' (%s) to partition '%s' at sector %d (at %s)\n"
+            % (
+                Write["filename"],
+                ReturnSizeString(size),
+                Write["label"],
+                Write["start_sector"],
+                ReturnSizeString(Write["start_sector"] * SECTOR_SIZE),
+            )
+        )
 
         if interactive is True:
-            device_log("Do you want to load this file? (Y|n|q)",0)
+            device_log("Do you want to load this file? (Y|n|q)", 0)
             loadfile = input("Do you want to load this file? (Y|n|q)")
-            if loadfile=='Y' or loadfile=='y' or loadfile=='':
+            if loadfile == "Y" or loadfile == "y" or loadfile == "":
                 pass
-            elif loadfile=='q' or loadfile=='Q':
-                device_log("\nmsp.py exiting by user pressing Q (quit) - Log is log_msp.txt\n\n")
+            elif loadfile == "q" or loadfile == "Q":
+                device_log(
+                    "\nmsp.py exiting by user pressing Q (quit) - Log is log_msp.txt\n\n"
+                )
                 sys.exit()
             else:
                 continue
@@ -530,7 +653,10 @@ def PerformWrite():
             device_log("\t| |  | (_| | |_| | | |   |_|  ")
             device_log("\t\\_|   \\__,_|\\__|_| |_|   (_)  \n\n")
 
-            device_log("WARNING: '%s' listed in '%s' not found\n" % (Write['filename'],rawprogram_filename))
+            device_log(
+                "WARNING: '%s' listed in '%s' not found\n"
+                % (Write["filename"], rawprogram_filename)
+            )
 
             if noprompt is True:
                 device_log("\nUse option -s c:\\path1 -s c:\\path2 etc")
@@ -540,46 +666,58 @@ def PerformWrite():
 
             device_log("Please provide a path for this file")
             device_log("Ex. \\\\somepath\\folder OR c:\\somepath\\folder\n")
-            device_log("Enter PATH or Q to quit? ",0)
+            device_log("Enter PATH or Q to quit? ", 0)
             temppath = input("Enter PATH or Q to quit? ")
-            if temppath=='Q' or temppath=='q' or temppath=='':
-                device_log("\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n")
+            if temppath == "Q" or temppath == "q" or temppath == "":
+                device_log(
+                    "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
+                )
                 sys.exit()
 
             device_log("\n")
 
-            FileWithPath = find_file(Write['filename'], [temppath])
+            FileWithPath = find_file(Write["filename"], [temppath])
 
-            size=0
+            size = 0
             if FileWithPath is not None:
                 size = os.path.getsize(FileWithPath)
 
-                device_log("\nShould this path be used to find other files? (Y|n|q)",0)
+                device_log("\nShould this path be used to find other files? (Y|n|q)", 0)
                 temp = input("\nShould this path be used to find other files? (Y|n|q)")
-                if temp=='Q' or temp=='q':
-                    device_log("\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n")
+                if temp == "Q" or temp == "q":
+                    device_log(
+                        "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
+                    )
                     sys.exit()
-                elif temp=='Y' or temp=='y' or temp=='':
+                elif temp == "Y" or temp == "y" or temp == "":
                     search_paths.append(temppath)
                 device_log("\n")
 
         if noprompt is False:
-            if size==0:
-                device_log("WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)",0)
-                loadfile = input("WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)")
-                if loadfile=='N' or loadfile=='n' or loadfile=='':
+            if size == 0:
+                device_log(
+                    "WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)",
+                    0,
+                )
+                loadfile = input(
+                    "WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)"
+                )
+                if loadfile == "N" or loadfile == "n" or loadfile == "":
                     continue
-                elif loadfile=='q' or loadfile=='Q':
-                    device_log("\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n")
+                elif loadfile == "q" or loadfile == "Q":
+                    device_log(
+                        "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
+                    )
                     sys.exit()
                 else:
                     pass
 
-
-        if Write['num_partition_sectors']==0:
-            Write['num_partition_sectors'] = int(size/SECTOR_SIZE)
-            if size%SECTOR_SIZE != 0:
-                Write['num_partition_sectors']+=1 # not an even multiple of SECTOR_SIZE, so ++
+        if Write["num_partition_sectors"] == 0:
+            Write["num_partition_sectors"] = int(size / SECTOR_SIZE)
+            if size % SECTOR_SIZE != 0:
+                Write[
+                    "num_partition_sectors"
+                ] += 1  # not an even multiple of SECTOR_SIZE, so ++
 
         ##device_log("At start_sector %i (%.2fKB) write %i sectors" % (Write['start_sector'],Write['start_sector']*SECTOR_SIZE/1024.0,Write['num_partition_sectors']))
         ##device_log("\tsize of \"%s\" is %i bytes" % (Write['filename'],size))
@@ -588,51 +726,77 @@ def PerformWrite():
         ## This below happens on files like partition0.bin, where they hold the entire partition table,
         ## but, only MBR is meant to be written, thus partition0.bin is 9 sectors but MBR is only 1 sector
 
-        if size > (Write['num_partition_sectors']*SECTOR_SIZE):
-            PrintBigWarning("WARNING: This complete image of size %i bytes is too big to fit on this partition of size %i bytes" % (size,Write['num_partition_sectors']*SECTOR_SIZE))
-            PrintBigWarning("WARNING: Only the first %i bytes of your image will be written\n\n" % (Write['num_partition_sectors']*SECTOR_SIZE))
-            size = Write['num_partition_sectors']*SECTOR_SIZE
+        if size > (Write["num_partition_sectors"] * SECTOR_SIZE):
+            PrintBigWarning(
+                "WARNING: This complete image of size %i bytes is too big to fit on this partition of size %i bytes"
+                % (size, Write["num_partition_sectors"] * SECTOR_SIZE)
+            )
+            PrintBigWarning(
+                "WARNING: Only the first %i bytes of your image will be written\n\n"
+                % (Write["num_partition_sectors"] * SECTOR_SIZE)
+            )
+            size = Write["num_partition_sectors"] * SECTOR_SIZE
             ThereWereWarnings = 1
 
         ##device_log("\tAttempting to read %i bytes from \n\t\"%s\" at file_sector_offset %i" % (size,Write['filename'],Write['file_sector_offset']))
-        #os.getcwd()+"\\"+
+        # os.getcwd()+"\\"+
 
         try:
             ipfile = open(FileWithPath, "rb")
         except Exception as x:
-            PrintBigError("Could not open FileWithPath=%s, cwd=%s\nREASON: %s" % (Write['filename'], os.getcwd(), x ))
+            PrintBigError(
+                "Could not open FileWithPath=%s, cwd=%s\nREASON: %s"
+                % (Write["filename"], os.getcwd(), x)
+            )
 
-        device_log("\tAttempting to move to sector %i (file file_sector_offset) in %s" % (Write['file_sector_offset'],Write['filename']))
+        device_log(
+            "\tAttempting to move to sector %i (file file_sector_offset) in %s"
+            % (Write["file_sector_offset"], Write["filename"])
+        )
         try:
-            ipfile.seek(int(Write['file_sector_offset']*SECTOR_SIZE))
+            ipfile.seek(int(Write["file_sector_offset"] * SECTOR_SIZE))
         except Exception as x:
-            PrintBigError("Could not move to sector %d in %s\nREASON: %s" % (Write['file_sector_offset'],Write['filename'],x))
+            PrintBigError(
+                "Could not move to sector %d in %s\nREASON: %s"
+                % (Write["file_sector_offset"], Write["filename"], x)
+            )
 
         device_log("\tAttempting to read %i bytes" % (size))
         try:
-            if size<MAX_FILE_SIZE_BEFORE_SPLIT:
+            if size < MAX_FILE_SIZE_BEFORE_SPLIT:
                 bytes_read = ipfile.read(size)
             else:
                 device_log("File is too large to read all at once, must be broken up")
         except Exception as x:
-            PrintBigError("Could not read %d bytes in %s\nREASON: %s" % (size,Write['filename'],x))
+            PrintBigError(
+                "Could not read %d bytes in %s\nREASON: %s"
+                % (size, Write["filename"], x)
+            )
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit()
 
-        if size<MAX_FILE_SIZE_BEFORE_SPLIT:
+        if size < MAX_FILE_SIZE_BEFORE_SPLIT:
             ipfile.close()
 
-        if size<MAX_FILE_SIZE_BEFORE_SPLIT:
-            device_log("\tSuccessfully read %d bytes of %d bytes and closed %s" % (len(bytes_read),size,Write['filename']))
+        if size < MAX_FILE_SIZE_BEFORE_SPLIT:
+            device_log(
+                "\tSuccessfully read %d bytes of %d bytes and closed %s"
+                % (len(bytes_read), size, Write["filename"])
+            )
 
-            Remainder = len(bytes_read)%SECTOR_SIZE
+            Remainder = len(bytes_read) % SECTOR_SIZE
 
             if Remainder != 0:
-                device_log("\tbytes_read is not a multiple of SECTOR_SIZE (%d bytes), appending zeros" % SECTOR_SIZE)
+                device_log(
+                    "\tbytes_read is not a multiple of SECTOR_SIZE (%d bytes), appending zeros"
+                    % SECTOR_SIZE
+                )
 
-                Bytes = struct.unpack("%dB" % len(bytes_read),bytes_read)    ## unpack returns list, so get index 0
+                Bytes = struct.unpack(
+                    "%dB" % len(bytes_read), bytes_read
+                )  ## unpack returns list, so get index 0
 
-                Temp         = list(Bytes) + [0x00]*(SECTOR_SIZE-Remainder)   # concat
+                Temp = list(Bytes) + [0x00] * (SECTOR_SIZE - Remainder)  # concat
                 TotalSize = len(Temp)
 
                 bytes_read = struct.pack("%dB" % TotalSize, *Temp)
@@ -640,23 +804,35 @@ def PerformWrite():
 
             # At this point bytes_read is a multiple of SECTOR_SIZE
 
-        #device_log("\t\tNeed to move to location %i (%i bytes) in %s" % (Write['start_sector'],(Write['start_sector']*SECTOR_SIZE),Filename))
-        #device_log("\t\tPartition['start_sector']*SECTOR_SIZE = %i" % (Write['start_sector']*SECTOR_SIZE))
+        # device_log("\t\tNeed to move to location %i (%i bytes) in %s" % (Write['start_sector'],(Write['start_sector']*SECTOR_SIZE),Filename))
+        # device_log("\t\tPartition['start_sector']*SECTOR_SIZE = %i" % (Write['start_sector']*SECTOR_SIZE))
 
-        if (2*DiskSizeInBytes)<Write['start_sector'] and os.path.basename(Filename)!="singleimage.bin":
-            device_log("2*DiskSizeInBytes=%d" % (2*DiskSizeInBytes))
-            device_log("Write['start_sector']=%i"%Write['start_sector'])
-            PrintBigError("Attempting to move to sector %i (%.2f MB) and only %i sectors (%.2f MB) exist (%i difference (%.2f MB) )" % (Write['start_sector'],Write['start_sector']*SECTOR_SIZE/1024.0,2*DiskSizeInBytes,DiskSizeInBytes/1024.0,Write['start_sector']-(2*DiskSizeInBytes),(Write['start_sector']-(2*DiskSizeInBytes))/2048.0))
+        if (2 * DiskSizeInBytes) < Write["start_sector"] and os.path.basename(
+            Filename
+        ) != "singleimage.bin":
+            device_log("2*DiskSizeInBytes=%d" % (2 * DiskSizeInBytes))
+            device_log("Write['start_sector']=%i" % Write["start_sector"])
+            PrintBigError(
+                "Attempting to move to sector %i (%.2f MB) and only %i sectors (%.2f MB) exist (%i difference (%.2f MB) )"
+                % (
+                    Write["start_sector"],
+                    Write["start_sector"] * SECTOR_SIZE / 1024.0,
+                    2 * DiskSizeInBytes,
+                    DiskSizeInBytes / 1024.0,
+                    Write["start_sector"] - (2 * DiskSizeInBytes),
+                    (Write["start_sector"] - (2 * DiskSizeInBytes)) / 2048.0,
+                )
+            )
 
         try:
-            if os.path.basename(Filename)=="singleimage.bin":
-                Filename = OutputFolder+os.path.basename(Filename)
+            if os.path.basename(Filename) == "singleimage.bin":
+                Filename = OutputFolder + os.path.basename(Filename)
 
             opfile = open(Filename, "r+b")  ## Filename = '\\.\PHYSICALDRIVE1'
         except Exception as x:
 
             PrintBigError("")
-            device_log("Could not open Filename=%s, cwd=%s" % (Filename, os.getcwd() ))
+            device_log("Could not open Filename=%s, cwd=%s" % (Filename, os.getcwd()))
             device_log("REASON: %s" % (x))
 
             if sys.platform.startswith("linux"):
@@ -667,68 +843,97 @@ def PerformWrite():
                 print("\t\\__ \\ |_| | (_| | (_) |_|")
                 print("\t|___/\\__,_|\\__,_|\\___/(_)\n")
                 device_log("\tDon't forget you need SUDO with this program")
-                device_log("\tsudo python msp.py partition.xml /dev/sdx (where x is the device node)")
+                device_log(
+                    "\tsudo python msp.py partition.xml /dev/sdx (where x is the device node)"
+                )
             else:
-                device_log("\t  ___      _           _       _     _             _                ___  ")
-                device_log("\t / _ \\    | |         (_)     (_)   | |           | |              |__ \\ ")
-                device_log("\t/ /_\\ \\ __| |_ __ ___  _ _ __  _ ___| |_ _ __ __ _| |_  ___  _ __     ) |")
-                device_log("\t|  _  |/ _` | '_ ` _ \\| | '_ \\| / __| __| '__/ _` | __|/ _ \\| '__|   / / ")
-                device_log("\t| | | | (_| | | | | | | | | | | \\__ \\ |_| | | (_| | |_| (_) | |     |_|  ")
-                device_log("\t\\_| |_/\\__,_|_| |_| |_|_|_| |_|_|___/\\__|_|  \\__,_|\\__|\\___/|_|     (_)  \n\n")
+                device_log(
+                    "\t  ___      _           _       _     _             _                ___  "
+                )
+                device_log(
+                    "\t / _ \\    | |         (_)     (_)   | |           | |              |__ \\ "
+                )
+                device_log(
+                    "\t/ /_\\ \\ __| |_ __ ___  _ _ __  _ ___| |_ _ __ __ _| |_  ___  _ __     ) |"
+                )
+                device_log(
+                    "\t|  _  |/ _` | '_ ` _ \\| | '_ \\| / __| __| '__/ _` | __|/ _ \\| '__|   / / "
+                )
+                device_log(
+                    "\t| | | | (_| | | | | | | | | | | \\__ \\ |_| | | (_| | |_| (_) | |     |_|  "
+                )
+                device_log(
+                    "\t\\_| |_/\\__,_|_| |_| |_|_|_| |_|_|___/\\__|_|  \\__,_|\\__|\\___/|_|     (_)  \n\n"
+                )
 
-                device_log("\n"+"-"*78)
+                device_log("\n" + "-" * 78)
                 device_log("\tThis program needs to be run as Administrator!!")
-                device_log("-"*78+"\n")
-                device_log("-"*78)
-                device_log("\tTo fix, you must open a CMD prompt with \"Run as administrator\"")
-                device_log("-"*78+"\n")
+                device_log("-" * 78 + "\n")
+                device_log("-" * 78)
+                device_log(
+                    '\tTo fix, you must open a CMD prompt with "Run as administrator"'
+                )
+                device_log("-" * 78 + "\n")
 
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit()
 
-        device_log("opfile = open('%s', 'r+b') , cwd=%s" % (Filename, os.getcwd() ))
+        device_log("opfile = open('%s', 'r+b') , cwd=%s" % (Filename, os.getcwd()))
         device_log("\n\tOpened %s" % Filename)
 
-
-        if Write['start_sector'] < 0:
-            device_log("start sector is less than 0 - skipping this instruction, most likely for GPT HACK")
+        if Write["start_sector"] < 0:
+            device_log(
+                "start sector is less than 0 - skipping this instruction, most likely for GPT HACK"
+            )
             continue
 
-        if Write['start_sector'] > int(DiskSizeInBytes/SECTOR_SIZE):
+        if Write["start_sector"] > int(DiskSizeInBytes / SECTOR_SIZE):
             PrintBigError("")
-            device_log("\nERROR: Start sector (%i) is BIGGER than the disk (%i sectors)" % (Write['start_sector'],int(DiskSizeInBytes/SECTOR_SIZE)))
-            device_log("\nERROR: Your device is TOO SMALL to handle this partition info")
+            device_log(
+                "\nERROR: Start sector (%i) is BIGGER than the disk (%i sectors)"
+                % (Write["start_sector"], int(DiskSizeInBytes / SECTOR_SIZE))
+            )
+            device_log(
+                "\nERROR: Your device is TOO SMALL to handle this partition info"
+            )
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit(1)
 
-        if int(Write['start_sector']) > 0:
+        if int(Write["start_sector"]) > 0:
             try:
-                opfile.seek(int(Write['start_sector']*SECTOR_SIZE))
+                opfile.seek(int(Write["start_sector"] * SECTOR_SIZE))
             except Exception as x:
-                PrintBigError("Could not move to sector %d on %s" % (Write['start_sector'],Filename))
+                PrintBigError(
+                    "Could not move to sector %d on %s"
+                    % (Write["start_sector"], Filename)
+                )
                 device_log("REASON: %s" % (x))
 
-            device_log("\tMoved to sector %d on %s" % (Write['start_sector'],Filename))
+            device_log("\tMoved to sector %d on %s" % (Write["start_sector"], Filename))
 
-        CurrentSector = Write['start_sector']
+        CurrentSector = Write["start_sector"]
         ##device_log("size=",size)
         ##device_log("MAX_FILE_SIZE_BEFORE_SPLIT=",MAX_FILE_SIZE_BEFORE_SPLIT)
 
-        CurrentSector += (size/SECTOR_SIZE)
+        CurrentSector += size / SECTOR_SIZE
 
-        if size<MAX_FILE_SIZE_BEFORE_SPLIT:
+        if size < MAX_FILE_SIZE_BEFORE_SPLIT:
             device_log("\tFile can be written completely.")
             device_log("\tCalling opfile.write(bytes_read)")
             try:
                 opfile.write(bytes_read)
             except Exception as x:
                 PrintBigError("")
-                device_log("Could not write %d bytes to %s" % (len(bytes_read),Filename))
+                device_log(
+                    "Could not write %d bytes to %s" % (len(bytes_read), Filename)
+                )
                 device_log("REASON: %s" % (x))
                 device_log("\nPlease try removing the medium and re-inserting it")
-                device_log("Strangly this helps sometimes after writing *new* partition tables\n\n")
-                #traceback.print_exc(file=sys.stdout)
-                #traceback.print_exc()
+                device_log(
+                    "Strangly this helps sometimes after writing *new* partition tables\n\n"
+                )
+                # traceback.print_exc(file=sys.stdout)
+                # traceback.print_exc()
                 sys.exit(1)
 
         else:
@@ -736,54 +941,77 @@ def PerformWrite():
             ##device_log("I need to break up this file")
 
             TempSize = size
-            NumLoop = int(TempSize/MAX_FILE_SIZE_BEFORE_SPLIT)
-            Remainder = size%MAX_FILE_SIZE_BEFORE_SPLIT
-            if Remainder>0:
-                Remainder=1
+            NumLoop = int(TempSize / MAX_FILE_SIZE_BEFORE_SPLIT)
+            Remainder = size % MAX_FILE_SIZE_BEFORE_SPLIT
+            if Remainder > 0:
+                Remainder = 1
 
-            device_log("\nNeed to break up this file, will loop %d times writing %i bytes each time" % (NumLoop+Remainder,MAX_FILE_SIZE_BEFORE_SPLIT))
-            TempSize=0
+            device_log(
+                "\nNeed to break up this file, will loop %d times writing %i bytes each time"
+                % (NumLoop + Remainder, MAX_FILE_SIZE_BEFORE_SPLIT)
+            )
+            TempSize = 0
             for a in range(NumLoop):
-                #device_log("read %i bytes" % MAX_FILE_SIZE_BEFORE_SPLIT)
+                # device_log("read %i bytes" % MAX_FILE_SIZE_BEFORE_SPLIT)
                 try:
                     bytes_read = ipfile.read(MAX_FILE_SIZE_BEFORE_SPLIT)
                 except Exception as x:
-                    PrintBigError("Could not read from %s\nREASON: %s" % (FileWithPath,x))
+                    PrintBigError(
+                        "Could not read from %s\nREASON: %s" % (FileWithPath, x)
+                    )
 
                 ##device_log("\n\t%i) Packing %i Bytes [%i:%i]" % (a+1,MAX_FILE_SIZE_BEFORE_SPLIT,TempSize,TempSize+MAX_FILE_SIZE_BEFORE_SPLIT))
                 ##bytes_read = struct.pack("%dB" % MAX_FILE_SIZE_BEFORE_SPLIT, *Bytes[TempSize:(TempSize+MAX_FILE_SIZE_BEFORE_SPLIT)])
-                device_log("\t%.2i) Writing %i Bytes [%i:%i]" % (a+1,MAX_FILE_SIZE_BEFORE_SPLIT,TempSize,TempSize+MAX_FILE_SIZE_BEFORE_SPLIT))
+                device_log(
+                    "\t%.2i) Writing %i Bytes [%i:%i]"
+                    % (
+                        a + 1,
+                        MAX_FILE_SIZE_BEFORE_SPLIT,
+                        TempSize,
+                        TempSize + MAX_FILE_SIZE_BEFORE_SPLIT,
+                    )
+                )
                 try:
                     opfile.write(bytes_read)
                 except Exception as x:
-                    PrintBigError("Could not write to %s\nREASON: %s" % (Filename,x))
+                    PrintBigError("Could not write to %s\nREASON: %s" % (Filename, x))
 
                 TempSize += MAX_FILE_SIZE_BEFORE_SPLIT
             ##device_log("Out of loop")
-            a+=1
+            a += 1
 
             if Remainder == 1:
                 # Need to PAD the file to be a multiple of SECTOR_SIZE bytes too
 
-                #device_log("\n\t%i) Packing %i Bytes [%i:%i]" % (a,(len(Bytes)-TempSize),TempSize,len(Bytes)))
-                #bytes_read = struct.pack("%dB" % (len(Bytes)-TempSize), *Bytes[TempSize:len(Bytes)])
+                # device_log("\n\t%i) Packing %i Bytes [%i:%i]" % (a,(len(Bytes)-TempSize),TempSize,len(Bytes)))
+                # bytes_read = struct.pack("%dB" % (len(Bytes)-TempSize), *Bytes[TempSize:len(Bytes)])
 
-                device_log("\t%.2i) Writing %i Bytes [%i:%i]" % (a+1,(size-TempSize),TempSize,size))
+                device_log(
+                    "\t%.2i) Writing %i Bytes [%i:%i]"
+                    % (a + 1, (size - TempSize), TempSize, size)
+                )
                 try:
-                    bytes_read = ipfile.read(size-TempSize)
+                    bytes_read = ipfile.read(size - TempSize)
                 except Exception as x:
-                    PrintBigError("Could not read from %s\nREASON: %s" % (FileWithPath,x))
+                    PrintBigError(
+                        "Could not read from %s\nREASON: %s" % (FileWithPath, x)
+                    )
 
                 ##device_log("len(bytes_read)=",len(bytes_read))
 
-                Remainder = len(bytes_read)%SECTOR_SIZE
+                Remainder = len(bytes_read) % SECTOR_SIZE
 
                 if Remainder != 0:
-                    device_log("\tbytes_read is not a multiple of SECTOR_SIZE (%d bytes), appending zeros" % SECTOR_SIZE)
+                    device_log(
+                        "\tbytes_read is not a multiple of SECTOR_SIZE (%d bytes), appending zeros"
+                        % SECTOR_SIZE
+                    )
 
-                    Bytes = struct.unpack("%dB" % len(bytes_read),bytes_read)    ## unpack returns list, so get index 0
+                    Bytes = struct.unpack(
+                        "%dB" % len(bytes_read), bytes_read
+                    )  ## unpack returns list, so get index 0
 
-                    Temp         = list(Bytes) + [0x00]*(SECTOR_SIZE-Remainder)   # concat
+                    Temp = list(Bytes) + [0x00] * (SECTOR_SIZE - Remainder)  # concat
                     TotalSize = len(Temp)
 
                     bytes_read = struct.pack("%dB" % TotalSize, *Temp)
@@ -791,21 +1019,23 @@ def PerformWrite():
 
                 # At this point bytes_read is a multiple of SECTOR_SIZE
 
-                #device_log("This is the final write")
+                # device_log("This is the final write")
                 try:
                     opfile.write(bytes_read)
                 except Exception as x:
-                    PrintBigError("Could not write to %s\nREASON: %s" % (Filename,x))
+                    PrintBigError("Could not write to %s\nREASON: %s" % (Filename, x))
 
             ipfile.close()
 
-        if os.path.basename(Filename)=="singleimage.bin":
-            device_log("\tSingleImageSize %i bytes (%i sectors)" % (CurrentSector*SECTOR_SIZE,CurrentSector))
+        if os.path.basename(Filename) == "singleimage.bin":
+            device_log(
+                "\tSingleImageSize %i bytes (%i sectors)"
+                % (CurrentSector * SECTOR_SIZE, CurrentSector)
+            )
             device_log("\tCurrentSector=%i" % CurrentSector)
-            device_log("\tDiskSize=%i sectors" % int(DiskSizeInBytes/SECTOR_SIZE))
+            device_log("\tDiskSize=%i sectors" % int(DiskSizeInBytes / SECTOR_SIZE))
 
-
-        #device_log("\tWrote %d bytes at sector %d on %s" % (len(bytes_read),Write['start_sector'],Filename))
+        # device_log("\tWrote %d bytes at sector %d on %s" % (len(bytes_read),Write['start_sector'],Filename))
 
         try:
             ##print opfile
@@ -813,104 +1043,152 @@ def PerformWrite():
         except Exception as x:
             device_log("\tWARNING: Can't close the file?")
             device_log("REASON: %s" % (x))
-            #sys.exit()
+            # sys.exit()
             pass
 
-
         device_log("\n\tWritten with")
-        device_log("\tpython dd.py --if=%s --bs=%i --count=%i --seek=%i --of=%s" % (FileWithPath,SECTOR_SIZE,int((size-1)/SECTOR_SIZE)+1,Write['start_sector'],Filename))
+        device_log(
+            "\tpython dd.py --if=%s --bs=%i --count=%i --seek=%i --of=%s"
+            % (
+                FileWithPath,
+                SECTOR_SIZE,
+                int((size - 1) / SECTOR_SIZE) + 1,
+                Write["start_sector"],
+                Filename,
+            )
+        )
         device_log("\n\tVerify with")
-        device_log("\tpython dd.py --if=%s --bs=%i --count=%i --skip=%i --of=dump.bin" % (Filename,SECTOR_SIZE,int((size-1)/SECTOR_SIZE)+1,Write['start_sector']))
+        device_log(
+            "\tpython dd.py --if=%s --bs=%i --count=%i --skip=%i --of=dump.bin"
+            % (
+                Filename,
+                SECTOR_SIZE,
+                int((size - 1) / SECTOR_SIZE) + 1,
+                Write["start_sector"],
+            )
+        )
 
-        device_log("\n\tSuccessfully wrote \"%s\" (%s payload) to %s" % (Write['filename'],ReturnSizeString(size),Filename))
+        device_log(
+            '\n\tSuccessfully wrote "%s" (%s payload) to %s'
+            % (Write["filename"], ReturnSizeString(size), Filename)
+        )
 
-        #raw_input("Enter something: ")
+        # raw_input("Enter something: ")
 
-        #if Write['filename']=="sbl3.mbn":
+        # if Write['filename']=="sbl3.mbn":
         #    sys.exit()
 
-    if os.path.basename(Filename)=="singleimage.bin":
-        if CurrentSector < int(DiskSizeInBytes/SECTOR_SIZE):
-            device_log("\n\nSingleImageSize %i bytes (%i sectors)" % (CurrentSector*SECTOR_SIZE,CurrentSector))
+    if os.path.basename(Filename) == "singleimage.bin":
+        if CurrentSector < int(DiskSizeInBytes / SECTOR_SIZE):
+            device_log(
+                "\n\nSingleImageSize %i bytes (%i sectors)"
+                % (CurrentSector * SECTOR_SIZE, CurrentSector)
+            )
             device_log("CurrentSector=%i" % CurrentSector)
-            device_log("DiskSizeInBytes=%i sectors" % int(DiskSizeInBytes/SECTOR_SIZE))
+            device_log(
+                "DiskSizeInBytes=%i sectors" % int(DiskSizeInBytes / SECTOR_SIZE)
+            )
 
     device_log("\nDone Writing Files\n")
 
     return ThereWereWarnings
 
-def GetPartitions():
-    global Devices,AvailablePartitions
-    if sys.platform.startswith("linux"):
-        #device_log("This is a linux system since sys.platform='%s'" % sys.platform)
 
-        device_log("-"*78    )
+def GetPartitions():
+    global Devices, AvailablePartitions
+    if sys.platform.startswith("linux"):
+        # device_log("This is a linux system since sys.platform='%s'" % sys.platform)
+
+        device_log("-" * 78)
         device_log("\tRemember - DON'T FORGET SUDO")
         device_log("\tRemember - DON'T FORGET SUDO")
         device_log("\tRemember - DON'T FORGET SUDO")
-        device_log("-"*78+"\n")
+        device_log("-" * 78 + "\n")
 
         os.system("cat /proc/partitions > temp_partitions.txt")
         with open("temp_partitions.txt") as IN:
             output = IN.readlines()
         for line in output:
-            #print line
+            # print line
 
-            m = re.search(r'(\d+) (sd[a-z])$', line)
+            m = re.search(r"(\d+) (sd[a-z])$", line)
             if m is not None:
-                Size    = int(m.group(1))
-                Device  = "/dev/"+m.group(2)
-                #device_log("%s\tSize=%d,%.1fMB (%.2fGB) (%iKB)" % (Device,Size,int(Size)/1024.0,int(Size)/(1024.0*1024.0),int(Size))
-                AvailablePartitions[Device] = Size*1024.0    # linux reports in terms of 1024,
-
+                Size = int(m.group(1))
+                Device = "/dev/" + m.group(2)
+                # device_log("%s\tSize=%d,%.1fMB (%.2fGB) (%iKB)" % (Device,Size,int(Size)/1024.0,int(Size)/(1024.0*1024.0),int(Size))
+                AvailablePartitions[Device] = (
+                    Size * 1024.0
+                )  # linux reports in terms of 1024,
 
     else:
         ##device_log("This is a windows system since sys.platform='%s'" % sys.platform
 
-        device_log("\t  ___      _           _       _     _             _                ___  ")
-        device_log("\t / _ \\    | |         (_)     (_)   | |           | |              |__ \\ ")
-        device_log("\t/ /_\\ \\ __| |_ __ ___  _ _ __  _ ___| |_ _ __ __ _| |_  ___  _ __     ) |")
-        device_log("\t|  _  |/ _` | '_ ` _ \\| | '_ \\| / __| __| '__/ _` | __|/ _ \\| '__|   / / ")
-        device_log("\t| | | | (_| | | | | | | | | | | \\__ \\ |_| | | (_| | |_| (_) | |     |_|  ")
-        device_log("\t\\_| |_/\\__,_|_| |_| |_|_|_| |_|_|___/\\__|_|  \\__,_|\\__|\\___/|_|     (_)  \n")
+        device_log(
+            "\t  ___      _           _       _     _             _                ___  "
+        )
+        device_log(
+            "\t / _ \\    | |         (_)     (_)   | |           | |              |__ \\ "
+        )
+        device_log(
+            "\t/ /_\\ \\ __| |_ __ ___  _ _ __  _ ___| |_ _ __ __ _| |_  ___  _ __     ) |"
+        )
+        device_log(
+            "\t|  _  |/ _` | '_ ` _ \\| | '_ \\| / __| __| '__/ _` | __|/ _ \\| '__|   / / "
+        )
+        device_log(
+            "\t| | | | (_| | | | | | | | | | | \\__ \\ |_| | | (_| | |_| (_) | |     |_|  "
+        )
+        device_log(
+            "\t\\_| |_/\\__,_|_| |_| |_|_|_| |_|_|___/\\__|_|  \\__,_|\\__|\\___/|_|     (_)  \n"
+        )
 
-        device_log("-"*78    )
+        device_log("-" * 78)
         device_log("\tRemember - Under Win7 you must run this as Administrator")
-        device_log("-"*78)
+        device_log("-" * 78)
 
-        response = external_call('wmic DISKDRIVE get DeviceID, MediaType, Model, Size')
+        response = external_call("wmic DISKDRIVE get DeviceID, MediaType, Model, Size")
         m = re.search("Access is denied", response)
         if m is not None:
-            PrintBigError("This computer does not have correct privileges, you need administrator group privilege\n")
+            PrintBigError(
+                "This computer does not have correct privileges, you need administrator group privilege\n"
+            )
 
-        device_log("\n"+response)
+        device_log("\n" + response)
 
-        response = response.replace('\r', '').strip("\n").split("\n")[1:]
+        response = response.replace("\r", "").strip("\n").split("\n")[1:]
         for line in response:
-            m = re.search(r'(PHYSICALDRIVE\d+).+ (\d+) ', line)
+            m = re.search(r"(PHYSICALDRIVE\d+).+ (\d+) ", line)
             if m is not None:
-                Size    = int(m.group(2))       # size in bytes
-                Device  = "\\\\.\\"+m.group(1)  # \\.\PHYSICALDRIVE1
+                Size = int(m.group(2))  # size in bytes
+                Device = "\\\\.\\" + m.group(1)  # \\.\PHYSICALDRIVE1
 
                 AvailablePartitions[Device] = Size
-
 
     Devices = list(AvailablePartitions.keys())
     Devices.sort()
 
-    device_log("--------------------------------Partitions Detected--------------------------------------")
+    device_log(
+        "--------------------------------Partitions Detected--------------------------------------"
+    )
     for device in Devices:
         value = AvailablePartitions[device]
 
-        if value/(1024.0*1024.0*1024.0) > 31.0:
-            device_log("%s   %s\tsectors:%i <--- Not likely an SD card, careful!" % (device,ReturnSizeString(value),value/SECTOR_SIZE) )
+        if value / (1024.0 * 1024.0 * 1024.0) > 31.0:
+            device_log(
+                "%s   %s\tsectors:%i <--- Not likely an SD card, careful!"
+                % (device, ReturnSizeString(value), value / SECTOR_SIZE)
+            )
         else:
-            device_log("%s   %s\tsectors:%i" % (device,ReturnSizeString(value),value/SECTOR_SIZE))
+            device_log(
+                "%s   %s\tsectors:%i"
+                % (device, ReturnSizeString(value), value / SECTOR_SIZE)
+            )
 
-    device_log("-"*78+"\n")
+    device_log("-" * 78 + "\n")
+
 
 def PerformPatching():
-    global PatchArray,Patching
+    global PatchArray, Patching
 
     device_log("\t             _        _     _             ")
     device_log("\t            | |      | |   (_)            ")
@@ -921,49 +1199,63 @@ def PerformPatching():
     device_log("\t| |                                  __/ |")
     device_log("\t|_|                                 |___/ ")
 
-    var = 'Y'
+    var = "Y"
     if Patching == "DISK":
-        var = 'N'           ## user must authorize this
+        var = "N"  ## user must authorize this
 
     ## PATCHING HAPPENS HERE - PATCHING HAPPENS HERE - PATCHING HAPPENS HERE
 
     for Patch in PatchArray:
 
-        if Patch['physical_partition_number']!=0:   ## msp tool can only write to PHY partition 0
-            device_log("WARNING '%s' for physical_partition_number=%d (only 0 is accessible) - THIS MIGHT FAIL" % (Patch['filename'],Patch['physical_partition_number']))
+        if (
+            Patch["physical_partition_number"] != 0
+        ):  ## msp tool can only write to PHY partition 0
+            device_log(
+                "WARNING '%s' for physical_partition_number=%d (only 0 is accessible) - THIS MIGHT FAIL"
+                % (Patch["filename"], Patch["physical_partition_number"])
+            )
 
         if Patching == "DISK":
             ## to be here means user wants to patch the actual disk
-            if Patch['filename'] == "DISK":
-                pass    ## all is well, want to patch DISK, and this is DISK
+            if Patch["filename"] == "DISK":
+                pass  ## all is well, want to patch DISK, and this is DISK
             else:
-                continue    ## this was filename, so skip it
+                continue  ## this was filename, so skip it
         else:
             ## to be here means were patching files, not the disk
-            if Patch['filename'] == "DISK":
-                continue    ## want to patch FILES, but this was a DISK, so skip it
+            if Patch["filename"] == "DISK":
+                continue  ## want to patch FILES, but this was a DISK, so skip it
             else:
-                pass    ## this was filename, so let's patch it
+                pass  ## this was filename, so let's patch it
 
-        device_log("\n" + "-"*78)
-        device_log("PATCH: (%s) %s" % (Patch['filename'],Patch['what']))
+        device_log("\n" + "-" * 78)
+        device_log("PATCH: (%s) %s" % (Patch["filename"], Patch["what"]))
 
-        FileToOpen =  Patch['filename']
+        FileToOpen = Patch["filename"]
 
         if noprompt is True:
             # means don't bug them, i.e. automation
             pass
         else:
-            if var=='N' or var=='n':
-                device_log("\nWARNING: Are you sure you want to PATCH to '%s' of size %s (y|N) " % (Filename,ReturnSizeString(DiskSizeInBytes)),0)
-                var = input("\nWARNING: Are you sure you want to PATCH to '%s' of size %s (y|N) " % (Filename,ReturnSizeString(DiskSizeInBytes)))
-                if var=='Y' or var=='y':
+            if var == "N" or var == "n":
+                device_log(
+                    "\nWARNING: Are you sure you want to PATCH to '%s' of size %s (y|N) "
+                    % (Filename, ReturnSizeString(DiskSizeInBytes)),
+                    0,
+                )
+                var = input(
+                    "\nWARNING: Are you sure you want to PATCH to '%s' of size %s (y|N) "
+                    % (Filename, ReturnSizeString(DiskSizeInBytes))
+                )
+                if var == "Y" or var == "y":
                     pass
                 else:
-                    device_log("\nmsp.py exiting - user didn't want to patch - Log is log_msp.txt\n\n")
+                    device_log(
+                        "\nmsp.py exiting - user didn't want to patch - Log is log_msp.txt\n\n"
+                    )
                     sys.exit(1)
 
-        if Patching=="DISK":
+        if Patching == "DISK":
             FileWithPath = Filename
         else:
             FileWithPath = find_file(FileToOpen, search_paths)
@@ -978,9 +1270,15 @@ def PerformPatching():
             device_log("\t\\_|   \\__,_|\\__|_| |_|   (_)  \n\n")
 
             if rawprogram_filename is None:
-                device_log("WARNING: '%s' listed in '%s' not found\n" % (FileToOpen,patch_filename))
+                device_log(
+                    "WARNING: '%s' listed in '%s' not found\n"
+                    % (FileToOpen, patch_filename)
+                )
             else:
-                device_log("WARNING: '%s' listed in '%s' not found\n" % (FileToOpen,rawprogram_filename))
+                device_log(
+                    "WARNING: '%s' listed in '%s' not found\n"
+                    % (FileToOpen, rawprogram_filename)
+                )
 
             if noprompt is True:
                 device_log("\nUse option -s c:\\path1 -s c:\\path2 etc")
@@ -990,142 +1288,205 @@ def PerformPatching():
 
             device_log("Please provide a path for this file")
             device_log("Ex. \\\\somepath\\folder OR c:\\somepath\\folder\n")
-            device_log("Enter PATH or Q to quit? ",0)
+            device_log("Enter PATH or Q to quit? ", 0)
             temppath = input("Enter PATH or Q to quit? ")
-            if temppath=='Q' or temppath=='q' or temppath=='':
-                device_log("\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n")
+            if temppath == "Q" or temppath == "q" or temppath == "":
+                device_log(
+                    "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
+                )
                 sys.exit()
 
             device_log("\n")
 
-            FileWithPath = find_file(Write['filename'], [temppath])
+            FileWithPath = find_file(Write["filename"], [temppath])
 
             if FileWithPath is not None:
                 os.path.getsize(FileWithPath)
 
-                device_log("\nShould this path be used to find other files? (Y|n|q)",0)
+                device_log("\nShould this path be used to find other files? (Y|n|q)", 0)
                 temp = input("\nShould this path be used to find other files? (Y|n|q)")
-                if temp=='Q' or temp=='q':
-                    device_log("\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n")
+                if temp == "Q" or temp == "q":
+                    device_log(
+                        "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
+                    )
                     sys.exit()
-                elif temp=='Y' or temp=='y' or temp=='':
+                elif temp == "Y" or temp == "y" or temp == "":
                     search_paths.append(temppath)
-                device_log("\n"            )
+                device_log("\n")
 
         try:
             opfile = open(FileWithPath, "r+b")
-            device_log("Opened %s, cwd=%s" % (FileWithPath,os.getcwd() ))
+            device_log("Opened %s, cwd=%s" % (FileWithPath, os.getcwd()))
         except Exception as x:
-            PrintBigError("Could not open %s, cwd=%s\nREASON: %s" % (FileWithPath,os.getcwd(),x ))
+            PrintBigError(
+                "Could not open %s, cwd=%s\nREASON: %s" % (FileWithPath, os.getcwd(), x)
+            )
 
-        if Patch['function']=="CRC32":
-            device_log("\t%s(%u,%u) requested " % (Patch['function'],Patch['arg0'],Patch['arg1']))
+        if Patch["function"] == "CRC32":
+            device_log(
+                "\t%s(%u,%u) requested "
+                % (Patch["function"], Patch["arg0"], Patch["arg1"])
+            )
 
-            PStartSector = int(Patch['arg0'])
-            PNumSectors  = int(Patch['arg1']/SECTOR_SIZE)
-            if PNumSectors==0 or (Patch['arg1']%SECTOR_SIZE)>0: # i.e. 640/SECTOR_SIZE means read 2 sectors worth
-                PNumSectors+=1
+            PStartSector = int(Patch["arg0"])
+            PNumSectors = int(Patch["arg1"] / SECTOR_SIZE)
+            if (
+                PNumSectors == 0 or (Patch["arg1"] % SECTOR_SIZE) > 0
+            ):  # i.e. 640/SECTOR_SIZE means read 2 sectors worth
+                PNumSectors += 1
 
             try:
-                if Patch['arg0']>64:
-                    device_log("\tPatch['arg0']=%d" % Patch['arg0'])
-                    device_log("\tPatch['arg1']=%d" % Patch['arg1'])
+                if Patch["arg0"] > 64:
+                    device_log("\tPatch['arg0']=%d" % Patch["arg0"])
+                    device_log("\tPatch['arg1']=%d" % Patch["arg1"])
 
-                    device_log("\tmoving to sector %d-%d (%d)" % (PStartSector,(64-PNumSectors),PStartSector-(64-PNumSectors)))
-                    opfile.seek( int( (PStartSector-(64-PNumSectors) )*SECTOR_SIZE ))
+                    device_log(
+                        "\tmoving to sector %d-%d (%d)"
+                        % (
+                            PStartSector,
+                            (64 - PNumSectors),
+                            PStartSector - (64 - PNumSectors),
+                        )
+                    )
+                    opfile.seek(int((PStartSector - (64 - PNumSectors)) * SECTOR_SIZE))
                 else:
-                    device_log("moving to sector %d (byte location %d)" % (Patch['arg0'],Patch['arg0']*SECTOR_SIZE))
-                    opfile.seek( int(Patch['arg0']*SECTOR_SIZE))
+                    device_log(
+                        "moving to sector %d (byte location %d)"
+                        % (Patch["arg0"], Patch["arg0"] * SECTOR_SIZE)
+                    )
+                    opfile.seek(int(Patch["arg0"] * SECTOR_SIZE))
 
             except Exception as x:
-                PrintBigError("Could not complete move in %s\nREASON: %s" % (FileWithPath,x))
+                PrintBigError(
+                    "Could not complete move in %s\nREASON: %s" % (FileWithPath, x)
+                )
 
             device_log("\tMove Successful ")
 
             try:
-                if Patch['arg0']>64:
-                    device_log("\tTrying to read %d bytes in %s" % (64*SECTOR_SIZE,FileWithPath))
-                    bytes_read = opfile.read(64*SECTOR_SIZE)
+                if Patch["arg0"] > 64:
+                    device_log(
+                        "\tTrying to read %d bytes in %s"
+                        % (64 * SECTOR_SIZE, FileWithPath)
+                    )
+                    bytes_read = opfile.read(64 * SECTOR_SIZE)
                 else:
-                    device_log("\tTrying to read %d bytes in %s" % (Patch['arg1'],FileWithPath))
-                    bytes_read = opfile.read(Patch['arg1'])
+                    device_log(
+                        "\tTrying to read %d bytes in %s"
+                        % (Patch["arg1"], FileWithPath)
+                    )
+                    bytes_read = opfile.read(Patch["arg1"])
             except Exception as x:
-                PrintBigError("Could not read in %s\nREASON: %s" % (FileWithPath,x))
+                PrintBigError("Could not read in %s\nREASON: %s" % (FileWithPath, x))
 
             device_log("\tlen(bytes_read)=%d" % len(bytes_read))
 
-            if Patch['arg0']>64:
-                Bytes = struct.unpack("%dB" % (64*SECTOR_SIZE),bytes_read)    ## unpack returns list, so get index 0
+            if Patch["arg0"] > 64:
+                Bytes = struct.unpack(
+                    "%dB" % (64 * SECTOR_SIZE), bytes_read
+                )  ## unpack returns list, so get index 0
             else:
-                Bytes = struct.unpack("%dB" % Patch['arg1'],bytes_read)    ## unpack returns list, so get index 0
+                Bytes = struct.unpack(
+                    "%dB" % Patch["arg1"], bytes_read
+                )  ## unpack returns list, so get index 0
 
-
-
-            if Patch['arg0']>64:
-                #PStartSector
-                #PNumSectors
-                StartByte = (64-PNumSectors)*SECTOR_SIZE
-                device_log("\tStartByte=%i"%StartByte)
+            if Patch["arg0"] > 64:
+                # PStartSector
+                # PNumSectors
+                StartByte = (64 - PNumSectors) * SECTOR_SIZE
+                device_log("\tStartByte=%i" % StartByte)
 
                 ##print "Patch['arg1'] is :",Patch['arg1']
-                Patch['value'] = CalcCRC32(Bytes[StartByte:],Patch['arg1'])
+                Patch["value"] = CalcCRC32(Bytes[StartByte:], Patch["arg1"])
             else:
-                Patch['value'] = CalcCRC32(Bytes,Patch['arg1'])
+                Patch["value"] = CalcCRC32(Bytes, Patch["arg1"])
 
-            device_log("\tCRC32=0x%.8X" % Patch['value'])
+            device_log("\tCRC32=0x%.8X" % Patch["value"])
 
         # ELSE - patch is not a CRC
-        if(int(Patch['start_sector'])>0):
+        if int(Patch["start_sector"]) > 0:
             try:
-                if Patch['start_sector']>64:
-                    device_log("moving to %d-63=%d" % (Patch['start_sector'],Patch['start_sector']-63))
-                    opfile.seek( int((Patch['start_sector']-63)*SECTOR_SIZE))
+                if Patch["start_sector"] > 64:
+                    device_log(
+                        "moving to %d-63=%d"
+                        % (Patch["start_sector"], Patch["start_sector"] - 63)
+                    )
+                    opfile.seek(int((Patch["start_sector"] - 63) * SECTOR_SIZE))
                 else:
-                    device_log("moving to sector %d (byte location %d)" % (Patch['start_sector'],Patch['start_sector']*SECTOR_SIZE))
-                    opfile.seek(int(Patch['start_sector']*SECTOR_SIZE))
+                    device_log(
+                        "moving to sector %d (byte location %d)"
+                        % (Patch["start_sector"], Patch["start_sector"] * SECTOR_SIZE)
+                    )
+                    opfile.seek(int(Patch["start_sector"] * SECTOR_SIZE))
             except Exception as x:
-                PrintBigError("Could not move to sector %d in %s\nREASON: %s" % (Patch['start_sector'],FileWithPath,x))
+                PrintBigError(
+                    "Could not move to sector %d in %s\nREASON: %s"
+                    % (Patch["start_sector"], FileWithPath, x)
+                )
 
         try:
-            if Patch['start_sector']>64:
-                bytes_read = opfile.read(64*SECTOR_SIZE)
-                if len(bytes_read) != (64*SECTOR_SIZE):
-                    PrintBigError("Didn't get the read size 64*SECTOR_SIZE" % FileWithPath)
+            if Patch["start_sector"] > 64:
+                bytes_read = opfile.read(64 * SECTOR_SIZE)
+                if len(bytes_read) != (64 * SECTOR_SIZE):
+                    PrintBigError(
+                        "Didn't get the read size 64*SECTOR_SIZE" % FileWithPath
+                    )
             else:
                 bytes_read = opfile.read(SECTOR_SIZE)
                 if len(bytes_read) != (SECTOR_SIZE):
-                    PrintBigError("Didn't get the read size SECTOR_SIZE in '%s'" % FileWithPath)
+                    PrintBigError(
+                        "Didn't get the read size SECTOR_SIZE in '%s'" % FileWithPath
+                    )
         except Exception as x:
-            PrintBigError("Could not read sector %d in %s\nREASON: %s" % (Patch['start_sector'],FileWithPath,x))
+            PrintBigError(
+                "Could not read sector %d in %s\nREASON: %s"
+                % (Patch["start_sector"], FileWithPath, x)
+            )
 
         device_log("success was able to read len(bytes_read)=%d" % (len(bytes_read)))
 
         # Move back to do the write
         try:
-            if Patch['start_sector']>64:
-                #device_log("moving to %d-63=%d" % (Patch['start_sector'],Patch['start_sector']-63))
-                opfile.seek(int((Patch['start_sector']-63)*SECTOR_SIZE))
+            if Patch["start_sector"] > 64:
+                # device_log("moving to %d-63=%d" % (Patch['start_sector'],Patch['start_sector']-63))
+                opfile.seek(int((Patch["start_sector"] - 63) * SECTOR_SIZE))
             else:
-                #device_log("moving to sector %d (byte location %d)" % (Patch['start_sector'],Patch['start_sector']*SECTOR_SIZE))
-                opfile.seek(int(Patch['start_sector']*SECTOR_SIZE))
+                # device_log("moving to sector %d (byte location %d)" % (Patch['start_sector'],Patch['start_sector']*SECTOR_SIZE))
+                opfile.seek(int(Patch["start_sector"] * SECTOR_SIZE))
         except Exception as x:
-            PrintBigError("Could not move to sector %d in %s\nREASON: %s" % (Patch['start_sector'],FileWithPath,x))
+            PrintBigError(
+                "Could not move to sector %d in %s\nREASON: %s"
+                % (Patch["start_sector"], FileWithPath, x)
+            )
 
-        if Patch['value'] < 0:
-            PrintBigError("Patch value was negative. This means your DISK size is too small")
+        if Patch["value"] < 0:
+            PrintBigError(
+                "Patch value was negative. This means your DISK size is too small"
+            )
 
-        device_log("At sector %d (0x%X) file_sector_offset %d (0x%X) in %s with %d (0x%X)" % (Patch['start_sector'],Patch['start_sector']*SECTOR_SIZE,Patch['byte_offset'],Patch['byte_offset'],FileWithPath,Patch['value'],Patch['value']))
+        device_log(
+            "At sector %d (0x%X) file_sector_offset %d (0x%X) in %s with %d (0x%X)"
+            % (
+                Patch["start_sector"],
+                Patch["start_sector"] * SECTOR_SIZE,
+                Patch["byte_offset"],
+                Patch["byte_offset"],
+                FileWithPath,
+                Patch["value"],
+                Patch["value"],
+            )
+        )
 
-        #Patch['byte_offset']
-        if Patch['start_sector']>64:
-            ValueList = list(struct.unpack("%dB"%(64*SECTOR_SIZE),bytes_read))
+        # Patch['byte_offset']
+        if Patch["start_sector"] > 64:
+            ValueList = list(struct.unpack("%dB" % (64 * SECTOR_SIZE), bytes_read))
         else:
-            ValueList = list(struct.unpack("%dB"%SECTOR_SIZE,bytes_read))	# "512B"
+            ValueList = list(struct.unpack("%dB" % SECTOR_SIZE, bytes_read))  # "512B"
 
-        #device_log("\nBefore")
-        #j=0
-        #sys.stdout.write("%.4X\t "%j)
-        #for b in ValueList[-512:]:
+        # device_log("\nBefore")
+        # j=0
+        # sys.stdout.write("%.4X\t "%j)
+        # for b in ValueList[-512:]:
         #    sys.stdout.write("%.2X "%b)
         #    j+=1
         #    #if j>64:
@@ -1134,28 +1495,27 @@ def PerformPatching():
         #        device_log(" ")
         #        sys.stdout.write("%.4X\t "%j)
 
+        device_log("Patch value:%i" % Patch["value"])
 
-        device_log("Patch value:%i"%Patch['value'])
-
-        for j in range(Patch['size_in_bytes']):
-            if Patch['start_sector']>64:
-                #device_log("Applying patch at %d+%d=%d value=0x%.2X" % (63*SECTOR_SIZE,Patch['byte_offset']+j,63*SECTOR_SIZE+j+Patch['byte_offset'],(Patch['value']>>(j*8))&0xFF))
-                ValueList[63*SECTOR_SIZE+Patch['byte_offset']+j ] = (Patch['value']>>(j*8))&0xFF
-                sys.stdout.write("%.2X " % (int(Patch['value']>>(j*8)) & 0xFF))
+        for j in range(Patch["size_in_bytes"]):
+            if Patch["start_sector"] > 64:
+                # device_log("Applying patch at %d+%d=%d value=0x%.2X" % (63*SECTOR_SIZE,Patch['byte_offset']+j,63*SECTOR_SIZE+j+Patch['byte_offset'],(Patch['value']>>(j*8))&0xFF))
+                ValueList[63 * SECTOR_SIZE + Patch["byte_offset"] + j] = (
+                    Patch["value"] >> (j * 8)
+                ) & 0xFF
+                sys.stdout.write("%.2X " % (int(Patch["value"] >> (j * 8)) & 0xFF))
             else:
-                ValueList[Patch['byte_offset']+j ] = (Patch['value']>>(j*8))&0xFF
-                #import pdb; pdb.set_trace()
-                sys.stdout.write("%.2X " % (int(Patch['value']>>(j*8)) & 0xFF))
+                ValueList[Patch["byte_offset"] + j] = (Patch["value"] >> (j * 8)) & 0xFF
+                # import pdb; pdb.set_trace()
+                sys.stdout.write("%.2X " % (int(Patch["value"] >> (j * 8)) & 0xFF))
 
-
-        #for b in ValueList:
+        # for b in ValueList:
         #    sys.stdout.write("%.2X "%b)
 
-
-        #device_log("\nAfter")
-        #j=0
-        #sys.stdout.write("%.4X\t "%j)
-        #for b in ValueList[-512:]:
+        # device_log("\nAfter")
+        # j=0
+        # sys.stdout.write("%.4X\t "%j)
+        # for b in ValueList[-512:]:
         #    sys.stdout.write("%.2X "%b)
         #    j+=1
         #    #if j>64:
@@ -1164,21 +1524,24 @@ def PerformPatching():
         #        device_log(" ")
         #        sys.stdout.write("%.4X\t "%j)
 
-        #device_log(" ")
+        # device_log(" ")
 
-        if Patch['start_sector']>64:
-            bytes_read = struct.pack("%dB"%(64*SECTOR_SIZE),*ValueList)
+        if Patch["start_sector"] > 64:
+            bytes_read = struct.pack("%dB" % (64 * SECTOR_SIZE), *ValueList)
         else:
-            bytes_read = struct.pack("%dB"%SECTOR_SIZE,*ValueList)
+            bytes_read = struct.pack("%dB" % SECTOR_SIZE, *ValueList)
 
         device_log("(little endian)")
         device_log("committing patch of length %d bytes" % len(bytes_read))
         try:
             opfile.write(bytes_read)
         except Exception as x:
-            PrintBigError("Could not write %d bytes to %s\nREASON: %s" % (len(bytes_read),FileWithPath,x))
+            PrintBigError(
+                "Could not write %d bytes to %s\nREASON: %s"
+                % (len(bytes_read), FileWithPath, x)
+            )
 
-            #WriteValue(fd, RawProgramInfo.start_sector, RawProgramInfo.byte_offset, RawProgramInfo.value, RawProgramInfo.size_in_bytes);
+            # WriteValue(fd, RawProgramInfo.start_sector, RawProgramInfo.byte_offset, RawProgramInfo.value, RawProgramInfo.size_in_bytes);
 
         try:
             opfile.close()
@@ -1192,58 +1555,99 @@ def PerformPatching():
             device_log("You're on LINUX! I'm performing a SYNC for you")
             os.system("sync")
 
-        device_log("PATCH: %s" % Patch['what'])
+        device_log("PATCH: %s" % Patch["what"])
         device_log("DONE\n")
 
-        #if Patch['what']== "Update Backup Header with Write Array Location.":
+        # if Patch['what']== "Update Backup Header with Write Array Location.":
         #    sys.exit(0)
 
     device_log("Done patching")
+
 
 def Usage():
     print("Usage: Mass Storage Programmer - destructively writes data to disks!!\n")
 
     sudo = ""
-    drive= ""
+    drive = ""
     if sys.platform.startswith("linux"):
         sudo = "sudo"
-        drive= "/dev/sdb"
+        drive = "/dev/sdb"
     else:
         print("\tYou must run as Administrator under Win7\n")
-        drive="\\\\.\\PHYSICALDRIVE1"
+        drive = "\\\\.\\PHYSICALDRIVE1"
 
     print("%-40s\t python msp.py" % "Display this info")
-    print("%-40s\t%s python msp.py -r wipe_rawprogram_PHY0.xml -d %s" % ("Wipe partition info (-w)",sudo,drive))
-    print("\n%-40s\t%s python msp.py -r rawprogram0.xml -d %s" % ("Write a device (-r)",sudo,drive))
-    print("%-40s\t%s python msp.py -r rawprogram0.xml -d 0" % ("Create a singleimage.bin (-r)",sudo))
-    print("%-40s\t%s python msp.py -r rawprogram0.xml -d 0 -t c:\\temp" % ("singleimage.bin stored to c:\\temp (-r)",sudo))
-    print("%-40s\t%s python msp.py -r rawprogram0.xml -d 16777216" % ("Create an 8GB singleimage.bin (-r)",sudo))
-    print("\n%-40s\t%s python msp.py -n -r rawprogram.xml -d %s" % ("no prompts (-n) i.e. automation",sudo,drive))
-    print("%-40s\t%s python msp.py -i -r rawprogram.xml -d %s " % ("Interactively choose files (-i)",sudo,drive))
-    print("%-40s\t%s python msp.py -f sbl1.mbn,sbl2.mbn -r rawprogram.xml -d %s " % ("Specify files from rawprogram.xml (-f)",sudo,drive))
-    print("%-40s\t%s python msp.py -s c:\\windows,d:\\ -r rawprogram.xml -d %s " % ("Search this path for files (-s)",sudo,drive))
-    print("\n%-40s\t%s python msp.py -p patch0.xml -d %s" % ("Patch a device (-p)",sudo,drive))
-    print("%-40s\t%s python msp.py -p patch0.xml -d singleimage.bin" % ("Patch files to singleimage (-p)",sudo))
-    print("%-40s\t%s python msp.py -p patch0.xml -d 16777216" % ("PRE-PATCH images for an 8GB disk (-p)",sudo))
-    print("\n%-40s\t%s python msp.py -r rawprogram0.xml -p patch0.xml -d %s" % ("ALL IN ONE STEP",sudo,drive))
+    print(
+        "%-40s\t%s python msp.py -r wipe_rawprogram_PHY0.xml -d %s"
+        % ("Wipe partition info (-w)", sudo, drive)
+    )
+    print(
+        "\n%-40s\t%s python msp.py -r rawprogram0.xml -d %s"
+        % ("Write a device (-r)", sudo, drive)
+    )
+    print(
+        "%-40s\t%s python msp.py -r rawprogram0.xml -d 0"
+        % ("Create a singleimage.bin (-r)", sudo)
+    )
+    print(
+        "%-40s\t%s python msp.py -r rawprogram0.xml -d 0 -t c:\\temp"
+        % ("singleimage.bin stored to c:\\temp (-r)", sudo)
+    )
+    print(
+        "%-40s\t%s python msp.py -r rawprogram0.xml -d 16777216"
+        % ("Create an 8GB singleimage.bin (-r)", sudo)
+    )
+    print(
+        "\n%-40s\t%s python msp.py -n -r rawprogram.xml -d %s"
+        % ("no prompts (-n) i.e. automation", sudo, drive)
+    )
+    print(
+        "%-40s\t%s python msp.py -i -r rawprogram.xml -d %s "
+        % ("Interactively choose files (-i)", sudo, drive)
+    )
+    print(
+        "%-40s\t%s python msp.py -f sbl1.mbn,sbl2.mbn -r rawprogram.xml -d %s "
+        % ("Specify files from rawprogram.xml (-f)", sudo, drive)
+    )
+    print(
+        "%-40s\t%s python msp.py -s c:\\windows,d:\\ -r rawprogram.xml -d %s "
+        % ("Search this path for files (-s)", sudo, drive)
+    )
+    print(
+        "\n%-40s\t%s python msp.py -p patch0.xml -d %s"
+        % ("Patch a device (-p)", sudo, drive)
+    )
+    print(
+        "%-40s\t%s python msp.py -p patch0.xml -d singleimage.bin"
+        % ("Patch files to singleimage (-p)", sudo)
+    )
+    print(
+        "%-40s\t%s python msp.py -p patch0.xml -d 16777216"
+        % ("PRE-PATCH images for an 8GB disk (-p)", sudo)
+    )
+    print(
+        "\n%-40s\t%s python msp.py -r rawprogram0.xml -p patch0.xml -d %s"
+        % ("ALL IN ONE STEP", sudo, drive)
+    )
 
-    print("\n"+"*"*78)
+    print("\n" + "*" * 78)
     print("Usage: Mass Storage Programmer - destructively writes data to disks!!")
-    print("*"*78+"\n")
+    print("*" * 78 + "\n")
 
 
 def ReturnSizeString(size):
-    if size>(1024*1024*1024):
-        return "%.2f GB" % (size/(1024.0*1024.0*1024.0))
-    elif size>(1024*1024):
-        return "%.2f MB" % (size/(1024.0*1024.0))
-    elif size>(1024):
-        return "%.2f KB" % (size/(1024.0))
+    if size > (1024 * 1024 * 1024):
+        return "%.2f GB" % (size / (1024.0 * 1024.0 * 1024.0))
+    elif size > (1024 * 1024):
+        return "%.2f MB" % (size / (1024.0 * 1024.0))
+    elif size > (1024):
+        return "%.2f KB" % (size / (1024.0))
     else:
         return "%i B" % (size)
 
 
 # A8h reflected is 15h, i.e. 10101000 <--> 00010101
+
 
 def PrintResetDeviceNow():
     device_log("\t______              _                            ")
@@ -1263,69 +1667,122 @@ def PrintResetDeviceNow():
     device_log("\t \\__,_|\\___| \\_/ |_|\\___|\\___| |_| |_|\\___/ \\_/\\_/  \n")
 
 
-def TestIfSparse(test_sparse,filetotest):
+def TestIfSparse(test_sparse, filetotest):
     if test_sparse is None:
-        PrintBigWarning("WARNING: testsparse.py is not found - Can't test if this file is SPARSE\n")
+        PrintBigWarning(
+            "WARNING: testsparse.py is not found - Can't test if this file is SPARSE\n"
+        )
 
     else:
-        sz = "python %s -i %s " % (test_sparse,filetotest)
+        sz = "python %s -i %s " % (test_sparse, filetotest)
         for path in search_paths:
             sz += "-s %s " % path
 
-        device_log("\n"+"-"*78)
-        device_log("-"*78)
+        device_log("\n" + "-" * 78)
+        device_log("-" * 78)
 
-        device_log("Checking if file '%s' is sparse. This is to save you from accidently" % filetotest)
-        device_log("using a sparse file without *unsparsing* it first. That is, if you copy it over as is")
-        device_log("it won't work (similar to a ZIP file, you want what is *inside*, not the ZIP file)")
-        device_log("-"*78)
-        device_log("-"*78)
+        device_log(
+            "Checking if file '%s' is sparse. This is to save you from accidently"
+            % filetotest
+        )
+        device_log(
+            "using a sparse file without *unsparsing* it first. That is, if you copy it over as is"
+        )
+        device_log(
+            "it won't work (similar to a ZIP file, you want what is *inside*, not the ZIP file)"
+        )
+        device_log("-" * 78)
+        device_log("-" * 78)
 
-        #filetotest_temp = find_file(filetotest, search_paths)
-        #if filetotest_temp is None:
+        # filetotest_temp = find_file(filetotest, search_paths)
+        # if filetotest_temp is None:
         #    PrintBigError("Can't located '%s'" % filetotest)
 
         device_log(sz)
         response = external_call(sz)
         m = re.search("SPARSE FILE DETECTED", response)
         if m is not None:
-            PrintBigError("File is sparse, can't continue - you must run 'python checksparse.py -i rawprogram0.xml'")
+            PrintBigError(
+                "File is sparse, can't continue - you must run 'python checksparse.py -i rawprogram0.xml'"
+            )
+
 
 def ReplaceDiskSizeInSectorsWithRealValue(MyArray):
     ## At this point I have the real size of DiskSizeInBytes, so let's fill in the blanks if they still exist
     for MyDict in MyArray:
-        if int(MyDict['start_sector']) > 0 and int(MyDict['start_sector'])>(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE):
-            MyDict['start_sector'] = (DiskSizeInBytes/SECTOR_SIZE)-(int(MyDict['start_sector'])-(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE))
-        if int(MyDict['num_partition_sectors']) > 0 and int(MyDict['num_partition_sectors'])>(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE):
-            MyDict['num_partition_sectors'] = (DiskSizeInBytes/SECTOR_SIZE)-(int(MyDict['num_partition_sectors'])-(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE))
-        if int(MyDict['file_sector_offset']) > 0 and int(MyDict['file_sector_offset'])>(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE):
-            MyDict['file_sector_offset'] = (DiskSizeInBytes/SECTOR_SIZE)-(int(MyDict['file_sector_offset'])-(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE))
-        if int(MyDict['value']) > 0 and int(MyDict['value'])>(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE):
-            MyDict['value'] = (DiskSizeInBytes/SECTOR_SIZE)-(int(MyDict['value'])-(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE))
+        if int(MyDict["start_sector"]) > 0 and int(MyDict["start_sector"]) > (
+            EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE
+        ):
+            MyDict["start_sector"] = (DiskSizeInBytes / SECTOR_SIZE) - (
+                int(MyDict["start_sector"])
+                - (EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE)
+            )
+        if int(MyDict["num_partition_sectors"]) > 0 and int(
+            MyDict["num_partition_sectors"]
+        ) > (EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE):
+            MyDict["num_partition_sectors"] = (DiskSizeInBytes / SECTOR_SIZE) - (
+                int(MyDict["num_partition_sectors"])
+                - (EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE)
+            )
+        if int(MyDict["file_sector_offset"]) > 0 and int(
+            MyDict["file_sector_offset"]
+        ) > (EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE):
+            MyDict["file_sector_offset"] = (DiskSizeInBytes / SECTOR_SIZE) - (
+                int(MyDict["file_sector_offset"])
+                - (EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE)
+            )
+        if int(MyDict["value"]) > 0 and int(MyDict["value"]) > (
+            EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE
+        ):
+            MyDict["value"] = (DiskSizeInBytes / SECTOR_SIZE) - (
+                int(MyDict["value"]) - (EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE)
+            )
+
 
 def CalculateMinDiskSize():
     OldMinDiskSizeInSectors = 0
     MinDiskSizeInSectors = 0
-    #Calculate the MinDiskSizeInSectors. This is a 2 step process
+    # Calculate the MinDiskSizeInSectors. This is a 2 step process
     # Once for normal partitions
     for Write in WriteSorted:
-        if int(Write['start_sector']) > 0 and int(Write['start_sector'])<(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE):
-            MinDiskSizeInSectors = (int(Write['start_sector']) + int(Write['num_partition_sectors']))
+        if int(Write["start_sector"]) > 0 and int(Write["start_sector"]) < (
+            EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE
+        ):
+            MinDiskSizeInSectors = int(Write["start_sector"]) + int(
+                Write["num_partition_sectors"]
+            )
         if OldMinDiskSizeInSectors != MinDiskSizeInSectors:
-            device_log("MinDiskSizeInSectors=%i sectors (%.2fMB)" % (MinDiskSizeInSectors,MinDiskSizeInSectors*SECTOR_SIZE/(1024.0*1024.0)))
+            device_log(
+                "MinDiskSizeInSectors=%i sectors (%.2fMB)"
+                % (
+                    MinDiskSizeInSectors,
+                    MinDiskSizeInSectors * SECTOR_SIZE / (1024.0 * 1024.0),
+                )
+            )
             OldMinDiskSizeInSectors = MinDiskSizeInSectors
 
     print("----------------------")
     # second time is for NUM_DISK_SECTORS-33 type of scenarios, since they will currently have
     # my made up value of EMMCBLD_MAX_DISK_SIZE_IN_BYTES+start_sector
     for Write in WriteSorted:
-        if int(Write['start_sector']) > 0 and int(Write['start_sector'])>(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE):
-            MinDiskSizeInSectors += int(Write['start_sector'])-(EMMCBLD_MAX_DISK_SIZE_IN_BYTES/SECTOR_SIZE)
+        if int(Write["start_sector"]) > 0 and int(Write["start_sector"]) > (
+            EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE
+        ):
+            MinDiskSizeInSectors += int(Write["start_sector"]) - (
+                EMMCBLD_MAX_DISK_SIZE_IN_BYTES / SECTOR_SIZE
+            )
         if OldMinDiskSizeInSectors != MinDiskSizeInSectors:
-            device_log("MinDiskSizeInSectors=%i sectors (%.2fMB)" % (MinDiskSizeInSectors,MinDiskSizeInSectors*SECTOR_SIZE/(1024*1024.0)))
+            device_log(
+                "MinDiskSizeInSectors=%i sectors (%.2fMB)"
+                % (
+                    MinDiskSizeInSectors,
+                    MinDiskSizeInSectors * SECTOR_SIZE / (1024 * 1024.0),
+                )
+            )
             OldMinDiskSizeInSectors = MinDiskSizeInSectors
 
     return MinDiskSizeInSectors
+
 
 ## ==============================================================================================
 ## ==============================================================================================
@@ -1338,61 +1795,80 @@ def CalculateMinDiskSize():
 AvailablePartitions = {}
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "r:p:d:ins:f:t:vb:", ["rawprogram=", "patch=", "dest=","noprompt=", "interactive=", "search_path=","file=","location=","verbose","sectorsize"])
+    opts, args = getopt.getopt(
+        sys.argv[1:],
+        "r:p:d:ins:f:t:vb:",
+        [
+            "rawprogram=",
+            "patch=",
+            "dest=",
+            "noprompt=",
+            "interactive=",
+            "search_path=",
+            "file=",
+            "location=",
+            "verbose",
+            "sectorsize",
+        ],
+    )
 except getopt.GetoptError as err:
     # print help information and exit:
     Usage()
     PrintBigError(str(err))
 
-test_sparse             = None
-dd                      = None
-xml_filename            = None
-rawprogram_filename     = None
-patch_filename          = None
-disk_name               = None
-search_paths            = []
-file_list               = []
-LoadSubsetOfFiles       = False
-interactive             = False
+test_sparse = None
+dd = None
+xml_filename = None
+rawprogram_filename = None
+patch_filename = None
+disk_name = None
+search_paths = []
+file_list = []
+LoadSubsetOfFiles = False
+interactive = False
 
-noprompt                = False
-verbose                 = False
+noprompt = False
+verbose = False
 
-Operation               = 0
-OPERATION_PROGRAM       = 2
-OPERATION_PATCH         = 4
-OPERATION_READ          = 8
+Operation = 0
+OPERATION_PROGRAM = 2
+OPERATION_PATCH = 4
+OPERATION_READ = 8
 
-Patching                = "FILES"
-OutputFolder            = ""
+Patching = "FILES"
+OutputFolder = ""
 
-Filename                = "singleimage.bin"
-DiskSizeInBytes                = 0
-MinDiskSizeInSectors             = 0
+Filename = "singleimage.bin"
+DiskSizeInBytes = 0
+MinDiskSizeInSectors = 0
 
 Usage()
-#GetPartitions()
+# GetPartitions()
 
 for o, a in opts:
     if o in ("-r", "--rawprogram"):
         rawprogram_filename = a
         Operation |= OPERATION_PROGRAM  ## assumed here. It will be corrected later
-    elif o in ("-b","--sectorsize"):
+    elif o in ("-b", "--sectorsize"):
         SECTOR_SIZE = int(a)
     elif o in ("-t", "--location"):
         OutputFolder = a
-        OutputFolder = re.sub(r"\\$","",OutputFolder)    # remove final slash if it exists
-        OutputFolder = re.sub(r"/$","",OutputFolder)     # remove final slash if it exists
+        OutputFolder = re.sub(
+            r"\\$", "", OutputFolder
+        )  # remove final slash if it exists
+        OutputFolder = re.sub(
+            r"/$", "", OutputFolder
+        )  # remove final slash if it exists
 
-        OutputFolder += "/"     # slashes will all be corrected below
+        OutputFolder += "/"  # slashes will all be corrected below
 
         if sys.platform.startswith("linux"):
-            OutputFolder = re.sub(r"\\","/",OutputFolder)   # correct slashes
+            OutputFolder = re.sub(r"\\", "/", OutputFolder)  # correct slashes
         else:
-            OutputFolder = re.sub(r"/","\\\\",OutputFolder) # correct slashes
+            OutputFolder = re.sub(r"/", "\\\\", OutputFolder)  # correct slashes
 
-        device_log("OutputFolder='%s'"%OutputFolder)
-        EnsureDirectoryExists(OutputFolder) # only need to call once
+        device_log("OutputFolder='%s'" % OutputFolder)
+        EnsureDirectoryExists(OutputFolder)  # only need to call once
 
         Filename = OutputFolder + Filename
 
@@ -1411,13 +1887,15 @@ for o, a in opts:
             ## to be here means they specified a number must be making a single image or patching files
             Patching = "FILES"
             Filename = OutputFolder + "singleimage.bin"
-            DiskSizeInBytes = int(int(m.group(1))*SECTOR_SIZE) # comes in as sectors, we now know the size of DiskSizeInBytes, could also be size 0!!
+            DiskSizeInBytes = int(
+                int(m.group(1)) * SECTOR_SIZE
+            )  # comes in as sectors, we now know the size of DiskSizeInBytes, could also be size 0!!
 
         else:
             ## to be here means they didn't specify a number, thus a device
-            Filename        = disk_name
-            Patching        = "DISK"
-            ValidDiskName   = False
+            Filename = disk_name
+            Patching = "DISK"
+            ValidDiskName = False
 
             # User can also specify the singleimage.bin name, and I can treat that like it's the disk
             GetPartitions()
@@ -1425,12 +1903,12 @@ for o, a in opts:
             if sys.platform.startswith("linux"):
                 m = re.search("/dev/sd[a-z]", disk_name)
                 if m is not None:
-                    ValidDiskName   = True
+                    ValidDiskName = True
             else:
                 m = re.search(r"(PHYSICALDRIVE\d+)", disk_name)
                 if m is not None:
-                    ValidDiskName   = True
-                    Filename = "\\\\.\\"+m.group(1)
+                    ValidDiskName = True
+                    Filename = "\\\\.\\" + m.group(1)
 
             if ValidDiskName:
                 if Filename not in Devices:
@@ -1439,7 +1917,9 @@ for o, a in opts:
             else:
                 # To be here means user did this possibly "-d singleimage.bin", i.e. to patch the singleimage.bin
                 try:
-                    DiskSizeInBytes = os.path.getsize(disk_name) # and thus singleimage.bin must already exist
+                    DiskSizeInBytes = os.path.getsize(
+                        disk_name
+                    )  # and thus singleimage.bin must already exist
                 except Exception as x:
 
                     PrintBigError("")
@@ -1468,10 +1948,11 @@ for o, a in opts:
         assert False, "unhandled option"
 
 
-
-if Operation==0:    ## Means nothing was specified above
+if Operation == 0:  ## Means nothing was specified above
     GetPartitions()
-    device_log("\nmsp.py exiting - Only showed options and drives detected - Log is log_msp.txt\n\n")
+    device_log(
+        "\nmsp.py exiting - Only showed options and drives detected - Log is log_msp.txt\n\n"
+    )
     if verbose is True:
         device_log("\nMass Storage Programmer (msp.py) VERSION 1.0\n")
     sys.exit(1)
@@ -1484,49 +1965,57 @@ device_log(file_list)
 
 if disk_name is None:
     if sys.platform.startswith("linux"):
-        device_log(r"Don't forget to specify your drive, EX '-d /dev/sdb' OR '-d 0' to create a singleimage")
+        device_log(
+            r"Don't forget to specify your drive, EX '-d /dev/sdb' OR '-d 0' to create a singleimage"
+        )
     else:
-        device_log(r"Don't foreget to specify your drive, EX '-d \\.\PHYSICALDRIVE1' OR '-d 0' to create a singleimage")
+        device_log(
+            r"Don't foreget to specify your drive, EX '-d \\.\PHYSICALDRIVE1' OR '-d 0' to create a singleimage"
+        )
 
     PrintBigError("You must specify a DISK, option -d")
 
 if (Operation & OPERATION_PROGRAM) > 0:
     if rawprogram_filename is None:
-        PrintBigError("You must specify an \"rawprogram\" XML file for option -r")
+        PrintBigError('You must specify an "rawprogram" XML file for option -r')
     else:
         rawprogram_filename = find_file(rawprogram_filename, search_paths)
         if rawprogram_filename is None:
-            PrintBigError("You must specify an \"rawprogram\" XML file for option -r")
+            PrintBigError('You must specify an "rawprogram" XML file for option -r')
 
 if (Operation & OPERATION_PATCH) > 0:
     if patch_filename is None:
-        PrintBigError("You must specify an \"patch\" XML file for option -p")
+        PrintBigError('You must specify an "patch" XML file for option -p')
     else:
         patch_filename = find_file(patch_filename, search_paths)
         if patch_filename is None:
-            PrintBigError("You must specify an \"patch\" XML file for option -p")
+            PrintBigError('You must specify an "patch" XML file for option -p')
 
-NumPhyPartitions        = 0
-WriteArray              = []
-ReadArray               = []
-PatchArray              = []
-PhyPartition            = {}       # Main HASH that holds all the partition info
+NumPhyPartitions = 0
+WriteArray = []
+ReadArray = []
+PatchArray = []
+PhyPartition = {}  # Main HASH that holds all the partition info
 
 ## At this point DiskSizeInBytes is either known or equal to 0
 if rawprogram_filename is not None:
     ParseXML(rawprogram_filename)
 
 Operation = 0
-if len(WriteArray)>0:
+if len(WriteArray) > 0:
     Operation |= OPERATION_PROGRAM
-if len(ReadArray)>0:
+if len(ReadArray) > 0:
     Operation |= OPERATION_READ
 
-if DiskSizeInBytes>0:
-    if DiskSizeInBytes<int(MinDiskSizeInSectors)*SECTOR_SIZE:
+if DiskSizeInBytes > 0:
+    if DiskSizeInBytes < int(MinDiskSizeInSectors) * SECTOR_SIZE:
         PrintBigError("")
-        device_log("\nERROR: Current eMMC/SD card is too small to program these partitions")
-        device_log("       Need at least %s" % ReturnSizeString(int(MinDiskSizeInSectors)))
+        device_log(
+            "\nERROR: Current eMMC/SD card is too small to program these partitions"
+        )
+        device_log(
+            "       Need at least %s" % ReturnSizeString(int(MinDiskSizeInSectors))
+        )
         device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
         sys.exit(1)
 
@@ -1539,68 +2028,81 @@ if DiskSizeInBytes>0:
 PartitionStartSector = []
 
 for Write in WriteArray:
-    if Write['filename']=="":
-        #device_log("no filename for label '%s'"%Write['label'])
+    if Write["filename"] == "":
+        # device_log("no filename for label '%s'"%Write['label'])
         continue
 
-    m = re.search(r"\.ext4$", Write['filename'])
+    m = re.search(r"\.ext4$", Write["filename"])
     if m is not None:
-        TestIfSparse(test_sparse,Write['filename'])
+        TestIfSparse(test_sparse, Write["filename"])
 
-    if 'sparse' in Write:
-        m = re.search("true", Write['sparse'],re.IGNORECASE)
+    if "sparse" in Write:
+        m = re.search("true", Write["sparse"], re.IGNORECASE)
         if m is not None:
             PrintBigError("")
-            device_log("Your rawprogram.xml file indicates that this is a sparse image, can't continue")
-            device_log("You must first run \"python checksparse.py -i rawprogram0.xml -s C:\\path1 -s C:\\path2\"")
-            device_log("This will modify rawprogram0.xml to be able to handle the sparse image(s)")
-            device_log("Also, you *must* specify the various paths to the sparse images and they need to be")
+            device_log(
+                "Your rawprogram.xml file indicates that this is a sparse image, can't continue"
+            )
+            device_log(
+                'You must first run "python checksparse.py -i rawprogram0.xml -s C:\\path1 -s C:\\path2"'
+            )
+            device_log(
+                "This will modify rawprogram0.xml to be able to handle the sparse image(s)"
+            )
+            device_log(
+                "Also, you *must* specify the various paths to the sparse images and they need to be"
+            )
             device_log("opened and parsed. Then you can run msp.py again to program.")
 
             device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
             sys.exit(1)
 
-    PartitionStartSector.append( Write["start_sector"] )
+    PartitionStartSector.append(Write["start_sector"])
 
-PartitionStartSector.sort() # This will make the negative values first
+PartitionStartSector.sort()  # This will make the negative values first
 
 ## Step 2. Create a "WriteSorted" based on PartitionStartSector
 WriteSorted = []
 Count = 0
 while 1 and (Operation & OPERATION_PROGRAM) > 0:
     for Write in WriteArray:
-        #device_log("---------------- with start_sector = %i and PartitionStartSector[%i]=%i" % (Write["start_sector"],Count,PartitionStartSector[Count]))
-        if Write['filename']=="":
+        # device_log("---------------- with start_sector = %i and PartitionStartSector[%i]=%i" % (Write["start_sector"],Count,PartitionStartSector[Count]))
+        if Write["filename"] == "":
             continue
 
         if Write["start_sector"] == PartitionStartSector[Count]:
             ##device_log("FOUND, len(PartitionStartSector)=%d and len(WriteSorted)=%d" % (len(PartitionStartSector),len(WriteSorted)))
             # To be here means I found the *next* start_sector in order, i.e. 0,100,200 etc
-            WriteSorted.append( Write )
+            WriteSorted.append(Write)
             Count += 1  # now go to next sorted entry
             if len(WriteSorted) == len(PartitionStartSector):
-                break   # we're done, both arrays are the same size
+                break  # we're done, both arrays are the same size
     if len(WriteSorted) == len(PartitionStartSector):
-        break   # we're done, both arrays are the same size
+        break  # we're done, both arrays are the same size
 
 MinDiskSizeInSectors = CalculateMinDiskSize()
 
-print("MinDiskSizeInSectors=",MinDiskSizeInSectors)
-print("DiskSizeInSectors   =",DiskSizeInBytes/SECTOR_SIZE)
+print("MinDiskSizeInSectors=", MinDiskSizeInSectors)
+print("DiskSizeInSectors   =", DiskSizeInBytes / SECTOR_SIZE)
 
-if DiskSizeInBytes==0:
-    DiskSizeInBytes = int(MinDiskSizeInSectors)*SECTOR_SIZE
+if DiskSizeInBytes == 0:
+    DiskSizeInBytes = int(MinDiskSizeInSectors) * SECTOR_SIZE
     if DiskSizeInBytes == 0:
         PrintBigError("")
         device_log("Something went wrong, couldn't determine size of disk?")
         if sys.platform.startswith("linux"):
             device_log(r"Did you remember to specify your drive, EX '-d /dev/sdb'")
         else:
-            device_log(r"Did you remember to specify your drive, EX '-d \\.\PHYSICALDRIVE1'")
+            device_log(
+                r"Did you remember to specify your drive, EX '-d \\.\PHYSICALDRIVE1'"
+            )
 
         device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
         sys.exit()
-    device_log("\nDiskSizeInBytes was set to 0, DiskSizeInBytes will be %s (%d sectors)" % (ReturnSizeString(DiskSizeInBytes),int(DiskSizeInBytes/SECTOR_SIZE)))
+    device_log(
+        "\nDiskSizeInBytes was set to 0, DiskSizeInBytes will be %s (%d sectors)"
+        % (ReturnSizeString(DiskSizeInBytes), int(DiskSizeInBytes / SECTOR_SIZE))
+    )
 
 
 if patch_filename is not None:
@@ -1616,7 +2118,7 @@ if (Operation & OPERATION_PROGRAM) > 0:
     # Can we test for sparse images?
     test_sparse = find_file("testsparse.py", search_paths)
 
-    if os.path.basename(Filename)=="singleimage.bin":
+    if os.path.basename(Filename) == "singleimage.bin":
         ## Wipe out any old singleimage
         try:
             open(Filename, "wb").close()
@@ -1625,28 +2127,47 @@ if (Operation & OPERATION_PROGRAM) > 0:
             print("\nERROR: Can't delete old singleimage.bin. Is it open??")
             sys.exit()
 
-        device_log("\nProgramming %s of size %s" % (Filename,ReturnSizeString(DiskSizeInBytes)))
+        device_log(
+            "\nProgramming %s of size %s"
+            % (Filename, ReturnSizeString(DiskSizeInBytes))
+        )
 
         if noprompt is False:
-            if (DiskSizeInBytes/(1024.0*1024.0))>100:
-                device_log("\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)",0)
-                var = input("\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)")
-                if var=='Y' or var=='y' or var=='':
+            if (DiskSizeInBytes / (1024.0 * 1024.0)) > 100:
+                device_log(
+                    "\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)",
+                    0,
+                )
+                var = input(
+                    "\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)"
+                )
+                if var == "Y" or var == "y" or var == "":
                     pass
                 else:
-                    device_log("\nmsp.py exiting - User didn't want to continue - Log is log_msp.txt\n\n")
+                    device_log(
+                        "\nmsp.py exiting - User didn't want to continue - Log is log_msp.txt\n\n"
+                    )
                     sys.exit()
     else:
         if noprompt is True:
             # means don't bug them, i.e. automation
             pass
         else:
-            device_log("\nWARNING: Are you sure you want to write to '%s' of size %s (y|N) " % (Filename,ReturnSizeString(DiskSizeInBytes)),0)
-            var = input("\nWARNING: Are you sure you want to write to '%s' of size %s (y|N) " % (Filename,ReturnSizeString(DiskSizeInBytes)))
-            if var=='Y' or var=='y':
+            device_log(
+                "\nWARNING: Are you sure you want to write to '%s' of size %s (y|N) "
+                % (Filename, ReturnSizeString(DiskSizeInBytes)),
+                0,
+            )
+            var = input(
+                "\nWARNING: Are you sure you want to write to '%s' of size %s (y|N) "
+                % (Filename, ReturnSizeString(DiskSizeInBytes))
+            )
+            if var == "Y" or var == "y":
                 pass
             else:
-                device_log("\nmsp.py exiting - User didn't want to continue - Log is log_msp.txt\n\n")
+                device_log(
+                    "\nmsp.py exiting - User didn't want to continue - Log is log_msp.txt\n\n"
+                )
                 sys.exit()
 
 if (Operation & OPERATION_READ) > 0:
@@ -1658,8 +2179,7 @@ ThereWereWarnings = 0
 if (Operation & OPERATION_PROGRAM) > 0 and (Operation & OPERATION_PATCH) > 0:
     ## Have info to do both write and patch
 
-
-    if Filename=="singleimage.bin":
+    if Filename == "singleimage.bin":
         # it's a singleimage, so do patching first
         PerformPatching()
 
@@ -1682,8 +2202,10 @@ elif (Operation & OPERATION_PROGRAM) > 0:
     ThereWereWarnings = PerformWrite()
     if (Operation & OPERATION_READ) > 0:
         PerformRead()
-    device_log("\n"+"-"*78)
-    device_log("If you wrote any partition table information (MBR0.bin, gpt_main0.bin, etc)")
+    device_log("\n" + "-" * 78)
+    device_log(
+        "If you wrote any partition table information (MBR0.bin, gpt_main0.bin, etc)"
+    )
     device_log(" ")
     device_log("         _             _ _      __                     _   ")
     device_log("        | |           ( ) |    / _|                   | |  ")
@@ -1703,14 +2225,17 @@ elif (Operation & OPERATION_PROGRAM) > 0:
     device_log("                        |_|                         ")
     device_log("\n")
 
-    sudo=""
+    sudo = ""
     if sys.platform.startswith("linux"):
-        sudo="sudo "
+        sudo = "sudo "
 
-    device_log("\tEx: %spython msp.py -p patch0.xml -d %s " % (sudo,Filename))
+    device_log("\tEx: %spython msp.py -p patch0.xml -d %s " % (sudo, Filename))
     device_log("\t\tOr, do it all in one step")
-    device_log("\tEx: %spython msp.py -r rawprogram0.xml -d %s -p patch0.xml" % (sudo,Filename))
-    device_log("-"*78)
+    device_log(
+        "\tEx: %spython msp.py -r rawprogram0.xml -d %s -p patch0.xml"
+        % (sudo, Filename)
+    )
+    device_log("-" * 78)
 
     if verbose is True:
         DoubleCheckDiskSize()
@@ -1722,21 +2247,32 @@ elif (Operation & OPERATION_PATCH) > 0:
 
 if (Operation & OPERATION_PROGRAM) > 0:
 
-    if os.path.basename(Filename)=="singleimage.bin":
+    if os.path.basename(Filename) == "singleimage.bin":
         device_log("\nNOTE: This program does *not* pad the last partition, therefore")
-        device_log("      singleimage.bin might be smaller than %d sectors (%.2f MB)" % (int(DiskSizeInBytes/SECTOR_SIZE),DiskSizeInBytes/(1048576.0)))
+        device_log(
+            "      singleimage.bin might be smaller than %d sectors (%.2f MB)"
+            % (int(DiskSizeInBytes / SECTOR_SIZE), DiskSizeInBytes / (1048576.0))
+        )
 
         device_log("\n\nSUCCESS - %s created" % Filename)
         device_log("SUCCESS - %s created" % Filename)
         device_log("SUCCESS - %s created\n" % Filename)
 
-        if FileNotFoundShowWarning==1:
-            device_log("\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete")
-            device_log("\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete")
-            device_log("\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete\n\n")
+        if FileNotFoundShowWarning == 1:
+            device_log(
+                "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete"
+            )
+            device_log(
+                "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete"
+            )
+            device_log(
+                "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete\n\n"
+            )
 
 device_log("\nmsp.py exiting SUCCESSFULLY- Log is log_msp.txt\n\n")
 
 if ThereWereWarnings == 1:
-    PrintBigWarning("There were warnings, please see log. \n\n--------> Your image *might* not work <----------\n")
+    PrintBigWarning(
+        "There were warnings, please see log. \n\n--------> Your image *might* not work <----------\n"
+    )
     sleep(2)

--- a/ptool.py
+++ b/ptool.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-#===========================================================================
-#Copyright (c) 2019, The Linux Foundation. All rights reserved.
+# ===========================================================================
+# Copyright (c) 2019, The Linux Foundation. All rights reserved.
 
-#Redistribution and use in source and binary forms, with or without
-#modification, are permitted provided that the following conditions are
-#met:
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
 #    * Redistributions of source code must retain the above copyright
 #      notice, this list of conditions and the following disclaimer.
 #    * Redistributions in binary form must reproduce the above
@@ -15,17 +15,17 @@
 #      contributors may be used to endorse or promote products derived
 #      from this software without specific prior written permission.
 #
-#THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
-#WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
-#ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
-#BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-#CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-#SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-#BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-#WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-#OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-#IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ===========================================================================*/
 
 import getopt
@@ -38,125 +38,208 @@ import sys
 from time import sleep
 from xml.dom import minidom
 from xml.etree import ElementTree as ET
-#from elementtree.ElementTree import ElementTree
+
+# from elementtree.ElementTree import ElementTree
 from xml.etree.ElementTree import Comment, Element, SubElement
 
-from utils import (CalcCRC32, EnsureDirectoryExists, PrintBigError,
-                   PrintBigWarning)
+from utils import CalcCRC32, EnsureDirectoryExists, PrintBigError, PrintBigWarning
 
-OutputFolder            = ""
+OutputFolder = ""
 
 LastPartitionBeginsAt = 0
-HashInstructions       = {}
+HashInstructions = {}
 tempVar = 5
 
-NumPhyPartitions        = 0
-PartitionCollection     = []        # An array of Partition objects. Partition is a hash of information about partition
-PhyPartition            = {}        # An array of PartitionCollection objects
+NumPhyPartitions = 0
+PartitionCollection = (
+    []
+)  # An array of Partition objects. Partition is a hash of information about partition
+PhyPartition = {}  # An array of PartitionCollection objects
 
-MinSectorsNeeded        = 0
+MinSectorsNeeded = 0
 # Ex. PhyPartition[0] holds the PartitionCollection that holds all the info for partitions in PHY partition 0
 
 AvailablePartitions = {}
 XMLFile = "module_common.py"
 
-ExtendedPartitionBegins= 0
-instructions           = []
-HashStruct             = {}
+ExtendedPartitionBegins = 0
+instructions = []
+HashStruct = {}
 
-StructPartitions       = []
+StructPartitions = []
 StructAdditionalFields = []
-AllPartitions          = {}
+AllPartitions = {}
 
-PARTITION_SYSTEM_GUID       =  0x3BC93EC9A0004BBA11D2F81FC12A7328
-PARTITION_MSFT_RESERVED_GUID=  0xAE1502F02DF97D814DB80B5CE3C9E316
-PARTITION_BASIC_DATA_GUID   =  0xC79926B7B668C0874433B9E5EBD0A0A2
+PARTITION_SYSTEM_GUID = 0x3BC93EC9A0004BBA11D2F81FC12A7328
+PARTITION_MSFT_RESERVED_GUID = 0xAE1502F02DF97D814DB80B5CE3C9E316
+PARTITION_BASIC_DATA_GUID = 0xC79926B7B668C0874433B9E5EBD0A0A2
 
-SECTOR_SIZE_IN_BYTES = 512   # This can be over ridden in the partition.xml file
+SECTOR_SIZE_IN_BYTES = 512  # This can be over ridden in the partition.xml file
 
-PrimaryGPT  = [0]*17408  # This gets redefined later based on SECTOR_SIZE_IN_BYTES This is LBA 0 to 33 (34 sectors total)    (start of disk)
-BackupGPT   = [0]*16896  # This gets redefined later based on SECTOR_SIZE_IN_BYTES This is LBA-33 to -1 (33 sectors total)   (end of disk)
+PrimaryGPT = [
+    0
+] * 17408  # This gets redefined later based on SECTOR_SIZE_IN_BYTES This is LBA 0 to 33 (34 sectors total)    (start of disk)
+BackupGPT = [
+    0
+] * 16896  # This gets redefined later based on SECTOR_SIZE_IN_BYTES This is LBA-33 to -1 (33 sectors total)   (end of disk)
 
-EmptyGPT  = [0]*17408  # This gets redefined later based on SECTOR_SIZE_IN_BYTES This is LBA 0 to 33 (34 sectors total)    (start of disk)
+EmptyGPT = [
+    0
+] * 17408  # This gets redefined later based on SECTOR_SIZE_IN_BYTES This is LBA 0 to 33 (34 sectors total)    (start of disk)
 
-PrimaryGPTNumLBAs=len(PrimaryGPT)//SECTOR_SIZE_IN_BYTES
-BackupGPTNumLBAs =len(BackupGPT)//SECTOR_SIZE_IN_BYTES
+PrimaryGPTNumLBAs = len(PrimaryGPT) // SECTOR_SIZE_IN_BYTES
+BackupGPTNumLBAs = len(BackupGPT) // SECTOR_SIZE_IN_BYTES
 
 ## Note that these HashInstructions are updated by the XML file
 
-HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']        = 64*1024
-HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']    = True
-HashInstructions['DISK_SIGNATURE']                      = 0x0
+HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] = 64 * 1024
+HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"] = True
+HashInstructions["DISK_SIGNATURE"] = 0x0
 
-MBR         = [0]*SECTOR_SIZE_IN_BYTES
-EBR         = [0]*SECTOR_SIZE_IN_BYTES
+MBR = [0] * SECTOR_SIZE_IN_BYTES
+EBR = [0] * SECTOR_SIZE_IN_BYTES
 
-hash_w       = [{'start_sector':0,'num_sectors':(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024//SECTOR_SIZE_IN_BYTES),
-                 'end_sector':(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024//SECTOR_SIZE_IN_BYTES)-1,'physical_partition_number':0,'boundary_num':0,'num_boundaries_covered':1}]
+hash_w = [
+    {
+        "start_sector": 0,
+        "num_sectors": (
+            HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            * 1024
+            // SECTOR_SIZE_IN_BYTES
+        ),
+        "end_sector": (
+            HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            * 1024
+            // SECTOR_SIZE_IN_BYTES
+        )
+        - 1,
+        "physical_partition_number": 0,
+        "boundary_num": 0,
+        "num_boundaries_covered": 1,
+    }
+]
 gen_patch = True
 NumWPregions = 0
 
+
 def ShowPartitionExample():
-    print("Your \"partition.xml\" file needs to look like something like this below")
+    print('Your "partition.xml" file needs to look like something like this below')
     print("\t(i.e. notice the *multiple* physical_partition tags)\n")
     print("<!-- This is physical partition 0 -->")
     print("<physical_partition>")
-    print("  <partition label=\"SBL1\" size_in_kb=\"100\" type=\"DEA0BA2C-CBDD-4805-B4F9-F428251C3E98\" filename=\"sbl1.mbn\"/>")
+    print(
+        '  <partition label="SBL1" size_in_kb="100" type="DEA0BA2C-CBDD-4805-B4F9-F428251C3E98" filename="sbl1.mbn"/>'
+    )
     print("</physical_partition>")
     print(" ")
     print("<!-- This is physical partition 1 -->")
     print("<physical_partition>")
-    print("  <partition label=\"SBL2\" size_in_kb=\"200\" type=\"8C6B52AD-8A9E-4398-AD09-AE916E53AE2D\" filename=\"sbl2.mbn\"/>")
+    print(
+        '  <partition label="SBL2" size_in_kb="200" type="8C6B52AD-8A9E-4398-AD09-AE916E53AE2D" filename="sbl2.mbn"/>'
+    )
     print("</physical_partition>")
+
 
 def ConvertKBtoSectors(x):
     ## 1KB / SECTOR_SIZE_IN_BYTES normally means return 2 (i.e. with SECTOR_SIZE_IN_BYTES=512)
     ## 2KB / SECTOR_SIZE_IN_BYTES normally means return 4 (i.e. with SECTOR_SIZE_IN_BYTES=512)
-    return int((x*1024)//SECTOR_SIZE_IN_BYTES)
+    return int((x * 1024) // SECTOR_SIZE_IN_BYTES)
 
-def UpdatePatch(StartSector,ByteOffset,PHYPartition,size_in_bytes,szvalue,szfilename,szwhat):
+
+def UpdatePatch(
+    StartSector, ByteOffset, PHYPartition, size_in_bytes, szvalue, szfilename, szwhat
+):
     global PatchesXML
-    SubElement(PatchesXML, 'patch', {'start_sector':StartSector, 'byte_offset':ByteOffset,
-                                     'physical_partition_number':str(PHYPartition), 'size_in_bytes':str(size_in_bytes),
-                                     'value':szvalue, 'filename':szfilename, 'SECTOR_SIZE_IN_BYTES':str(SECTOR_SIZE_IN_BYTES), 'what':szwhat   })
+    SubElement(
+        PatchesXML,
+        "patch",
+        {
+            "start_sector": StartSector,
+            "byte_offset": ByteOffset,
+            "physical_partition_number": str(PHYPartition),
+            "size_in_bytes": str(size_in_bytes),
+            "value": szvalue,
+            "filename": szfilename,
+            "SECTOR_SIZE_IN_BYTES": str(SECTOR_SIZE_IN_BYTES),
+            "what": szwhat,
+        },
+    )
 
 
-def UpdateRawProgram(RawProgramXML, StartSector, size_in_KB, PHYPartition, file_sector_offset, num_partition_sectors, filename, sparse, label,readbackverify='false', partofsingleimage='false'):
-    if StartSector<0:
-        szStartSector = "NUM_DISK_SECTORS%d." % StartSector      ## as in NUM_DISK_SECTORS-33 since %d=-33
-        szStartByte   = "(%d*NUM_DISK_SECTORS)%d." % (SECTOR_SIZE_IN_BYTES,StartSector*SECTOR_SIZE_IN_BYTES)
+def UpdateRawProgram(
+    RawProgramXML,
+    StartSector,
+    size_in_KB,
+    PHYPartition,
+    file_sector_offset,
+    num_partition_sectors,
+    filename,
+    sparse,
+    label,
+    readbackverify="false",
+    partofsingleimage="false",
+):
+    if StartSector < 0:
+        szStartSector = (
+            "NUM_DISK_SECTORS%d." % StartSector
+        )  ## as in NUM_DISK_SECTORS-33 since %d=-33
+        szStartByte = "(%d*NUM_DISK_SECTORS)%d." % (
+            SECTOR_SIZE_IN_BYTES,
+            StartSector * SECTOR_SIZE_IN_BYTES,
+        )
     else:
-        #print "\nTo be here means StartSector>0"
-        #print "UpdateRawProgram StartSector=",StartSector
-        #print "StartSector=",type(StartSector)
-        #print "-----------------------------------------"
+        # print "\nTo be here means StartSector>0"
+        # print "UpdateRawProgram StartSector=",StartSector
+        # print "StartSector=",type(StartSector)
+        # print "-----------------------------------------"
 
-        szStartByte   = str(hex(int(StartSector)*SECTOR_SIZE_IN_BYTES))
+        szStartByte = str(hex(int(StartSector) * SECTOR_SIZE_IN_BYTES))
         szStartSector = str(StartSector)
 
-    #import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
 
-    if num_partition_sectors<=0:
-        #print "*"*78
-        #print "WARNING: num_partition_sectors is %d for '%s' PHYPartition=%d, setting it to 0" % (num_partition_sectors,label,PHYPartition)
-        #print "\tThis can happen if you only have 1 partition and thus it is the grow partition"
+    if num_partition_sectors <= 0:
+        # print "*"*78
+        # print "WARNING: num_partition_sectors is %d for '%s' PHYPartition=%d, setting it to 0" % (num_partition_sectors,label,PHYPartition)
+        # print "\tThis can happen if you only have 1 partition and thus it is the grow partition"
         num_partition_sectors = 0
         size_in_KB = 0
 
     if erasefirst:
-        if label!="cdt":
-            SubElement(RawProgramXML, 'erase', {'start_sector':szStartSector, 'physical_partition_number':str(PHYPartition),
-                                                'num_partition_sectors':str(num_partition_sectors), 'filename':filename,
-                                                'SECTOR_SIZE_IN_BYTES':str(SECTOR_SIZE_IN_BYTES) })
+        if label != "cdt":
+            SubElement(
+                RawProgramXML,
+                "erase",
+                {
+                    "start_sector": szStartSector,
+                    "physical_partition_number": str(PHYPartition),
+                    "num_partition_sectors": str(num_partition_sectors),
+                    "filename": filename,
+                    "SECTOR_SIZE_IN_BYTES": str(SECTOR_SIZE_IN_BYTES),
+                },
+            )
 
+    SubElement(
+        RawProgramXML,
+        "program",
+        {
+            "start_sector": szStartSector,
+            "size_in_KB": str(size_in_KB),
+            "physical_partition_number": str(PHYPartition),
+            "partofsingleimage": partofsingleimage,
+            "file_sector_offset": str(file_sector_offset),
+            "num_partition_sectors": str(num_partition_sectors),
+            "readbackverify": readbackverify,
+            "filename": filename,
+            "sparse": sparse,
+            "start_byte_hex": szStartByte,
+            "SECTOR_SIZE_IN_BYTES": str(SECTOR_SIZE_IN_BYTES),
+            "label": label,
+        },
+    )
 
-    SubElement(RawProgramXML, 'program', {'start_sector':szStartSector, 'size_in_KB':str(size_in_KB), 'physical_partition_number':str(PHYPartition), 'partofsingleimage':partofsingleimage,
-                                          'file_sector_offset':str(file_sector_offset), 'num_partition_sectors':str(num_partition_sectors), 'readbackverify':readbackverify,
-                                          'filename':filename,  'sparse':sparse, 'start_byte_hex':szStartByte,  'SECTOR_SIZE_IN_BYTES':str(SECTOR_SIZE_IN_BYTES), 'label':label       })
-
-
-    #iter = RawProgramXML.getiterator()
-    #for element in iter:
+    # iter = RawProgramXML.getiterator()
+    # for element in iter:
     #    print "\nElement:" , element.tag, " : ", element.text   # thins like image,primary,extended etc
     #    if element.keys():
     #        print "\tAttributes:"
@@ -164,9 +247,7 @@ def UpdateRawProgram(RawProgramXML, StartSector, size_in_KB, PHYPartition, file_
     #        for name, value in element.items():
     #            print "\t\tName: '%s'=>'%s' " % (name,value)
 
-
-    #import pdb; pdb.set_trace()
-
+    # import pdb; pdb.set_trace()
 
 
 def ValidGUIDForm(GUID):
@@ -174,13 +255,16 @@ def ValidGUIDForm(GUID):
     if not isinstance(GUID, str):
         GUID = str(GUID)
 
-    print("Testing if GUID=",GUID)
+    print("Testing if GUID=", GUID)
 
-    m = re.search(r'0x([a-fA-F\d]{32})$', GUID)     #0xC79926B7B668C0874433B9E5EBD0A0A2
+    m = re.search(r"0x([a-fA-F\d]{32})$", GUID)  # 0xC79926B7B668C0874433B9E5EBD0A0A2
     if m is not None:
         return True
 
-    m = re.search(r'([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})', GUID)
+    m = re.search(
+        r"([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})",
+        GUID,
+    )
     if m is not None:
         return True
 
@@ -188,37 +272,39 @@ def ValidGUIDForm(GUID):
 
     return False
 
+
 def ValidateTYPE(Type):
     # for type I must support the original "4C" and if they put "0x4C"
 
     if isinstance(Type, int):
-        if Type>=0 and Type<=255:
+        if Type >= 0 and Type <= 255:
             return Type
 
     if not isinstance(Type, str):
         Type = str(Type)
 
-    m = re.search(r'^(0x)?([a-fA-F\d][a-fA-F\d]?)$', Type)
+    m = re.search(r"^(0x)?([a-fA-F\d][a-fA-F\d]?)$", Type)
     if m is None:
-        print("\tWARNING: Type \"%s\" is not in the form 0x4C" % Type)
+        print('\tWARNING: Type "%s" is not in the form 0x4C' % Type)
         sys.exit(1)
     else:
-        #print m.group(2)
-        #print "---------"
-        #print "\tType is \"0x%X\"" % Type
-        return int(m.group(2),16)
+        # print m.group(2)
+        # print "---------"
+        # print "\tType is \"0x%X\"" % Type
+        return int(m.group(2), 16)
+
 
 def ValidateGUID(GUID):
 
     if not isinstance(GUID, str):
         GUID = str(GUID)
 
-    print("Looking to validate GUID=",GUID)
+    print("Looking to validate GUID=", GUID)
 
-    m = re.search(r'0x([a-fA-F\d]{32})$', GUID)     #0xC79926B7B668C0874433B9E5EBD0A0A2
+    m = re.search(r"0x([a-fA-F\d]{32})$", GUID)  # 0xC79926B7B668C0874433B9E5EBD0A0A2
     if m is not None:
-        tempGUID = int(m.group(1),16)
-        print("\tGUID \"%s\"" % GUID)
+        tempGUID = int(m.group(1), 16)
+        print('\tGUID "%s"' % GUID)
 
         if tempGUID == PARTITION_SYSTEM_GUID:
             print("\tPARTITION_SYSTEM_GUID detected\n")
@@ -232,42 +318,68 @@ def ValidateGUID(GUID):
         return tempGUID
 
     else:
-        #ebd0a0a2-b9e5-4433-87c0-68b6b72699c7  --> #0x C7 99 26 B7 B6 68 C087 4433 B9E5 EBD0A0A2
-        m = re.search(r'([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})', GUID)
+        # ebd0a0a2-b9e5-4433-87c0-68b6b72699c7  --> #0x C7 99 26 B7 B6 68 C087 4433 B9E5 EBD0A0A2
+        m = re.search(
+            r"([a-fA-F\d]{8})-([a-fA-F\d]{4})-([a-fA-F\d]{4})-([a-fA-F\d]{2})([a-fA-F\d]{2})-([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})",
+            GUID,
+        )
         if m is not None:
             print("Found more advanced type")
-            tempGUID = (int(m.group(4),16)<<64) | (int(m.group(3),16)<<48) | (int(m.group(2),16)<<32) | int(m.group(1),16)
-            tempGUID|= (int(m.group(8),16)<<96) | (int(m.group(7),16)<<88) | (int(m.group(6),16)<<80) | (int(m.group(5),16)<<72)
-            tempGUID|= (int(m.group(11),16)<<120)| (int(m.group(10),16)<<112)| (int(m.group(9),16)<<104)
-            print("** CONVERTED GUID \"%s\" is FOUND --> 0x%X" % (GUID,tempGUID))
+            tempGUID = (
+                (int(m.group(4), 16) << 64)
+                | (int(m.group(3), 16) << 48)
+                | (int(m.group(2), 16) << 32)
+                | int(m.group(1), 16)
+            )
+            tempGUID |= (
+                (int(m.group(8), 16) << 96)
+                | (int(m.group(7), 16) << 88)
+                | (int(m.group(6), 16) << 80)
+                | (int(m.group(5), 16) << 72)
+            )
+            tempGUID |= (
+                (int(m.group(11), 16) << 120)
+                | (int(m.group(10), 16) << 112)
+                | (int(m.group(9), 16) << 104)
+            )
+            print('** CONVERTED GUID "%s" is FOUND --> 0x%X' % (GUID, tempGUID))
             return tempGUID
         else:
-            print("\nWARNING: "+"-"*78)
-            print("*"*78)
-            print("WARNING: GUID \"%s\" is not in the form ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" % GUID)
-            print("*"*78)
-            print("WARNING"+"-"*78+"\n")
-            print("Converted to PARTITION_BASIC_DATA_GUID (0xC79926B7B668C0874433B9E5EBD0A0A2)\n")
+            print("\nWARNING: " + "-" * 78)
+            print("*" * 78)
+            print(
+                'WARNING: GUID "%s" is not in the form ebd0a0a2-b9e5-4433-87c0-68b6b72699c7'
+                % GUID
+            )
+            print("*" * 78)
+            print("WARNING" + "-" * 78 + "\n")
+            print(
+                "Converted to PARTITION_BASIC_DATA_GUID (0xC79926B7B668C0874433B9E5EBD0A0A2)\n"
+            )
             return PARTITION_BASIC_DATA_GUID
 
+
 def WriteGPT(GPTMAIN, GPTBACKUP, GPTEMPTY):
-    global opfile,PrimaryGPT,BackupGPT,GPTBOTH
-    #for b in PrimaryGPT:
+    global opfile, PrimaryGPT, BackupGPT, GPTBOTH
+    # for b in PrimaryGPT:
     #    opfile.write(struct.pack("B", b))
-    #for b in BackupGPT:
+    # for b in BackupGPT:
     #    opfile.write(struct.pack("B", b))
 
     with open(GPTMAIN, "wb") as ofile:
         for b in PrimaryGPT:
             ofile.write(struct.pack("B", b))
 
-    print("\nCreated \"%s\"\t\t\t<-- Primary GPT partition tables + protective MBR" % GPTMAIN)
+    print(
+        '\nCreated "%s"\t\t\t<-- Primary GPT partition tables + protective MBR'
+        % GPTMAIN
+    )
 
     with open(GPTBACKUP, "wb") as ofile:
         for b in BackupGPT:
             ofile.write(struct.pack("B", b))
 
-    print("Created \"%s\"\t\t<-- Backup GPT partition tables" % GPTBACKUP)
+    print('Created "%s"\t\t<-- Backup GPT partition tables' % GPTBACKUP)
 
     with open(GPTBOTH, "wb") as ofile:
         for b in PrimaryGPT:
@@ -275,7 +387,9 @@ def WriteGPT(GPTMAIN, GPTBACKUP, GPTEMPTY):
         for b in BackupGPT:
             ofile.write(struct.pack("B", b))
 
-    print("Created \"%s\" \t\t<-- you can run 'perl parseGPT.pl %s'" % (GPTBOTH,GPTBOTH))
+    print(
+        "Created \"%s\" \t\t<-- you can run 'perl parseGPT.pl %s'" % (GPTBOTH, GPTBOTH)
+    )
 
     ## EmptyGPT is just all 0's, let's fill in the correct data
     FillInEmptyGPT()
@@ -284,505 +398,798 @@ def WriteGPT(GPTMAIN, GPTBACKUP, GPTEMPTY):
         for b in EmptyGPT:
             ofile.write(struct.pack("B", b))
 
-    print("Created \"%s\"\t\t<-- Empty GPT partition table, use to force EDL mode (very useful)" % GPTEMPTY)
+    print(
+        'Created "%s"\t\t<-- Empty GPT partition table, use to force EDL mode (very useful)'
+        % GPTEMPTY
+    )
+
 
 def FillInEmptyGPT():
     global EmptyGPT
 
-    i=SECTOR_SIZE_IN_BYTES+16
-    EmptyGPT[0:i]       = PrimaryGPT[0:i]  ## this copies up to EFI PART, REVISION and HEADER SIZE
-    EmptyGPT[i:i+4]     = [0xD6, 0x51, 0x5B, 0x44] # CRC32
-    i+=8
-    EmptyGPT[i:i+1]     = [0x01] # Current LBA
-    i+=16
-    EmptyGPT[i:i+1]     = [0x22] # First useable LBA
-    i+=16
-    EmptyGPT[i:i+16]    = [0x32, 0x1B, 0x10, 0x98, 0xE2, 0xBB, 0xF2, 0x4B, 0xA0, 0x6E, 0x2B, 0xB3, 0x3D, 0x00, 0x0C, 0x20] # DISK GUID
-    i+=16
-    EmptyGPT[i:i+1]     = [0x02] # Starting LBA
-    i+=8
-    EmptyGPT[i:i+16]    = [0x04, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x04, 0x87, 0x5D, 0x3C, 0x00, 0x00, 0x00, 0x00] # Num Entries, Size of Array, CRC
+    i = SECTOR_SIZE_IN_BYTES + 16
+    EmptyGPT[0:i] = PrimaryGPT[
+        0:i
+    ]  ## this copies up to EFI PART, REVISION and HEADER SIZE
+    EmptyGPT[i : i + 4] = [0xD6, 0x51, 0x5B, 0x44]  # CRC32
+    i += 8
+    EmptyGPT[i : i + 1] = [0x01]  # Current LBA
+    i += 16
+    EmptyGPT[i : i + 1] = [0x22]  # First useable LBA
+    i += 16
+    EmptyGPT[i : i + 16] = [
+        0x32,
+        0x1B,
+        0x10,
+        0x98,
+        0xE2,
+        0xBB,
+        0xF2,
+        0x4B,
+        0xA0,
+        0x6E,
+        0x2B,
+        0xB3,
+        0x3D,
+        0x00,
+        0x0C,
+        0x20,
+    ]  # DISK GUID
+    i += 16
+    EmptyGPT[i : i + 1] = [0x02]  # Starting LBA
+    i += 8
+    EmptyGPT[i : i + 16] = [
+        0x04,
+        0x00,
+        0x00,
+        0x00,
+        0x80,
+        0x00,
+        0x00,
+        0x00,
+        0x04,
+        0x87,
+        0x5D,
+        0x3C,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    ]  # Num Entries, Size of Array, CRC
 
-    i=2*SECTOR_SIZE_IN_BYTES+16
-    EmptyGPT[i:i+16]    = [0x6B, 0xCA, 0x1F, 0xEF, 0x31, 0x26, 0xC9, 0x95, 0x5C, 0x13, 0x61, 0xEB, 0x3F, 0xCF, 0x87, 0xF9]  # unique GUID
-    i+=16
-    EmptyGPT[i:i+1]     = [0x22] # first LBA
-    i+=8
-    EmptyGPT[i:i+2]     = [0x21, 0x02]  # last LBA
-    i+=16
-    EmptyGPT[i:i+9]     = [0x65, 0x00, 0x6D, 0x00, 0x70, 0x00, 0x74, 0x00, 0x79]    # unicode "empty" partition name
+    i = 2 * SECTOR_SIZE_IN_BYTES + 16
+    EmptyGPT[i : i + 16] = [
+        0x6B,
+        0xCA,
+        0x1F,
+        0xEF,
+        0x31,
+        0x26,
+        0xC9,
+        0x95,
+        0x5C,
+        0x13,
+        0x61,
+        0xEB,
+        0x3F,
+        0xCF,
+        0x87,
+        0xF9,
+    ]  # unique GUID
+    i += 16
+    EmptyGPT[i : i + 1] = [0x22]  # first LBA
+    i += 8
+    EmptyGPT[i : i + 2] = [0x21, 0x02]  # last LBA
+    i += 16
+    EmptyGPT[i : i + 9] = [
+        0x65,
+        0x00,
+        0x6D,
+        0x00,
+        0x70,
+        0x00,
+        0x74,
+        0x00,
+        0x79,
+    ]  # unicode "empty" partition name
 
 
-
-def UpdatePrimaryGPT(value,length,i):
+def UpdatePrimaryGPT(value, length, i):
     global PrimaryGPT
     for b in range(length):
-        PrimaryGPT[i] = ((int(value)>>(b*8)) & 0xFF)
-        i+=1
+        PrimaryGPT[i] = (int(value) >> (b * 8)) & 0xFF
+        i += 1
     return i
 
-def UpdateBackupGPT(value,length,i):
+
+def UpdateBackupGPT(value, length, i):
     global BackupGPT
     for b in range(length):
-        BackupGPT[i] = ((int(value)>>(b*8)) & 0xFF)
-        i+=1
+        BackupGPT[i] = (int(value) >> (b * 8)) & 0xFF
+        i += 1
     return i
+
 
 def ShowBackupGPT(sector):
     global BackupGPT
     print("Sector: %d" % sector)
     for j in range(32):
         for i in range(16):
-            sys.stdout.write("%.2X " % BackupGPT[i+j*16+sector*SECTOR_SIZE_IN_BYTES])
+            sys.stdout.write(
+                "%.2X " % BackupGPT[i + j * 16 + sector * SECTOR_SIZE_IN_BYTES]
+            )
         print(" ")
     print(" ")
 
-def CreateFileOfZeros(filename,num_total_sectors):
+
+def CreateFileOfZeros(filename, num_total_sectors):
     if OutputFolder:
         filename = os.path.join(OutputFolder, filename)
     num_sectors = int(num_total_sectors)
-    temp = [0]*(SECTOR_SIZE_IN_BYTES*num_sectors)
-    zeros = struct.pack("%iB"%(SECTOR_SIZE_IN_BYTES*num_sectors),*temp)
+    temp = [0] * (SECTOR_SIZE_IN_BYTES * num_sectors)
+    zeros = struct.pack("%iB" % (SECTOR_SIZE_IN_BYTES * num_sectors), *temp)
     try:
         with open(filename, "w+b") as opfile:
             opfile.write(zeros)
     except Exception as x:
-        print("ERROR: Could not create or write '%s', cwd=%s\nREASON: %s" % (filename, os.getcwd(), x))
+        print(
+            "ERROR: Could not create or write '%s', cwd=%s\nREASON: %s"
+            % (filename, os.getcwd(), x)
+        )
         sys.exit(1)
 
-    print("Created \"%s\"\t\t<-- full of binary zeros - used by \"wipe\" rawprogram files" % filename)
+    print(
+        'Created "%s"\t\t<-- full of binary zeros - used by "wipe" rawprogram files'
+        % filename
+    )
+
 
 def CreateErasingRawProgramFiles():
     global gen_patch
-    CreateFileOfZeros("zeros_1sector.bin",1)
-    CreateFileOfZeros("zeros_%dsectors.bin" % BackupGPTNumLBAs,BackupGPTNumLBAs)
+    CreateFileOfZeros("zeros_1sector.bin", 1)
+    CreateFileOfZeros("zeros_%dsectors.bin" % BackupGPTNumLBAs, BackupGPTNumLBAs)
 
     ##import pdb; pdb.set_trace()
     for i in range(8):  # PHY partitions 0 to 7 exist (with 4,5,6,7 as GPPs)
-        if i==3:
-            continue    # no such PHY partition as of Feb 23, 2012
-        temp = Element('data')
-        temp.append(Comment('NOTE: This is an ** Autogenerated file **'))
-        temp.append(Comment('NOTE: Sector size is %ibytes'%SECTOR_SIZE_IN_BYTES))
+        if i == 3:
+            continue  # no such PHY partition as of Feb 23, 2012
+        temp = Element("data")
+        temp.append(Comment("NOTE: This is an ** Autogenerated file **"))
+        temp.append(Comment("NOTE: Sector size is %ibytes" % SECTOR_SIZE_IN_BYTES))
 
-        CreateFileOfZeros("zeros_33sectors.bin",33)
-        UpdateRawProgram(temp,0, 1*SECTOR_SIZE_IN_BYTES/1024.0, i, 0, 1, "zeros_1sector.bin", "false", "Overwrite MBR sector")
-        UpdateRawProgram(temp,1, BackupGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, i, 0, BackupGPTNumLBAs, "zeros_%dsectors.bin" % BackupGPTNumLBAs, "false", "Overwrite Primary GPT Sectors")
+        CreateFileOfZeros("zeros_33sectors.bin", 33)
+        UpdateRawProgram(
+            temp,
+            0,
+            1 * SECTOR_SIZE_IN_BYTES / 1024.0,
+            i,
+            0,
+            1,
+            "zeros_1sector.bin",
+            "false",
+            "Overwrite MBR sector",
+        )
+        UpdateRawProgram(
+            temp,
+            1,
+            BackupGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+            i,
+            0,
+            BackupGPTNumLBAs,
+            "zeros_%dsectors.bin" % BackupGPTNumLBAs,
+            "false",
+            "Overwrite Primary GPT Sectors",
+        )
 
         backup_gpt_lba = -BackupGPTNumLBAs
         if gen_patch:
-            UpdateRawProgram(temp,backup_gpt_lba, BackupGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, i, 0, BackupGPTNumLBAs, "zeros_%dsectors.bin" % BackupGPTNumLBAs, "false", "Overwrite Backup GPT Sectors")
+            UpdateRawProgram(
+                temp,
+                backup_gpt_lba,
+                BackupGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+                i,
+                0,
+                BackupGPTNumLBAs,
+                "zeros_%dsectors.bin" % BackupGPTNumLBAs,
+                "false",
+                "Overwrite Backup GPT Sectors",
+            )
 
-        RAW_PROGRAM = '%swipe_rawprogram_PHY%d.xml' % (OutputFolder,i)
+        RAW_PROGRAM = "%swipe_rawprogram_PHY%d.xml" % (OutputFolder, i)
 
         with open(RAW_PROGRAM, "w") as opfile:
-            opfile.write( prettify(temp) )
-        print("Created \"%s\"\t<-- Used to *wipe/erase* partition information" % RAW_PROGRAM)
+            opfile.write(prettify(temp))
+        print(
+            'Created "%s"\t<-- Used to *wipe/erase* partition information' % RAW_PROGRAM
+        )
 
 
-NumPartitions       = 0
-SizeOfPartitionArray= 0
+NumPartitions = 0
+SizeOfPartitionArray = 0
 
-def CreateGPTPartitionTable(PhysicalPartitionNumber,UserProvided=False):
-    global opfile,PhyPartition,PrimaryGPT,BackupGPT,EmptyGPT,RawProgramXML, GPTMAIN, GPTBACKUP, GPTBOTH, RAW_PROGRAM, PATCHES, PrimaryGPTNumLBAs, BackupGPTNumLBAs
+
+def CreateGPTPartitionTable(PhysicalPartitionNumber, UserProvided=False):
+    global opfile, PhyPartition, PrimaryGPT, BackupGPT, EmptyGPT, RawProgramXML, GPTMAIN, GPTBACKUP, GPTBOTH, RAW_PROGRAM, PATCHES, PrimaryGPTNumLBAs, BackupGPTNumLBAs
     global gen_patch
 
     print("\n\nMaking GUID Partitioning Table (GPT)")
 
-    #PrintBanner("instructions")
+    # PrintBanner("instructions")
 
-    #print "\nGoing through partitions listed in XML file"
+    # print "\nGoing through partitions listed in XML file"
 
     ## Step 2. Move through partitions resizing as needed based on WRITE_PROTECT_BOUNDARY_IN_KB
 
-    #print "\n\n--------------------------------------------------------"
-    #print "This is the order of the partitions"
+    # print "\n\n--------------------------------------------------------"
+    # print "This is the order of the partitions"
     # I most likely need to resize at least one partition below to the WRITE_PROTECT_BOUNDARY_IN_KB boundary
-    #for k in range(len(PhyPartition)):
+    # for k in range(len(PhyPartition)):
 
     k = PhysicalPartitionNumber
 
-    GPTMAIN                     = '%sgpt_main%d.bin'        % (OutputFolder,k)
-    GPTEMPTY                    = '%sgpt_empty%d.bin'       % (OutputFolder,k)
-    GPTBACKUP                   = '%sgpt_backup%d.bin'      % (OutputFolder,k)
-    GPTBOTH                     = '%sgpt_both%d.bin'        % (OutputFolder,k)
-    RAW_PROGRAM                 = '%srawprogram%d.xml'      % (OutputFolder,k)
-    RAW_PROGRAM_WIPE_PARTITIONS = '%srawprogram%d_WIPE_PARTITIONS.xml'% (OutputFolder,k)
-    RAW_PROGRAM_BLANK_GPT       = '%srawprogram%d_BLANK_GPT.xml'% (OutputFolder,k)
-    PATCHES                     = '%spatch%i.xml'           % (OutputFolder,k)
+    GPTMAIN = "%sgpt_main%d.bin" % (OutputFolder, k)
+    GPTEMPTY = "%sgpt_empty%d.bin" % (OutputFolder, k)
+    GPTBACKUP = "%sgpt_backup%d.bin" % (OutputFolder, k)
+    GPTBOTH = "%sgpt_both%d.bin" % (OutputFolder, k)
+    RAW_PROGRAM = "%srawprogram%d.xml" % (OutputFolder, k)
+    RAW_PROGRAM_WIPE_PARTITIONS = "%srawprogram%d_WIPE_PARTITIONS.xml" % (
+        OutputFolder,
+        k,
+    )
+    RAW_PROGRAM_BLANK_GPT = "%srawprogram%d_BLANK_GPT.xml" % (OutputFolder, k)
+    PATCHES = "%spatch%i.xml" % (OutputFolder, k)
 
-    #for k in range(1):
+    # for k in range(1):
 
-    #PrimaryGPT = [0]*(34*SECTOR_SIZE_IN_BYTES)  # This is LBA 0 to 33 (34 sectors total)    (start of disk)
-    #BackupGPT  = [0]*(33*SECTOR_SIZE_IN_BYTES)  # This is LBA-33 to -1 (33 sectors total)   (end of disk)
-    if SECTOR_SIZE_IN_BYTES==4096:
-        PrimaryGPT = [0]*(1*SECTOR_SIZE_IN_BYTES+1*SECTOR_SIZE_IN_BYTES+4*SECTOR_SIZE_IN_BYTES)
-        BackupGPT  = [0]*(1*SECTOR_SIZE_IN_BYTES+4*SECTOR_SIZE_IN_BYTES)
-        EmptyGPT   = [0]*(1*SECTOR_SIZE_IN_BYTES+1*SECTOR_SIZE_IN_BYTES+4*SECTOR_SIZE_IN_BYTES)
+    # PrimaryGPT = [0]*(34*SECTOR_SIZE_IN_BYTES)  # This is LBA 0 to 33 (34 sectors total)    (start of disk)
+    # BackupGPT  = [0]*(33*SECTOR_SIZE_IN_BYTES)  # This is LBA-33 to -1 (33 sectors total)   (end of disk)
+    if SECTOR_SIZE_IN_BYTES == 4096:
+        PrimaryGPT = [0] * (
+            1 * SECTOR_SIZE_IN_BYTES
+            + 1 * SECTOR_SIZE_IN_BYTES
+            + 4 * SECTOR_SIZE_IN_BYTES
+        )
+        BackupGPT = [0] * (1 * SECTOR_SIZE_IN_BYTES + 4 * SECTOR_SIZE_IN_BYTES)
+        EmptyGPT = [0] * (
+            1 * SECTOR_SIZE_IN_BYTES
+            + 1 * SECTOR_SIZE_IN_BYTES
+            + 4 * SECTOR_SIZE_IN_BYTES
+        )
     else:
-        PrimaryGPT = [0]*(34*SECTOR_SIZE_IN_BYTES)  # This is LBA 0 to 33 (34 sectors total)    (start of disk)
-        BackupGPT  = [0]*(33*SECTOR_SIZE_IN_BYTES)  # This is LBA-33 to -1 (33 sectors total)   (end of disk)
-        EmptyGPT   = [0]*(34*SECTOR_SIZE_IN_BYTES)  # This is LBA 0 to 33 (34 sectors total)    (start of disk)
-
+        PrimaryGPT = [0] * (
+            34 * SECTOR_SIZE_IN_BYTES
+        )  # This is LBA 0 to 33 (34 sectors total)    (start of disk)
+        BackupGPT = [0] * (
+            33 * SECTOR_SIZE_IN_BYTES
+        )  # This is LBA-33 to -1 (33 sectors total)   (end of disk)
+        EmptyGPT = [0] * (
+            34 * SECTOR_SIZE_IN_BYTES
+        )  # This is LBA 0 to 33 (34 sectors total)    (start of disk)
 
     ## ---------------------------------------------------------------------------------
     ## Step 2. Move through xml definition and figure out partitions sizes
     ## ---------------------------------------------------------------------------------
 
-    PrimaryGPTNumLBAs=len(PrimaryGPT)//SECTOR_SIZE_IN_BYTES
-    BackupGPTNumLBAs =len(BackupGPT)//SECTOR_SIZE_IN_BYTES
-    i           = 2*SECTOR_SIZE_IN_BYTES    ## partition arrays begin here
-    FirstLBA    = PrimaryGPTNumLBAs
-    LastLBA     = FirstLBA               ## Make these equal at first
+    PrimaryGPTNumLBAs = len(PrimaryGPT) // SECTOR_SIZE_IN_BYTES
+    BackupGPTNumLBAs = len(BackupGPT) // SECTOR_SIZE_IN_BYTES
+    i = 2 * SECTOR_SIZE_IN_BYTES  ## partition arrays begin here
+    FirstLBA = PrimaryGPTNumLBAs
+    LastLBA = FirstLBA  ## Make these equal at first
 
-    if HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'] is True:
-        UpdateWPhash(FirstLBA, 0)   # make sure 1st write protect boundary is setup correctly
+    if HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"] is True:
+        UpdateWPhash(
+            FirstLBA, 0
+        )  # make sure 1st write protect boundary is setup correctly
 
-    #print "len(PhyPartition)=%d and k=%d" % (len(PhyPartition),k)
+    # print "len(PhyPartition)=%d and k=%d" % (len(PhyPartition),k)
 
-    if(k>=len(PhyPartition)):
+    if k >= len(PhyPartition):
         if UserProvided:
-            print("\nERROR: PHY Partition %i of %i not found" % (k,len(PhyPartition)))
-            print("\nERROR: PHY Partition %i of %i not found\n\n" % (k,len(PhyPartition)))
+            print("\nERROR: PHY Partition %i of %i not found" % (k, len(PhyPartition)))
+            print(
+                "\nERROR: PHY Partition %i of %i not found\n\n" % (k, len(PhyPartition))
+            )
             ShowPartitionExample()
             sys.exit()
         else:
-            print("\nERROR: PHY Partition %i of %i not found\n\n" % (k,len(PhyPartition)))
+            print(
+                "\nERROR: PHY Partition %i of %i not found\n\n" % (k, len(PhyPartition))
+            )
             return  ## Automatically trying to do 0 to 7, and some don't exist, which is to be expected
 
     SectorsTillNextBoundary = 0
 
-
-    print("\n\nOn PHY Partition %d that has %d partitions" % (k,len(PhyPartition[k])))
+    print("\n\nOn PHY Partition %d that has %d partitions" % (k, len(PhyPartition[k])))
     for j in range(len(PhyPartition[k])):
-        #print "\nPartition name='%s' (readonly=%s)" % (PhyPartition[k][j]['label'], PhyPartition[k][j]['readonly'])
-        #print "\tat sector location %d (%d KB or %.2f MB) and LastLBA=%d" % (FirstLBA,FirstLBA/2,FirstLBA/2048,LastLBA)
-        #print "%d of %d with label %s" %(j,len(PhyPartition[k]),PhyPartition[k][j]['label'])
+        # print "\nPartition name='%s' (readonly=%s)" % (PhyPartition[k][j]['label'], PhyPartition[k][j]['readonly'])
+        # print "\tat sector location %d (%d KB or %.2f MB) and LastLBA=%d" % (FirstLBA,FirstLBA/2,FirstLBA/2048,LastLBA)
+        # print "%d of %d with label %s" %(j,len(PhyPartition[k]),PhyPartition[k][j]['label'])
 
-        print("\n"+"="*78)
+        print("\n" + "=" * 78)
 
-        size_kb = float(PhyPartition[k][j]['size_in_kb'])
-        size_bytes = math.ceil(size_kb * 1024)                                      #Count the number of bytes
-        sectors = math.ceil(size_bytes / SECTOR_SIZE_IN_BYTES)                      #Calculate the number of sectors rounded up
-        PhyPartition[k][j]['size_in_kb'] = sectors * SECTOR_SIZE_IN_BYTES / 1024
+        size_kb = float(PhyPartition[k][j]["size_in_kb"])
+        size_bytes = math.ceil(size_kb * 1024)  # Count the number of bytes
+        sectors = math.ceil(
+            size_bytes / SECTOR_SIZE_IN_BYTES
+        )  # Calculate the number of sectors rounded up
+        PhyPartition[k][j]["size_in_kb"] = sectors * SECTOR_SIZE_IN_BYTES / 1024
 
         ##import pdb; pdb.set_trace() ## verifying sizes
 
-        if HashInstructions['PERFORMANCE_BOUNDARY_IN_KB']>0:
-            PrintBigWarning("WARNING: HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] is %i KB\n\tbut HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] is FALSE!!\n\n" % HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
-            PrintBigWarning("WARNING: This means partitions will *NOT* be aligned to a HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] of %i KB !!\n\n" % HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
+        if HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"] > 0:
+            PrintBigWarning(
+                "WARNING: HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] is %i KB\n\tbut HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] is FALSE!!\n\n"
+                % HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"]
+            )
+            PrintBigWarning(
+                "WARNING: This means partitions will *NOT* be aligned to a HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] of %i KB !!\n\n"
+                % HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"]
+            )
             print("To correct this, partition.xml should look like this\n")
             print("\t<parser_instructions>")
-            print("\t\tPERFORMANCE_BOUNDARY_IN_KB = %i" % HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
+            print(
+                "\t\tPERFORMANCE_BOUNDARY_IN_KB = %i"
+                % HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"]
+            )
             print("\t\tALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY=true")
             print("\t</parser_instructions>\n\n")
 
-            if HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] is True:
+            if HashInstructions["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] is True:
                 ## to be here means this partition *must* be on an ALIGN boundary
-                print("\tAlignment is to %iKB" % PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB'])
-                SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(FirstLBA,PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']) ## hi
-                if SectorsTillNextBoundary>0:
-                    print("\tSectorsTillNextBoundary=%d, FirstLBA=%d it needs to be moved to be aligned to %d" % (SectorsTillNextBoundary,FirstLBA,FirstLBA + SectorsTillNextBoundary))
+                print(
+                    "\tAlignment is to %iKB"
+                    % PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"]
+                )
+                SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(
+                    FirstLBA, PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"]
+                )  ## hi
+                if SectorsTillNextBoundary > 0:
+                    print(
+                        "\tSectorsTillNextBoundary=%d, FirstLBA=%d it needs to be moved to be aligned to %d"
+                        % (
+                            SectorsTillNextBoundary,
+                            FirstLBA,
+                            FirstLBA + SectorsTillNextBoundary,
+                        )
+                    )
                     ##print "\tPhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']=",PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']
                     FirstLBA += SectorsTillNextBoundary
         else:
-            if PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']>0:
+            if PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"] > 0:
                 print("\tThis partition is *NOT* aligned to a performance boundary\n")
 
-        if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']>0:
-            SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(FirstLBA,HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
+        if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] > 0:
+            SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(
+                FirstLBA, HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            )
 
-        if PhyPartition[k][j]['readonly']=="true":
+        if PhyPartition[k][j]["readonly"] == "true":
             ## to be here means this partition is read-only, so see if we need to move the start
             if FirstLBA <= hash_w[NumWPregions]["end_sector"]:
-                print("\tWe *don't* need to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"]))
+                print(
+                    "\tWe *don't* need to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)"
+                    % (FirstLBA, hash_w[NumWPregions]["end_sector"])
+                )
                 pass
             else:
-                print("\tFirstLBA (%d) is *not* covered by the end of the WP region (%d),\n\tit needs to be moved to be aligned to %d" % (FirstLBA,hash_w[NumWPregions]["end_sector"],FirstLBA + SectorsTillNextBoundary))
+                print(
+                    "\tFirstLBA (%d) is *not* covered by the end of the WP region (%d),\n\tit needs to be moved to be aligned to %d"
+                    % (
+                        FirstLBA,
+                        hash_w[NumWPregions]["end_sector"],
+                        FirstLBA + SectorsTillNextBoundary,
+                    )
+                )
                 FirstLBA += SectorsTillNextBoundary
 
         else:
             print("\n\tThis partition is *NOT* readonly")
             ## to be here means this partition is writeable, so see if we need to move the start
             if FirstLBA <= hash_w[NumWPregions]["end_sector"]:
-                print("\tWe *need* to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"]))
-                print("\nhash_w[NumWPregions]['end_sector']=%i" % hash_w[NumWPregions]["end_sector"])
-                print("FirstLBA=%i\n" %FirstLBA)
+                print(
+                    "\tWe *need* to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)"
+                    % (FirstLBA, hash_w[NumWPregions]["end_sector"])
+                )
+                print(
+                    "\nhash_w[NumWPregions]['end_sector']=%i"
+                    % hash_w[NumWPregions]["end_sector"]
+                )
+                print("FirstLBA=%i\n" % FirstLBA)
                 FirstLBA += SectorsTillNextBoundary
 
                 print("\tFirstLBA is now %d" % (FirstLBA))
             else:
-                #print "Great, We *don't* need to move FirstLBA (%d) since it's *not* covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"])
+                # print "Great, We *don't* need to move FirstLBA (%d) since it's *not* covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"])
                 pass
 
-        if (j+1) == len(PhyPartition[k]):
+        if (j + 1) == len(PhyPartition[k]):
             print("\nTHIS IS THE *LAST* PARTITION")
 
-            if HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] and gen_patch:
+            if HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"] and gen_patch:
 
                 print("\nMeans patching instructions go here")
 
-                PhyPartition[k][j]['size_in_kb']  = 0 # infinite huge
+                PhyPartition[k][j]["size_in_kb"] = 0  # infinite huge
                 print("PhyPartition[k][j]['size_in_kb'] set to 0")
 
-                print("LastLBA=",LastLBA)
-                print("FirstLBA=",FirstLBA)
+                print("LastLBA=", LastLBA)
+                print("FirstLBA=", FirstLBA)
 
                 # gpt patch - size of last partition ################################################
-                #StartSector         = 2*512+40+j*128        ## i.e. skip sector 0 and 1, then it's offset
-                #ByteOffset          = str(StartSector%512)
-                #StartSector         = str(int(StartSector / 512))
+                # StartSector         = 2*512+40+j*128        ## i.e. skip sector 0 and 1, then it's offset
+                # ByteOffset          = str(StartSector%512)
+                # StartSector         = str(int(StartSector / 512))
 
-                StartSector         = 40+j*128        ## i.e. skip sector 0 and 1, then it's offset
-                ByteOffset          = str(StartSector%SECTOR_SIZE_IN_BYTES)
-                StartSector         = str(2+int(StartSector / SECTOR_SIZE_IN_BYTES))
+                StartSector = (
+                    40 + j * 128
+                )  ## i.e. skip sector 0 and 1, then it's offset
+                ByteOffset = str(StartSector % SECTOR_SIZE_IN_BYTES)
+                StartSector = str(2 + int(StartSector / SECTOR_SIZE_IN_BYTES))
 
-                BackupStartSector   = 40+j*128
-                ByteOffset          = str(BackupStartSector%SECTOR_SIZE_IN_BYTES)
-                BackupStartSector   = int(BackupStartSector / SECTOR_SIZE_IN_BYTES)
+                BackupStartSector = 40 + j * 128
+                ByteOffset = str(BackupStartSector % SECTOR_SIZE_IN_BYTES)
+                BackupStartSector = int(BackupStartSector / SECTOR_SIZE_IN_BYTES)
 
                 ## gpt patch - main gpt partition array
-                UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,os.path.basename(GPTMAIN),"Update last partition %d '%s' with actual size in Primary Header." % ((j+1),PhyPartition[k][j]['label']))
-                UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,"DISK",              "Update last partition %d '%s' with actual size in Primary Header." % ((j+1),PhyPartition[k][j]['label']))
+                UpdatePatch(
+                    StartSector,
+                    ByteOffset,
+                    PhysicalPartitionNumber,
+                    8,
+                    "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+                    os.path.basename(GPTMAIN),
+                    "Update last partition %d '%s' with actual size in Primary Header."
+                    % ((j + 1), PhyPartition[k][j]["label"]),
+                )
+                UpdatePatch(
+                    StartSector,
+                    ByteOffset,
+                    PhysicalPartitionNumber,
+                    8,
+                    "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+                    "DISK",
+                    "Update last partition %d '%s' with actual size in Primary Header."
+                    % ((j + 1), PhyPartition[k][j]["label"]),
+                )
 
                 ## gpt patch - backup gpt partition array
-                UpdatePatch(str(BackupStartSector),    ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,os.path.basename(GPTBACKUP),"Update last partition %d '%s' with actual size in Backup Header." % ((j+1),PhyPartition[k][j]['label']))
-                UpdatePatch("NUM_DISK_SECTORS-%d." % (BackupGPTNumLBAs-BackupStartSector),ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,"DISK",                "Update last partition %d '%s' with actual size in Backup Header." % ((j+1),PhyPartition[k][j]['label']))
-            elif HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] and not gen_patch:
-                print("Ignoring GROW_LAST_PARTITION_TO_FILL_DISK because patching was disabled")
+                UpdatePatch(
+                    str(BackupStartSector),
+                    ByteOffset,
+                    PhysicalPartitionNumber,
+                    8,
+                    "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+                    os.path.basename(GPTBACKUP),
+                    "Update last partition %d '%s' with actual size in Backup Header."
+                    % ((j + 1), PhyPartition[k][j]["label"]),
+                )
+                UpdatePatch(
+                    "NUM_DISK_SECTORS-%d." % (BackupGPTNumLBAs - BackupStartSector),
+                    ByteOffset,
+                    PhysicalPartitionNumber,
+                    8,
+                    "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+                    "DISK",
+                    "Update last partition %d '%s' with actual size in Backup Header."
+                    % ((j + 1), PhyPartition[k][j]["label"]),
+                )
+            elif HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"] and not gen_patch:
+                print(
+                    "Ignoring GROW_LAST_PARTITION_TO_FILL_DISK because patching was disabled"
+                )
 
-        LastLBA = FirstLBA + ConvertKBtoSectors( PhyPartition[k][j]['size_in_kb'] ) ## increase by num sectors, LastLBA inclusive, so add 1 for size
+        LastLBA = FirstLBA + ConvertKBtoSectors(
+            PhyPartition[k][j]["size_in_kb"]
+        )  ## increase by num sectors, LastLBA inclusive, so add 1 for size
         LastLBA -= 1  # inclusive, meaning 0 to 3 is 4 sectors
 
-        #import pdb; pdb.set_trace()
+        # import pdb; pdb.set_trace()
 
-        print("\n\tAt sector location %d with size %.2f MB (%d sectors) and LastLBA=%d (0x%X)" % (FirstLBA,PhyPartition[k][j]['size_in_kb']/1024.0,ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb']),LastLBA,int(LastLBA)))
+        print(
+            "\n\tAt sector location %d with size %.2f MB (%d sectors) and LastLBA=%d (0x%X)"
+            % (
+                FirstLBA,
+                PhyPartition[k][j]["size_in_kb"] / 1024.0,
+                ConvertKBtoSectors(PhyPartition[k][j]["size_in_kb"]),
+                LastLBA,
+                int(LastLBA),
+            )
+        )
 
-        if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']>0:
-            AlignedRemainder = FirstLBA % HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']
-            if AlignedRemainder==0:
-                print("\tWPB: This partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)" % (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'],FirstLBA,FirstLBA/(ConvertKBtoSectors(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']))))
+        if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] > 0:
+            AlignedRemainder = (
+                FirstLBA % HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            )
+            if AlignedRemainder == 0:
+                print(
+                    "\tWPB: This partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)"
+                    % (
+                        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"],
+                        FirstLBA,
+                        FirstLBA
+                        / (
+                            ConvertKBtoSectors(
+                                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                            )
+                        ),
+                    )
+                )
 
-        if PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']>0:
-            AlignedRemainder = FirstLBA % PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']
-            if AlignedRemainder==0:
-                print("\t"+"-"*78)
-                print("\tPERF: This partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)" % (PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB'],FirstLBA,FirstLBA/(ConvertKBtoSectors(PhyPartition[k][j]['PERFORMANCE_BOUNDARY_IN_KB']))))
-                print("\t"+"-"*78)
+        if PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"] > 0:
+            AlignedRemainder = (
+                FirstLBA % PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"]
+            )
+            if AlignedRemainder == 0:
+                print("\t" + "-" * 78)
+                print(
+                    "\tPERF: This partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)"
+                    % (
+                        PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"],
+                        FirstLBA,
+                        FirstLBA
+                        / (
+                            ConvertKBtoSectors(
+                                PhyPartition[k][j]["PERFORMANCE_BOUNDARY_IN_KB"]
+                            )
+                        ),
+                    )
+                )
+                print("\t" + "-" * 78)
 
-        if PhyPartition[k][j]['readonly']=="true":
-            UpdateWPhash(FirstLBA, ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb']))
+        if PhyPartition[k][j]["readonly"] == "true":
+            UpdateWPhash(FirstLBA, ConvertKBtoSectors(PhyPartition[k][j]["size_in_kb"]))
 
-        #print Partition.keys()
-        #print Partition.has_key("label")
-        #print "\tsize %i kB (%.2f MB)" % (PhyPartition[k][j]['size_in_kb'], PhyPartition[k][j]['size_in_kb']/1024)
+        # print Partition.keys()
+        # print Partition.has_key("label")
+        # print "\tsize %i kB (%.2f MB)" % (PhyPartition[k][j]['size_in_kb'], PhyPartition[k][j]['size_in_kb']/1024)
 
-        PartitionTypeGUID = PhyPartition[k][j]['type']
+        PartitionTypeGUID = PhyPartition[k][j]["type"]
         print("\nPartitionTypeGUID\t0x%X" % PartitionTypeGUID)
 
         # If the partition is a multiple of 4, it must start on an LBA boundary of size SECTOR_SIZE_IN_BYTES
-#        if j%4==0 :
-#            # To be here means the partition number is a multiple of 4, so it must start on
-#            # an LBA boundary, i.e. LBA2, LBA3 etc.
-#            if i%SECTOR_SIZE_IN_BYTES > 0:
-#                print "\tWARNING: Location is %i, need to add %i to offset" % (i, SECTOR_SIZE_IN_BYTES-(i%SECTOR_SIZE_IN_BYTES))
-#                i += (SECTOR_SIZE_IN_BYTES-(i%SECTOR_SIZE_IN_BYTES))
-#
-#            print "\n==============================================================================="
-#       print "This partition array entry (%i) is a multiple of 4 and must begin on a boundary of size %i bytes" % (j,SECTOR_SIZE_IN_BYTES)
-#            print "This partition array entry is at LBA%i, absolute byte address %i (0x%X)" % (i/SECTOR_SIZE_IN_BYTES,i,i)
-#       print "NOTE: LBA0 is protective MBR, LBA1 is Primary GPT Header, LBA2 beginning of Partition Array"
-#            print "===============================================================================\n"
+        #        if j%4==0 :
+        #            # To be here means the partition number is a multiple of 4, so it must start on
+        #            # an LBA boundary, i.e. LBA2, LBA3 etc.
+        #            if i%SECTOR_SIZE_IN_BYTES > 0:
+        #                print "\tWARNING: Location is %i, need to add %i to offset" % (i, SECTOR_SIZE_IN_BYTES-(i%SECTOR_SIZE_IN_BYTES))
+        #                i += (SECTOR_SIZE_IN_BYTES-(i%SECTOR_SIZE_IN_BYTES))
+        #
+        #            print "\n==============================================================================="
+        #       print "This partition array entry (%i) is a multiple of 4 and must begin on a boundary of size %i bytes" % (j,SECTOR_SIZE_IN_BYTES)
+        #            print "This partition array entry is at LBA%i, absolute byte address %i (0x%X)" % (i/SECTOR_SIZE_IN_BYTES,i,i)
+        #       print "NOTE: LBA0 is protective MBR, LBA1 is Primary GPT Header, LBA2 beginning of Partition Array"
+        #            print "===============================================================================\n"
 
         for b in range(16):
-            PrimaryGPT[i] = ((PartitionTypeGUID>>(b*8)) & 0xFF)
-            i+=1
+            PrimaryGPT[i] = (PartitionTypeGUID >> (b * 8)) & 0xFF
+            i += 1
 
         # Unique Partition GUID
         if sequentialguid == 1:
-            UniquePartitionGUID = j+1
+            UniquePartitionGUID = j + 1
         else:
-            if PhyPartition[k][j]['uguid'] != "false":
-                UniquePartitionGUID = PhyPartition[k][j]['uguid']
+            if PhyPartition[k][j]["uguid"] != "false":
+                UniquePartitionGUID = PhyPartition[k][j]["uguid"]
             else:
-                UniquePartitionGUID = random.randint(0,2**(128))
+                UniquePartitionGUID = random.randint(0, 2 ** (128))
 
         print("UniquePartitionGUID\t0x%X" % UniquePartitionGUID)
-
 
         # This HACK section is for verifying with GPARTED, allowing me to put in
         # whatever uniqueGUID that program came up with
 
-        #if j==0:
+        # if j==0:
         #    UniquePartitionGUID = 0x373C17CF53BC7FB149B85A927ED24483
-        #elif j==1:
+        # elif j==1:
         #    UniquePartitionGUID = 0x1D3C4663FC172F904EC7E0C7A8CF84EC
-        #elif j==2:
+        # elif j==2:
         #    UniquePartitionGUID = 0x04A9B2AAEF96DAAE465F429D0EF5C6E2
-        #else:
+        # else:
         #    UniquePartitionGUID = 0x4D82D027725FD3AE46AF1C5A28944977
 
         for b in range(16):
-            PrimaryGPT[i] = ((UniquePartitionGUID>>(b*8)) & 0xFF)
-            i+=1
+            PrimaryGPT[i] = (UniquePartitionGUID >> (b * 8)) & 0xFF
+            i += 1
 
         # First LBA
         for b in range(8):
-            PrimaryGPT[i] = ((int(FirstLBA)>>(b*8)) & 0xFF)
-            i+=1
+            PrimaryGPT[i] = (int(FirstLBA) >> (b * 8)) & 0xFF
+            i += 1
 
         # Last LBA
         for b in range(8):
-            PrimaryGPT[i] = ((int(LastLBA)>>(b*8)) & 0xFF)
-            i+=1
+            PrimaryGPT[i] = (int(LastLBA) >> (b * 8)) & 0xFF
+            i += 1
 
-        print("**** FirstLBA=%d and LastLBA=%d and size is %i sectors" % (FirstLBA,LastLBA,LastLBA-FirstLBA+1))
+        print(
+            "**** FirstLBA=%d and LastLBA=%d and size is %i sectors"
+            % (FirstLBA, LastLBA, LastLBA - FirstLBA + 1)
+        )
 
         # Attributes
         Attributes = 0x0
-        #import pdb; pdb.set_trace()
+        # import pdb; pdb.set_trace()
 
-        if PhyPartition[k][j]['readonly']=="true":
-            Attributes |= 1<<60 ## Bit 60 is read only
-        if PhyPartition[k][j]['hidden']=="true":
-            Attributes |= 1<<62
-        if PhyPartition[k][j]['dontautomount']=="true":
-            Attributes |= 1<<63
-        if PhyPartition[k][j]['system']=="true":
-            Attributes |= 1<<0
-        if PhyPartition[k][j]['tries_remaining']>0:
-            Attributes |= PhyPartition[k][j]['tries_remaining']<<52
-        if PhyPartition[k][j]['priority']>0:
-            Attributes |= PhyPartition[k][j]['priority']<<48
+        if PhyPartition[k][j]["readonly"] == "true":
+            Attributes |= 1 << 60  ## Bit 60 is read only
+        if PhyPartition[k][j]["hidden"] == "true":
+            Attributes |= 1 << 62
+        if PhyPartition[k][j]["dontautomount"] == "true":
+            Attributes |= 1 << 63
+        if PhyPartition[k][j]["system"] == "true":
+            Attributes |= 1 << 0
+        if PhyPartition[k][j]["tries_remaining"] > 0:
+            Attributes |= PhyPartition[k][j]["tries_remaining"] << 52
+        if PhyPartition[k][j]["priority"] > 0:
+            Attributes |= PhyPartition[k][j]["priority"] << 48
 
         print("Attributes\t\t0x%X" % Attributes)
 
         ##import pdb; pdb.set_trace()
 
         for b in range(8):
-            PrimaryGPT[i] = ((Attributes>>(b*8)) & 0xFF)
-            i+=1
+            PrimaryGPT[i] = (Attributes >> (b * 8)) & 0xFF
+            i += 1
 
-        if len(PhyPartition[k][j]['label'])>36:
-            print("Label %s is more than 36 characters, therefore it's truncated" % PhyPartition[k][j]['label'])
-            PhyPartition[k][j]['label'] = PhyPartition[k][j]['label'][0:36]
+        if len(PhyPartition[k][j]["label"]) > 36:
+            print(
+                "Label %s is more than 36 characters, therefore it's truncated"
+                % PhyPartition[k][j]["label"]
+            )
+            PhyPartition[k][j]["label"] = PhyPartition[k][j]["label"][0:36]
 
-        #print "LABEL %s and i=%i" % (PhyPartition[k][j]['label'],i)
+        # print "LABEL %s and i=%i" % (PhyPartition[k][j]['label'],i)
         # Partition Name
-        for b in PhyPartition[k][j]['label']:
+        for b in PhyPartition[k][j]["label"]:
             PrimaryGPT[i] = ord(b)
-            i+=1
+            i += 1
             PrimaryGPT[i] = 0x00
-            i+=1
+            i += 1
 
-        for b in range(36-len(PhyPartition[k][j]['label'])):
+        for b in range(36 - len(PhyPartition[k][j]["label"])):
             PrimaryGPT[i] = 0x00
-            i+=1
+            i += 1
             PrimaryGPT[i] = 0x00
-            i+=1
+            i += 1
 
-        #for b in range(2):
+        # for b in range(2):
         #    PrimaryGPT[i] = 0x00 ; i+=1
-        #for b in range(70):
+        # for b in range(70):
         #    PrimaryGPT[i] = 0x00 ; i+=1
 
         ##FileToProgram   = ""
         ##FileOffset      = 0
-        PartitionLabel  = ""
+        PartitionLabel = ""
 
         ## Default for each partition is no file
-        FileToProgram           = [""]
-        FileOffset              = [0]
-        FilePartitionOffset     = [0]
-        FileAppsbin             = ["false"]
-        FileSparse              = ["false"]
+        FileToProgram = [""]
+        FileOffset = [0]
+        FilePartitionOffset = [0]
+        FileAppsbin = ["false"]
+        FileSparse = ["false"]
 
-        if 'filename' in PhyPartition[k][j]:
+        if "filename" in PhyPartition[k][j]:
             ##print "filename exists"
-            #print PhyPartition[k][j]['filename']
-            #print FileToProgram[0]
+            # print PhyPartition[k][j]['filename']
+            # print FileToProgram[0]
 
-        # These are all the default values that should be there, including an empty string possibly for filename
-            FileToProgram[0]            = PhyPartition[k][j]['filename'][0]
-            FileOffset[0]               = PhyPartition[k][j]['fileoffset'][0]
-            FilePartitionOffset[0]      = PhyPartition[k][j]['filepartitionoffset'][0]
-            FileAppsbin[0]              = PhyPartition[k][j]['appsbin'][0]
-            FileSparse[0]               = PhyPartition[k][j]['sparse'][0]
+            # These are all the default values that should be there, including an empty string possibly for filename
+            FileToProgram[0] = PhyPartition[k][j]["filename"][0]
+            FileOffset[0] = PhyPartition[k][j]["fileoffset"][0]
+            FilePartitionOffset[0] = PhyPartition[k][j]["filepartitionoffset"][0]
+            FileAppsbin[0] = PhyPartition[k][j]["appsbin"][0]
+            FileSparse[0] = PhyPartition[k][j]["sparse"][0]
 
-            for z in range(1,len(PhyPartition[k][j]['filename'])):
-                FileToProgram.append( PhyPartition[k][j]['filename'][z] )
-                FileOffset.append( PhyPartition[k][j]['fileoffset'][z] )
-                FilePartitionOffset.append( PhyPartition[k][j]['filepartitionoffset'][z] )
-                FileAppsbin.append( PhyPartition[k][j]['appsbin'][z] )
-                FileSparse.append( PhyPartition[k][j]['sparse'][z] )
+            for z in range(1, len(PhyPartition[k][j]["filename"])):
+                FileToProgram.append(PhyPartition[k][j]["filename"][z])
+                FileOffset.append(PhyPartition[k][j]["fileoffset"][z])
+                FilePartitionOffset.append(PhyPartition[k][j]["filepartitionoffset"][z])
+                FileAppsbin.append(PhyPartition[k][j]["appsbin"][z])
+                FileSparse.append(PhyPartition[k][j]["sparse"][z])
 
-            #print PhyPartition[k][j]['fileoffset']
+            # print PhyPartition[k][j]['fileoffset']
 
-
-        #for z in range(len(FileToProgram)):
+        # for z in range(len(FileToProgram)):
         #    print "FileToProgram[",z,"]=",FileToProgram[z]
         #    print "FileOffset[",z,"]=",FileOffset[z]
         #    print " "
 
-
-        if 'label' in PhyPartition[k][j]:
-            PartitionLabel = PhyPartition[k][j]['label']
+        if "label" in PhyPartition[k][j]:
+            PartitionLabel = PhyPartition[k][j]["label"]
 
         for z in range(len(FileToProgram)):
-        #print "===============================%i of %i===========================================" % (z,len(FileToProgram))
-            #print "File: ",FileToProgram[z]
-            #print "Label: ",FileToProgram[z]
-            #print "FilePartitionOffset[z]=",FilePartitionOffset[z]
-            #print "UpdateRawProgram(RawProgramXML,",(FirstLBA+FilePartitionOffset[z]),",",((LastLBA-FirstLBA)*SECTOR_SIZE_IN_BYTES/1024.0),",",PhysicalPartitionNumber,",",FileOffset[z],",",(LastLBA-FirstLBA-FilePartitionOffset[z]),",",(FileToProgram[z]),",", PartitionLabel,")"
-            #print "LastLBA=",LastLBA
-            #print "FirstLBA=",FirstLBA
-            #print "FilePartitionOffset[z]=",FilePartitionOffset[z]
-            UpdateRawProgram(RawProgramXML,
-                             FirstLBA+FilePartitionOffset[z], # Start sector
-                             ((LastLBA-FirstLBA+1))*SECTOR_SIZE_IN_BYTES/1024.0, # Size in KB
-                             PhysicalPartitionNumber,
-                             FileOffset[z],
-                             LastLBA-FirstLBA+1 - FilePartitionOffset[z], # num_partition_sectors
-                             FileToProgram[z],
-                             FileSparse[z],
-                             PartitionLabel,
-                             PhyPartition[k][j]['readbackverify'],
-                             PhyPartition[k][j]['partofsingleimage'])
-            if (j+1) == len(PhyPartition[k]):
+            # print "===============================%i of %i===========================================" % (z,len(FileToProgram))
+            # print "File: ",FileToProgram[z]
+            # print "Label: ",FileToProgram[z]
+            # print "FilePartitionOffset[z]=",FilePartitionOffset[z]
+            # print "UpdateRawProgram(RawProgramXML,",(FirstLBA+FilePartitionOffset[z]),",",((LastLBA-FirstLBA)*SECTOR_SIZE_IN_BYTES/1024.0),",",PhysicalPartitionNumber,",",FileOffset[z],",",(LastLBA-FirstLBA-FilePartitionOffset[z]),",",(FileToProgram[z]),",", PartitionLabel,")"
+            # print "LastLBA=",LastLBA
+            # print "FirstLBA=",FirstLBA
+            # print "FilePartitionOffset[z]=",FilePartitionOffset[z]
+            UpdateRawProgram(
+                RawProgramXML,
+                FirstLBA + FilePartitionOffset[z],  # Start sector
+                ((LastLBA - FirstLBA + 1))
+                * SECTOR_SIZE_IN_BYTES
+                / 1024.0,  # Size in KB
+                PhysicalPartitionNumber,
+                FileOffset[z],
+                LastLBA
+                - FirstLBA
+                + 1
+                - FilePartitionOffset[z],  # num_partition_sectors
+                FileToProgram[z],
+                FileSparse[z],
+                PartitionLabel,
+                PhyPartition[k][j]["readbackverify"],
+                PhyPartition[k][j]["partofsingleimage"],
+            )
+            if (j + 1) == len(PhyPartition[k]):
                 ## last partition, and if GROW was set to True, it will only have a size of 0
-                UpdateRawProgram(RawProgramXML_Wipe,
-                                 FirstLBA+FilePartitionOffset[z], #Start Sector
-                                 (ConvertKBtoSectors(PhyPartition[k][j]['original_size_in_kb'])+(LastLBA-FirstLBA)+1)*SECTOR_SIZE_IN_BYTES/1024.0, # Size in KB
-                                 PhysicalPartitionNumber,
-                                 FileOffset[z],
-                                 ConvertKBtoSectors(PhyPartition[k][j]['original_size_in_kb'])+LastLBA-FirstLBA+1-FilePartitionOffset[z],
-                                 "zeros_%dsectors.bin" % BackupGPTNumLBAs,
-                                 "false",
-                                 PartitionLabel,
-                                 PhyPartition[k][j]['readbackverify'],
-                                 PhyPartition[k][j]['partofsingleimage'])
+                UpdateRawProgram(
+                    RawProgramXML_Wipe,
+                    FirstLBA + FilePartitionOffset[z],  # Start Sector
+                    (
+                        ConvertKBtoSectors(PhyPartition[k][j]["original_size_in_kb"])
+                        + (LastLBA - FirstLBA)
+                        + 1
+                    )
+                    * SECTOR_SIZE_IN_BYTES
+                    / 1024.0,  # Size in KB
+                    PhysicalPartitionNumber,
+                    FileOffset[z],
+                    ConvertKBtoSectors(PhyPartition[k][j]["original_size_in_kb"])
+                    + LastLBA
+                    - FirstLBA
+                    + 1
+                    - FilePartitionOffset[z],
+                    "zeros_%dsectors.bin" % BackupGPTNumLBAs,
+                    "false",
+                    PartitionLabel,
+                    PhyPartition[k][j]["readbackverify"],
+                    PhyPartition[k][j]["partofsingleimage"],
+                )
             else:
-                UpdateRawProgram(RawProgramXML_Wipe,
-                                 FirstLBA+FilePartitionOffset[z], # Start Sector
-                                 ((LastLBA-FirstLBA)+1)*SECTOR_SIZE_IN_BYTES/1024.0,  # Size in KB
-                                 PhysicalPartitionNumber,
-                                 FileOffset[z],
-                                 LastLBA-FirstLBA+1-FilePartitionOffset[z], # num_partition_sectors
-                                 "zeros_%dsectors.bin" % BackupGPTNumLBAs,
-                                 "false",
-                                 PartitionLabel,
-                                 PhyPartition[k][j]['readbackverify'],
-                                 PhyPartition[k][j]['partofsingleimage'])
+                UpdateRawProgram(
+                    RawProgramXML_Wipe,
+                    FirstLBA + FilePartitionOffset[z],  # Start Sector
+                    ((LastLBA - FirstLBA) + 1)
+                    * SECTOR_SIZE_IN_BYTES
+                    / 1024.0,  # Size in KB
+                    PhysicalPartitionNumber,
+                    FileOffset[z],
+                    LastLBA
+                    - FirstLBA
+                    + 1
+                    - FilePartitionOffset[z],  # num_partition_sectors
+                    "zeros_%dsectors.bin" % BackupGPTNumLBAs,
+                    "false",
+                    PartitionLabel,
+                    PhyPartition[k][j]["readbackverify"],
+                    PhyPartition[k][j]["partofsingleimage"],
+                )
 
-            if j==0:
-                UpdateRawProgram(RawProgramXML_Blank,0, PrimaryGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, PhysicalPartitionNumber, FileOffset[z], PrimaryGPTNumLBAs, "gpt_empty%d.bin" % k, "false", "PrimaryGPT", "false", "false")
+            if j == 0:
+                UpdateRawProgram(
+                    RawProgramXML_Blank,
+                    0,
+                    PrimaryGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+                    PhysicalPartitionNumber,
+                    FileOffset[z],
+                    PrimaryGPTNumLBAs,
+                    "gpt_empty%d.bin" % k,
+                    "false",
+                    "PrimaryGPT",
+                    "false",
+                    "false",
+                )
 
+        LastLBA += (
+            1  ## move to the next free sector, also, 0 to 9 inclusive means it's 10
+        )
+        ## so below (LastLBA-FirstLBA) must = 10
 
-        LastLBA += 1    ## move to the next free sector, also, 0 to 9 inclusive means it's 10
-                        ## so below (LastLBA-FirstLBA) must = 10
-
-        FirstLBA = LastLBA      # getting ready for next partition, FirstLBA is now where we left off
-
+        FirstLBA = LastLBA  # getting ready for next partition, FirstLBA is now where we left off
 
     ## Still working on *this* PHY partition
 
@@ -790,438 +1197,788 @@ def CreateGPTPartitionTable(PhysicalPartitionNumber,UserProvided=False):
 
     i = 0x1BE
 
-    PrimaryGPT[i+0]         = 0x00                  # not bootable
-    PrimaryGPT[i+1]         = 0x00                  # head
-    PrimaryGPT[i+2]         = 0x01                  # sector
-    PrimaryGPT[i+3]         = 0x00                  # cylinder
-    PrimaryGPT[i+4]         = 0xEE                  # type
-    PrimaryGPT[i+5]         = 0xFF                  # head
-    PrimaryGPT[i+6]         = 0xFF                  # sector
-    PrimaryGPT[i+7]         = 0xFF                  # cylinder
-    PrimaryGPT[i+8:i+8+4]   = [0x01,0x00,0x00,0x00] # starting sector
-    PrimaryGPT[i+12:i+12+4] = [0xFF,0xFF,0xFF,0xFF] # starting sector
+    PrimaryGPT[i + 0] = 0x00  # not bootable
+    PrimaryGPT[i + 1] = 0x00  # head
+    PrimaryGPT[i + 2] = 0x01  # sector
+    PrimaryGPT[i + 3] = 0x00  # cylinder
+    PrimaryGPT[i + 4] = 0xEE  # type
+    PrimaryGPT[i + 5] = 0xFF  # head
+    PrimaryGPT[i + 6] = 0xFF  # sector
+    PrimaryGPT[i + 7] = 0xFF  # cylinder
+    PrimaryGPT[i + 8 : i + 8 + 4] = [0x01, 0x00, 0x00, 0x00]  # starting sector
+    PrimaryGPT[i + 12 : i + 12 + 4] = [0xFF, 0xFF, 0xFF, 0xFF]  # starting sector
 
-    PrimaryGPT[440]         = (HashInstructions['DISK_SIGNATURE'])&0xFF
-    PrimaryGPT[441]         = (HashInstructions['DISK_SIGNATURE']>>8)&0xFF
-    PrimaryGPT[442]         = (HashInstructions['DISK_SIGNATURE']>>16)&0xFF
-    PrimaryGPT[443]         = (HashInstructions['DISK_SIGNATURE']>>24)&0xFF
+    PrimaryGPT[440] = (HashInstructions["DISK_SIGNATURE"]) & 0xFF
+    PrimaryGPT[441] = (HashInstructions["DISK_SIGNATURE"] >> 8) & 0xFF
+    PrimaryGPT[442] = (HashInstructions["DISK_SIGNATURE"] >> 16) & 0xFF
+    PrimaryGPT[443] = (HashInstructions["DISK_SIGNATURE"] >> 24) & 0xFF
 
-    PrimaryGPT[510:512]     = [0x55,0xAA]           # magic byte for MBR partitioning - always at this location regardless of SECTOR_SIZE_IN_BYTES
+    PrimaryGPT[510:512] = [
+        0x55,
+        0xAA,
+    ]  # magic byte for MBR partitioning - always at this location regardless of SECTOR_SIZE_IN_BYTES
 
     i = SECTOR_SIZE_IN_BYTES
     ## Signature and Revision and HeaderSize i.e. "EFI PART" and 00 00 01 00 and 5C 00 00 00
-    PrimaryGPT[i:i+16] = [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54, 0x00, 0x00, 0x01, 0x00, 0x5C, 0x00, 0x00, 0x00]
-    i+=16
+    PrimaryGPT[i : i + 16] = [
+        0x45,
+        0x46,
+        0x49,
+        0x20,
+        0x50,
+        0x41,
+        0x52,
+        0x54,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x5C,
+        0x00,
+        0x00,
+        0x00,
+    ]
+    i += 16
 
-    PrimaryGPT[i:i+4] = [0x00, 0x00, 0x00, 0x00]
-    i+=4  ## CRC is zeroed out till calculated later
-    PrimaryGPT[i:i+4] = [0x00, 0x00, 0x00, 0x00]
-    i+=4  ## Reserved, set to 0
+    PrimaryGPT[i : i + 4] = [0x00, 0x00, 0x00, 0x00]
+    i += 4  ## CRC is zeroed out till calculated later
+    PrimaryGPT[i : i + 4] = [0x00, 0x00, 0x00, 0x00]
+    i += 4  ## Reserved, set to 0
 
     # Update the field that says the LBA of the header, for Primary it is always 1.
-    i = UpdatePrimaryGPT(1,8,i)
+    i = UpdatePrimaryGPT(1, 8, i)
     LastUseableLBA = LastLBA - 1
     BackupLBA = LastUseableLBA + BackupGPTNumLBAs
-    print("BackupLBA {0} = LastUseableLBA {1} + BackupGPTNumLBAs {2}".format(    BackupLBA, LastUseableLBA , BackupGPTNumLBAs))
-    #Update GPT Backup LBA, this field may be updated by patching.
-    i = UpdatePrimaryGPT(BackupLBA,8,i)
-    FirstLBA  = PrimaryGPTNumLBAs
-    i = UpdatePrimaryGPT(FirstLBA,8,i)
-    i = UpdatePrimaryGPT(LastUseableLBA,8,i)
+    print(
+        "BackupLBA {0} = LastUseableLBA {1} + BackupGPTNumLBAs {2}".format(
+            BackupLBA, LastUseableLBA, BackupGPTNumLBAs
+        )
+    )
+    # Update GPT Backup LBA, this field may be updated by patching.
+    i = UpdatePrimaryGPT(BackupLBA, 8, i)
+    FirstLBA = PrimaryGPTNumLBAs
+    i = UpdatePrimaryGPT(FirstLBA, 8, i)
+    i = UpdatePrimaryGPT(LastUseableLBA, 8, i)
 
     ##print "\n\nBackup GPT is at sector %i" % BackupLBA
     ##print "Last Usable LBA is at sector %i" % (LastLBA)
 
-    DiskGUID = random.randint(0,2**(128))
-    i = UpdatePrimaryGPT(DiskGUID,16,i)
+    DiskGUID = random.randint(0, 2 ** (128))
+    i = UpdatePrimaryGPT(DiskGUID, 16, i)
 
     PartitionsLBA = 2
-    i = UpdatePrimaryGPT(PartitionsLBA,8,i)
+    i = UpdatePrimaryGPT(PartitionsLBA, 8, i)
 
-    NumPartitions = (SECTOR_SIZE_IN_BYTES/128)*int(len(PhyPartition[k])/(SECTOR_SIZE_IN_BYTES/128))  # Want a multiple of (SECTOR_SIZE_IN_BYTES) to fill the sector (avoids gdisk warning)
-    if (len(PhyPartition[k])%(SECTOR_SIZE_IN_BYTES/128))>0:
-        NumPartitions+=(SECTOR_SIZE_IN_BYTES/128)
+    NumPartitions = (SECTOR_SIZE_IN_BYTES / 128) * int(
+        len(PhyPartition[k]) / (SECTOR_SIZE_IN_BYTES / 128)
+    )  # Want a multiple of (SECTOR_SIZE_IN_BYTES) to fill the sector (avoids gdisk warning)
+    if (len(PhyPartition[k]) % (SECTOR_SIZE_IN_BYTES / 128)) > 0:
+        NumPartitions += SECTOR_SIZE_IN_BYTES / 128
 
     if force128partitions == 1:
-        print("\n\nGPT table will list 128 partitions instead of ",NumPartitions)
+        print("\n\nGPT table will list 128 partitions instead of ", NumPartitions)
         print("This makes the output compatible with some older test utilities")
         NumPartitions = 128
 
-    i = UpdatePrimaryGPT(NumPartitions,4,i) ## (offset 80) Number of partition entries
+    i = UpdatePrimaryGPT(
+        NumPartitions, 4, i
+    )  ## (offset 80) Number of partition entries
     ##NumPartitions = 8    ;   i = UpdatePrimaryGPT(NumPartitions,4,i) ## (offset 80) Number of partition entries
     SizeOfPartitionArray = 128
-    i = UpdatePrimaryGPT(SizeOfPartitionArray,4,i) ## (offset 84) Size of partition entries
+    i = UpdatePrimaryGPT(
+        SizeOfPartitionArray, 4, i
+    )  ## (offset 84) Size of partition entries
 
     ## Now I can calculate the partitions CRC
-    print("\n\nCalculating CRC with NumPartitions=%i, SizeOfPartitionArray=%i (bytes each) TOTAL LENGTH %d" % (NumPartitions,SizeOfPartitionArray,NumPartitions*SizeOfPartitionArray))
+    print(
+        "\n\nCalculating CRC with NumPartitions=%i, SizeOfPartitionArray=%i (bytes each) TOTAL LENGTH %d"
+        % (NumPartitions, SizeOfPartitionArray, NumPartitions * SizeOfPartitionArray)
+    )
     ##PartitionsCRC = CalcCRC32(PrimaryGPT[1024:],NumPartitions*SizeOfPartitionArray)  ## Each partition entry is 128 bytes
 
+    PartitionsPerSector = SECTOR_SIZE_IN_BYTES // 128  ## 128 bytes per partition
 
-    PartitionsPerSector = SECTOR_SIZE_IN_BYTES//128  ## 128 bytes per partition
-
-    if NumPartitions>PartitionsPerSector:
-        SectorsToCalculateCRCOver = NumPartitions//PartitionsPerSector
-        if NumPartitions%PartitionsPerSector:
-            SectorsToCalculateCRCOver+=1
+    if NumPartitions > PartitionsPerSector:
+        SectorsToCalculateCRCOver = NumPartitions // PartitionsPerSector
+        if NumPartitions % PartitionsPerSector:
+            SectorsToCalculateCRCOver += 1
     else:
         SectorsToCalculateCRCOver = 1
 
-    PartitionsCRC = CalcCRC32(PrimaryGPT[(2*SECTOR_SIZE_IN_BYTES):],SectorsToCalculateCRCOver * SECTOR_SIZE_IN_BYTES)  ## NAND HACK
-    i = UpdatePrimaryGPT(PartitionsCRC,4,i)
+    PartitionsCRC = CalcCRC32(
+        PrimaryGPT[(2 * SECTOR_SIZE_IN_BYTES) :],
+        SectorsToCalculateCRCOver * SECTOR_SIZE_IN_BYTES,
+    )  ## NAND HACK
+    i = UpdatePrimaryGPT(PartitionsCRC, 4, i)
     print("\n\nCalculated PARTITION CRC is 0x%.8X" % PartitionsCRC)
 
-    #Compute the CRC over the header.
-    CalcHeaderCRC = CalcCRC32(PrimaryGPT[SECTOR_SIZE_IN_BYTES:],92)
-    UpdatePrimaryGPT(CalcHeaderCRC,4,SECTOR_SIZE_IN_BYTES+16)
-
+    # Compute the CRC over the header.
+    CalcHeaderCRC = CalcCRC32(PrimaryGPT[SECTOR_SIZE_IN_BYTES:], 92)
+    UpdatePrimaryGPT(CalcHeaderCRC, 4, SECTOR_SIZE_IN_BYTES + 16)
 
     if gen_patch:
         ## gpt patch - main gpt header - last useable lba
-        ByteOffset          = str(48)
-        StartSector         = str(1)
-        BackupStartSector   = str(BackupGPTNumLBAs-1)  ## Want last sector    ##str(32)
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,os.path.basename(GPTMAIN), "Update Primary Header with LastUseableLBA.")
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,"DISK",               "Update Primary Header with LastUseableLBA.")
-        UpdatePatch(BackupStartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,os.path.basename(GPTBACKUP), "Update Backup Header with LastUseableLBA.")
-        UpdatePatch("NUM_DISK_SECTORS-1.",ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,"DISK",             "Update Backup Header with LastUseableLBA.")
+        ByteOffset = str(48)
+        StartSector = str(1)
+        BackupStartSector = str(BackupGPTNumLBAs - 1)  ## Want last sector    ##str(32)
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+            os.path.basename(GPTMAIN),
+            "Update Primary Header with LastUseableLBA.",
+        )
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+            "DISK",
+            "Update Primary Header with LastUseableLBA.",
+        )
+        UpdatePatch(
+            BackupStartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+            os.path.basename(GPTBACKUP),
+            "Update Backup Header with LastUseableLBA.",
+        )
+        UpdatePatch(
+            "NUM_DISK_SECTORS-1.",
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-%d." % PrimaryGPTNumLBAs,
+            "DISK",
+            "Update Backup Header with LastUseableLBA.",
+        )
 
         # gpt patch - location of backup gpt header ##########################################
-        ByteOffset          = str(32)
-        StartSector         = str(1)
+        ByteOffset = str(32)
+        StartSector = str(1)
         ## gpt patch - main gpt header
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-1.",os.path.basename(GPTMAIN), "Update Primary Header with BackupGPT Header Location.")
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-1.","DISK",               "Update Primary Header with BackupGPT Header Location.")
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-1.",
+            os.path.basename(GPTMAIN),
+            "Update Primary Header with BackupGPT Header Location.",
+        )
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-1.",
+            "DISK",
+            "Update Primary Header with BackupGPT Header Location.",
+        )
 
         # gpt patch - currentLBA backup header ##########################################
-        ByteOffset          = str(24)
-        BackupStartSector   = str(BackupGPTNumLBAs-1)  ## Want last sector    ##str(32)
+        ByteOffset = str(24)
+        BackupStartSector = str(BackupGPTNumLBAs - 1)  ## Want last sector    ##str(32)
         ## gpt patch - main gpt header
-        UpdatePatch(BackupStartSector,    ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-1.",os.path.basename(GPTBACKUP), "Update Backup Header with CurrentLBA.")
-        UpdatePatch("NUM_DISK_SECTORS-1.",ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-1.","DISK",                 "Update Backup Header with CurrentLBA.")
+        UpdatePatch(
+            BackupStartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-1.",
+            os.path.basename(GPTBACKUP),
+            "Update Backup Header with CurrentLBA.",
+        )
+        UpdatePatch(
+            "NUM_DISK_SECTORS-1.",
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-1.",
+            "DISK",
+            "Update Backup Header with CurrentLBA.",
+        )
 
         # gpt patch - location of backup gpt header ##########################################
-        ByteOffset          = str(72)
-        BackupStartSector   = str(BackupGPTNumLBAs-1)  ## Want last sector    ##str(32)
+        ByteOffset = str(72)
+        BackupStartSector = str(BackupGPTNumLBAs - 1)  ## Want last sector    ##str(32)
 
         ## gpt patch - main gpt header
-        UpdatePatch(BackupStartSector,   ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % BackupGPTNumLBAs,os.path.basename(GPTBACKUP), "Update Backup Header with Partition Array Location.")
-        UpdatePatch("NUM_DISK_SECTORS-1",ByteOffset,PhysicalPartitionNumber,8,"NUM_DISK_SECTORS-%d." % BackupGPTNumLBAs,"DISK",                 "Update Backup Header with Partition Array Location.")
+        UpdatePatch(
+            BackupStartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-%d." % BackupGPTNumLBAs,
+            os.path.basename(GPTBACKUP),
+            "Update Backup Header with Partition Array Location.",
+        )
+        UpdatePatch(
+            "NUM_DISK_SECTORS-1",
+            ByteOffset,
+            PhysicalPartitionNumber,
+            8,
+            "NUM_DISK_SECTORS-%d." % BackupGPTNumLBAs,
+            "DISK",
+            "Update Backup Header with Partition Array Location.",
+        )
 
         # gpt patch - Partition Array CRC ################################################
-        ByteOffset          = str(88)
-        StartSector         = str(1)
-        BackupStartSector   = str(BackupGPTNumLBAs-1)  ## Want last sector    ##str(32)
+        ByteOffset = str(88)
+        StartSector = str(1)
+        BackupStartSector = str(BackupGPTNumLBAs - 1)  ## Want last sector    ##str(32)
 
         ## gpt patch - main gpt header
         # Add some patch tag that does nothing to keep XML parsers happy.
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,4,"CRC32(2,%d)" % (NumPartitions*SizeOfPartitionArray),os.path.basename(GPTMAIN), "Update Primary Header with CRC of Partition Array.") # CRC32(start_sector:num_bytes)
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,4,"CRC32(2,%d)" % (NumPartitions*SizeOfPartitionArray),"DISK",               "Update Primary Header with CRC of Partition Array.") # CRC32(start_sector:num_bytes)
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(2,%d)" % (NumPartitions * SizeOfPartitionArray),
+            os.path.basename(GPTMAIN),
+            "Update Primary Header with CRC of Partition Array.",
+        )  # CRC32(start_sector:num_bytes)
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(2,%d)" % (NumPartitions * SizeOfPartitionArray),
+            "DISK",
+            "Update Primary Header with CRC of Partition Array.",
+        )  # CRC32(start_sector:num_bytes)
 
         ## gpt patch - backup gpt header
-        UpdatePatch(BackupStartSector,    ByteOffset,PhysicalPartitionNumber,4,"CRC32(0,%d)" % (NumPartitions*SizeOfPartitionArray),os.path.basename(GPTBACKUP), "Update Backup Header with CRC of Partition Array.")   # CRC32(start_sector:num_bytes)
-        UpdatePatch("NUM_DISK_SECTORS-1.",ByteOffset,PhysicalPartitionNumber,4,"CRC32(NUM_DISK_SECTORS-%d.,%d)" % (BackupGPTNumLBAs,NumPartitions*SizeOfPartitionArray),"DISK",                 "Update Backup Header with CRC of Partition Array.")   # CRC32(start_sector:num_bytes)
-
+        UpdatePatch(
+            BackupStartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(0,%d)" % (NumPartitions * SizeOfPartitionArray),
+            os.path.basename(GPTBACKUP),
+            "Update Backup Header with CRC of Partition Array.",
+        )  # CRC32(start_sector:num_bytes)
+        UpdatePatch(
+            "NUM_DISK_SECTORS-1.",
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(NUM_DISK_SECTORS-%d.,%d)"
+            % (BackupGPTNumLBAs, NumPartitions * SizeOfPartitionArray),
+            "DISK",
+            "Update Backup Header with CRC of Partition Array.",
+        )  # CRC32(start_sector:num_bytes)
 
     # gpt patch - Header CRC ################################################
-    ByteOffset          = str(16)
-    StartSector         = str(1)
-    BackupStartSector   = str(BackupGPTNumLBAs-1)  ## Want last sector    ##str(32)
+    ByteOffset = str(16)
+    StartSector = str(1)
+    BackupStartSector = str(BackupGPTNumLBAs - 1)  ## Want last sector    ##str(32)
     # Add some PATCH entries that have no effect in programming to keep XML parser happy, since they expect to see a <patch
     ## gpt patch - main gpt header
-    UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,4,"0",os.path.basename(GPTMAIN), "Zero Out Header CRC in Primary Header.")      # zero out old CRC first
-    UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,4,"CRC32(1,92)",os.path.basename(GPTMAIN), "Update Primary Header with CRC of Primary Header.") # CRC32(start_sector:num_bytes)
+    UpdatePatch(
+        StartSector,
+        ByteOffset,
+        PhysicalPartitionNumber,
+        4,
+        "0",
+        os.path.basename(GPTMAIN),
+        "Zero Out Header CRC in Primary Header.",
+    )  # zero out old CRC first
+    UpdatePatch(
+        StartSector,
+        ByteOffset,
+        PhysicalPartitionNumber,
+        4,
+        "CRC32(1,92)",
+        os.path.basename(GPTMAIN),
+        "Update Primary Header with CRC of Primary Header.",
+    )  # CRC32(start_sector:num_bytes)
     if gen_patch:
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,4,"0",          "DISK", "Zero Out Header CRC in Primary Header.")      # zero out old CRC first
-        UpdatePatch(StartSector,ByteOffset,PhysicalPartitionNumber,4,"CRC32(1,92)","DISK", "Update Primary Header with CRC of Primary Header.") # CRC32(start_sector:num_bytes)
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "0",
+            "DISK",
+            "Zero Out Header CRC in Primary Header.",
+        )  # zero out old CRC first
+        UpdatePatch(
+            StartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(1,92)",
+            "DISK",
+            "Update Primary Header with CRC of Primary Header.",
+        )  # CRC32(start_sector:num_bytes)
 
         ## gpt patch - backup gpt header
-        #import pdb; pdb.set_trace()
-        UpdatePatch(BackupStartSector,ByteOffset,PhysicalPartitionNumber,4,"0",os.path.basename(GPTBACKUP), "Zero Out Header CRC in Backup Header.")      # zero out old CRC first
-        UpdatePatch(BackupStartSector,ByteOffset,PhysicalPartitionNumber,4,"CRC32(%s,92)" % BackupStartSector,os.path.basename(GPTBACKUP), "Update Backup Header with CRC of Backup Header.")  # CRC32(start_sector:num_bytes)
+        # import pdb; pdb.set_trace()
+        UpdatePatch(
+            BackupStartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "0",
+            os.path.basename(GPTBACKUP),
+            "Zero Out Header CRC in Backup Header.",
+        )  # zero out old CRC first
+        UpdatePatch(
+            BackupStartSector,
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(%s,92)" % BackupStartSector,
+            os.path.basename(GPTBACKUP),
+            "Update Backup Header with CRC of Backup Header.",
+        )  # CRC32(start_sector:num_bytes)
 
-        UpdatePatch("NUM_DISK_SECTORS-1.",ByteOffset,PhysicalPartitionNumber,4,"0",           "DISK", "Zero Out Header CRC in Backup Header.")      # zero out old CRC first
-        UpdatePatch("NUM_DISK_SECTORS-1.",ByteOffset,PhysicalPartitionNumber,4,"CRC32(NUM_DISK_SECTORS-1.,92)","DISK", "Update Backup Header with CRC of Backup Header.")  # CRC32(start_sector:num_bytes)
+        UpdatePatch(
+            "NUM_DISK_SECTORS-1.",
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "0",
+            "DISK",
+            "Zero Out Header CRC in Backup Header.",
+        )  # zero out old CRC first
+        UpdatePatch(
+            "NUM_DISK_SECTORS-1.",
+            ByteOffset,
+            PhysicalPartitionNumber,
+            4,
+            "CRC32(NUM_DISK_SECTORS-1.,92)",
+            "DISK",
+            "Update Backup Header with CRC of Backup Header.",
+        )  # CRC32(start_sector:num_bytes)
 
     ## now create the backup GPT partitions
-    BackupGPT       = [0xFF]*(int(BackupGPTNumLBAs)*SECTOR_SIZE_IN_BYTES)
-    BackupGPT[0:]   = PrimaryGPT[2*SECTOR_SIZE_IN_BYTES:]
+    BackupGPT = [0xFF] * (int(BackupGPTNumLBAs) * SECTOR_SIZE_IN_BYTES)
+    BackupGPT[0:] = PrimaryGPT[2 * SECTOR_SIZE_IN_BYTES :]
 
     ## now create the backup GPT header
 
-    BackupGPT[int(BackupGPTNumLBAs-1)*SECTOR_SIZE_IN_BYTES:int(BackupGPTNumLBAs)*SECTOR_SIZE_IN_BYTES]= PrimaryGPT[1*SECTOR_SIZE_IN_BYTES:2*SECTOR_SIZE_IN_BYTES] ##BackupGPTNumLBAs=33
-    #ShowBackupGPT(32)
+    BackupGPT[
+        int(BackupGPTNumLBAs - 1)
+        * SECTOR_SIZE_IN_BYTES : int(BackupGPTNumLBAs)
+        * SECTOR_SIZE_IN_BYTES
+    ] = PrimaryGPT[
+        1 * SECTOR_SIZE_IN_BYTES : 2 * SECTOR_SIZE_IN_BYTES
+    ]  ##BackupGPTNumLBAs=33
+    # ShowBackupGPT(32)
 
     ## Need to update CurrentLBA, BackupLBA and then recalc CRC for this header
-    i = int(BackupGPTNumLBAs-1)*SECTOR_SIZE_IN_BYTES+8+4+4
-    i = UpdateBackupGPT(0, 4, i)  ## zero out CRC for the header, will be computed later.
+    i = int(BackupGPTNumLBAs - 1) * SECTOR_SIZE_IN_BYTES + 8 + 4 + 4
+    i = UpdateBackupGPT(
+        0, 4, i
+    )  ## zero out CRC for the header, will be computed later.
     i = UpdateBackupGPT(0, 4, i)  ## reserved 4 zeros
 
     # Update the field that says the LBA of this header.
-    i = UpdateBackupGPT(BackupLBA,8,i)
+    i = UpdateBackupGPT(BackupLBA, 8, i)
     # Update the field that says the LBA of the other header.
-    i = UpdateBackupGPT(1,8,i)
+    i = UpdateBackupGPT(1, 8, i)
 
-    #print "\n\nBackup GPT is at sector %i" % CurrentLBA
-    #print "Last Usable LBA is at sector %i" % (CurrentLBA-33)
+    # print "\n\nBackup GPT is at sector %i" % CurrentLBA
+    # print "Last Usable LBA is at sector %i" % (CurrentLBA-33)
 
-    i += 8+8+16
+    i += 8 + 8 + 16
     BackupTableLBA = BackupLBA - BackupGPTNumLBAs + 1
     i = UpdateBackupGPT(BackupTableLBA, 8, i)
-    #print "PartitionsLBA = %d (0x%X)" % (PartitionsLBA,PartitionsLBA)
+    # print "PartitionsLBA = %d (0x%X)" % (PartitionsLBA,PartitionsLBA)
 
     ##print "\nCalculating CRC for Backup Header"
-    CalcHeaderCRC = CalcCRC32(BackupGPT[int(BackupGPTNumLBAs-1)*SECTOR_SIZE_IN_BYTES:],92)
-    #print "\nCalcHeaderCRC of BackupGPT is 0x%.8X" % CalcHeaderCRC
-    i = int(BackupGPTNumLBAs-1)*SECTOR_SIZE_IN_BYTES+8+4+4
-    i = UpdateBackupGPT(CalcHeaderCRC,4,i)  ## zero out CRC
+    CalcHeaderCRC = CalcCRC32(
+        BackupGPT[int(BackupGPTNumLBAs - 1) * SECTOR_SIZE_IN_BYTES :], 92
+    )
+    # print "\nCalcHeaderCRC of BackupGPT is 0x%.8X" % CalcHeaderCRC
+    i = int(BackupGPTNumLBAs - 1) * SECTOR_SIZE_IN_BYTES + 8 + 4 + 4
+    i = UpdateBackupGPT(CalcHeaderCRC, 4, i)  ## zero out CRC
 
-    #ShowBackupGPT(32)
+    # ShowBackupGPT(32)
 
-    UpdateRawProgram(RawProgramXML,0,       PrimaryGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, PhysicalPartitionNumber, 0, PrimaryGPTNumLBAs, os.path.basename(GPTMAIN), 'false', 'PrimaryGPT','false','true')
-    UpdateRawProgram(RawProgramXML_Wipe,0,  1*SECTOR_SIZE_IN_BYTES/1024.0, PhysicalPartitionNumber, 0,  1, "zeros_1sector.bin", 'false', 'PrimaryGPT-MBR','false','true')
-    UpdateRawProgram(RawProgramXML_Wipe,1, BackupGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, PhysicalPartitionNumber, 0, BackupGPTNumLBAs, "zeros_%dsectors.bin" % BackupGPTNumLBAs, 'false', 'PrimaryGPT','false','true')
+    UpdateRawProgram(
+        RawProgramXML,
+        0,
+        PrimaryGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+        PhysicalPartitionNumber,
+        0,
+        PrimaryGPTNumLBAs,
+        os.path.basename(GPTMAIN),
+        "false",
+        "PrimaryGPT",
+        "false",
+        "true",
+    )
+    UpdateRawProgram(
+        RawProgramXML_Wipe,
+        0,
+        1 * SECTOR_SIZE_IN_BYTES / 1024.0,
+        PhysicalPartitionNumber,
+        0,
+        1,
+        "zeros_1sector.bin",
+        "false",
+        "PrimaryGPT-MBR",
+        "false",
+        "true",
+    )
+    UpdateRawProgram(
+        RawProgramXML_Wipe,
+        1,
+        BackupGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+        PhysicalPartitionNumber,
+        0,
+        BackupGPTNumLBAs,
+        "zeros_%dsectors.bin" % BackupGPTNumLBAs,
+        "false",
+        "PrimaryGPT",
+        "false",
+        "true",
+    )
 
-    #print "szStartSector=%s" % szStartSector
+    # print "szStartSector=%s" % szStartSector
 
     start_gpt_backup_lba = -BackupGPTNumLBAs
     if not gen_patch:
         start_gpt_backup_lba = BackupTableLBA
 
-    UpdateRawProgram(RawProgramXML,start_gpt_backup_lba,       BackupGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, PhysicalPartitionNumber, 0, BackupGPTNumLBAs, os.path.basename(GPTBACKUP), 'false', 'BackupGPT','false','true')
-    UpdateRawProgram(RawProgramXML_Wipe,start_gpt_backup_lba, BackupGPTNumLBAs*SECTOR_SIZE_IN_BYTES/1024.0, PhysicalPartitionNumber, 0, BackupGPTNumLBAs, "zeros_%dsectors.bin" % BackupGPTNumLBAs, 'false', 'BackupGPT','false','true')
+    UpdateRawProgram(
+        RawProgramXML,
+        start_gpt_backup_lba,
+        BackupGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+        PhysicalPartitionNumber,
+        0,
+        BackupGPTNumLBAs,
+        os.path.basename(GPTBACKUP),
+        "false",
+        "BackupGPT",
+        "false",
+        "true",
+    )
+    UpdateRawProgram(
+        RawProgramXML_Wipe,
+        start_gpt_backup_lba,
+        BackupGPTNumLBAs * SECTOR_SIZE_IN_BYTES / 1024.0,
+        PhysicalPartitionNumber,
+        0,
+        BackupGPTNumLBAs,
+        "zeros_%dsectors.bin" % BackupGPTNumLBAs,
+        "false",
+        "BackupGPT",
+        "false",
+        "true",
+    )
     ##print "szStartSector=%s" % szStartSector
-
 
     WriteGPT(GPTMAIN, GPTBACKUP, GPTEMPTY)
 
     with open(RAW_PROGRAM, "w") as opfile:
-        opfile.write( prettify(RawProgramXML) )
-    print("\nCreated \"%s\"\t\t\t<-- YOUR partition information is HERE" % RAW_PROGRAM)
+        opfile.write(prettify(RawProgramXML))
+    print('\nCreated "%s"\t\t\t<-- YOUR partition information is HERE' % RAW_PROGRAM)
 
     with open(RAW_PROGRAM_WIPE_PARTITIONS, "w") as opfile:
-        opfile.write( prettify(RawProgramXML_Wipe) )
-    print("Created \"%s\"\t<-- Wipe out your images with this file (if needed for testing)" % RAW_PROGRAM_WIPE_PARTITIONS)
+        opfile.write(prettify(RawProgramXML_Wipe))
+    print(
+        'Created "%s"\t<-- Wipe out your images with this file (if needed for testing)'
+        % RAW_PROGRAM_WIPE_PARTITIONS
+    )
 
     with open(RAW_PROGRAM_BLANK_GPT, "w") as opfile:
-        opfile.write( prettify(RawProgramXML_Blank) )
-    print("Created \"%s\"\t\t<-- Valid empty GPT partition table (to force to EDL)" % RAW_PROGRAM_BLANK_GPT)
+        opfile.write(prettify(RawProgramXML_Blank))
+    print(
+        'Created "%s"\t\t<-- Valid empty GPT partition table (to force to EDL)'
+        % RAW_PROGRAM_BLANK_GPT
+    )
 
-    with open(PATCHES, "w") as opfile:             # gpt
-        opfile.write( prettify(PatchesXML) )
-    print("Created \"%s\"\t\t\t\t<-- Tailor your partition tables to YOUR device with this file\n" % PATCHES)
-
+    with open(PATCHES, "w") as opfile:  # gpt
+        opfile.write(prettify(PatchesXML))
+    print(
+        'Created "%s"\t\t\t\t<-- Tailor your partition tables to YOUR device with this file\n'
+        % PATCHES
+    )
 
 
 def AlignVariablesToEqualSigns(sz):
-    temp = re.sub(r"(\t| )+=","=",sz)
-    temp = re.sub(r"=(\t| )+","=",temp)
+    temp = re.sub(r"(\t| )+=", "=", sz)
+    temp = re.sub(r"=(\t| )+", "=", temp)
     return temp
 
+
 def ReturnArrayFromSpaceSeparatedList(sz):
-    temp = re.sub(r"\s+|\n"," ",sz)
-    temp = re.sub(r"^\s+","",temp)
-    temp = re.sub(r"\s+$","",temp)
-    return temp.split(' ')
+    temp = re.sub(r"\s+|\n", " ", sz)
+    temp = re.sub(r"^\s+", "", temp)
+    temp = re.sub(r"\s+$", "", temp)
+    return temp.split(" ")
+
 
 def ParseXML(XMLFile):
-    global OutputToCreate,NumPhyPartitions, PartitionCollection, PhyPartition,MinSectorsNeeded,SECTOR_SIZE_IN_BYTES
+    global OutputToCreate, NumPhyPartitions, PartitionCollection, PhyPartition, MinSectorsNeeded, SECTOR_SIZE_IN_BYTES
 
-    root = ET.parse( XMLFile )
+    root = ET.parse(XMLFile)
 
-    #Create an iterator
+    # Create an iterator
     iter = list(root.iter())
 
     for element in iter:
-        #print "\nElement:" , element.tag   # thins like image,primary,extended etc
+        # print "\nElement:" , element.tag   # thins like image,primary,extended etc
 
-        if element.tag=="parser_instructions":
-            instructions = ReturnArrayFromSpaceSeparatedList(AlignVariablesToEqualSigns(element.text))
+        if element.tag == "parser_instructions":
+            instructions = ReturnArrayFromSpaceSeparatedList(
+                AlignVariablesToEqualSigns(element.text)
+            )
 
             for element in instructions:
-                temp = element.split('=')
+                temp = element.split("=")
                 if len(temp) > 1:
                     HashInstructions[temp[0].strip()] = temp[1].strip()
-                    #print "HashInstructions['%s'] = %s" % (temp[0].strip(),temp[1].strip())
+                    # print "HashInstructions['%s'] = %s" % (temp[0].strip(),temp[1].strip())
 
-
-    if 'SECTOR_SIZE_IN_BYTES' in HashInstructions:
-        if isinstance(HashInstructions['SECTOR_SIZE_IN_BYTES'], str):
-            m = re.search(r'^(\d+)$', HashInstructions['SECTOR_SIZE_IN_BYTES'])
+    if "SECTOR_SIZE_IN_BYTES" in HashInstructions:
+        if isinstance(HashInstructions["SECTOR_SIZE_IN_BYTES"], str):
+            m = re.search(r"^(\d+)$", HashInstructions["SECTOR_SIZE_IN_BYTES"])
             if m is None:
                 ## we didn't match, so assign deafult
-                HashInstructions['SECTOR_SIZE_IN_BYTES'] = 512
+                HashInstructions["SECTOR_SIZE_IN_BYTES"] = 512
                 SECTOR_SIZE_IN_BYTES = 512
             else:
-                HashInstructions['SECTOR_SIZE_IN_BYTES'] = int(HashInstructions['SECTOR_SIZE_IN_BYTES'])
-                SECTOR_SIZE_IN_BYTES = HashInstructions['SECTOR_SIZE_IN_BYTES']
+                HashInstructions["SECTOR_SIZE_IN_BYTES"] = int(
+                    HashInstructions["SECTOR_SIZE_IN_BYTES"]
+                )
+                SECTOR_SIZE_IN_BYTES = HashInstructions["SECTOR_SIZE_IN_BYTES"]
 
-                PrintBigWarning("WARNING: SECTOR_SIZE_IN_BYTES CHANGED <-- This may impact your targets ability to read the partition tables!!")
-                print("\n\nWARNING: SECTOR_SIZE_IN_BYTES *changed* from 512bytes/sector to %ibytes/sector" % SECTOR_SIZE_IN_BYTES)
-                print("WARNING: SECTOR_SIZE_IN_BYTES *changed* from 512bytes/sector to %ibytes/sector" % SECTOR_SIZE_IN_BYTES)
-                print("WARNING: SECTOR_SIZE_IN_BYTES *changed* from 512bytes/sector to %ibytes/sector\n\n" % SECTOR_SIZE_IN_BYTES)
+                PrintBigWarning(
+                    "WARNING: SECTOR_SIZE_IN_BYTES CHANGED <-- This may impact your targets ability to read the partition tables!!"
+                )
+                print(
+                    "\n\nWARNING: SECTOR_SIZE_IN_BYTES *changed* from 512bytes/sector to %ibytes/sector"
+                    % SECTOR_SIZE_IN_BYTES
+                )
+                print(
+                    "WARNING: SECTOR_SIZE_IN_BYTES *changed* from 512bytes/sector to %ibytes/sector"
+                    % SECTOR_SIZE_IN_BYTES
+                )
+                print(
+                    "WARNING: SECTOR_SIZE_IN_BYTES *changed* from 512bytes/sector to %ibytes/sector\n\n"
+                    % SECTOR_SIZE_IN_BYTES
+                )
                 sleep(2)
     else:
-        #print "SECTOR_SIZE_IN_BYTES does not exist"
-        HashInstructions['SECTOR_SIZE_IN_BYTES'] = 512
+        # print "SECTOR_SIZE_IN_BYTES does not exist"
+        HashInstructions["SECTOR_SIZE_IN_BYTES"] = 512
 
-
-    if 'WRITE_PROTECT_BOUNDARY_IN_KB' in HashInstructions:
-        if isinstance(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'], str):
-            m = re.search(r'^(\d+)$', HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
+    if "WRITE_PROTECT_BOUNDARY_IN_KB" in HashInstructions:
+        if isinstance(HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"], str):
+            m = re.search(r"^(\d+)$", HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"])
             if m is None:
                 ## we didn't match, so assign deafult
-                HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'] = 0
+                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] = 0
             else:
-                HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'] = int(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
+                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] = int(
+                    HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                )
     else:
-        #print "WRITE_PROTECT_BOUNDARY_IN_KB does not exist"
-        HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'] = 65536
+        # print "WRITE_PROTECT_BOUNDARY_IN_KB does not exist"
+        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] = 65536
 
-    if 'PERFORMANCE_BOUNDARY_IN_KB' in HashInstructions:
-        if isinstance(HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'], str):
-            m = re.search(r'^(\d+)$', HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
+    if "PERFORMANCE_BOUNDARY_IN_KB" in HashInstructions:
+        if isinstance(HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"], str):
+            m = re.search(r"^(\d+)$", HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"])
             if m is None:
                 ## we didn't match, so assign deafult
-                HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] = 0
+                HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"] = 0
             else:
-                HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] = int(HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
+                HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"] = int(
+                    HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"]
+                )
     else:
-        #print "PERFORMANCE_BOUNDARY_IN_KB does not exist"
-        HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'] = 0
+        # print "PERFORMANCE_BOUNDARY_IN_KB does not exist"
+        HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"] = 0
 
-    if 'GROW_LAST_PARTITION_TO_FILL_DISK' in HashInstructions:
-        if isinstance(HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'], str):
-            m = re.search("^(true)$", HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] ,re.IGNORECASE)
-            #print type(m)
+    if "GROW_LAST_PARTITION_TO_FILL_DISK" in HashInstructions:
+        if isinstance(HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"], str):
+            m = re.search(
+                "^(true)$",
+                HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"],
+                re.IGNORECASE,
+            )
+            # print type(m)
             if m is None:
-                HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = False    # no match
-                #print "assigned false"
+                HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"] = False  # no match
+                # print "assigned false"
             else:
-                HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = True     # matched string true
-                #print "assigned true"
+                HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"] = (
+                    True  # matched string true
+                )
+                # print "assigned true"
     else:
-        HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = False
+        HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"] = False
 
-    if 'WRITE_PROTECT_GPT_PARTITION_TABLE' in HashInstructions:
-        if isinstance(HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'], str):
-            m = re.search("^(true)$", HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'] ,re.IGNORECASE)
-            #print type(m)
+    if "WRITE_PROTECT_GPT_PARTITION_TABLE" in HashInstructions:
+        if isinstance(HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"], str):
+            m = re.search(
+                "^(true)$",
+                HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"],
+                re.IGNORECASE,
+            )
+            # print type(m)
             if m is None:
-                HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'] = False    # no match
-                #print "assigned false"
+                HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"] = (
+                    False  # no match
+                )
+                # print "assigned false"
             else:
-                HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'] = True     # matched string true
-                #print "assigned true"
+                HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"] = (
+                    True  # matched string true
+                )
+                # print "assigned true"
     else:
-        HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'] = False
+        HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"] = False
 
-    if 'ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY' in HashInstructions:
-        if isinstance(HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'], str):
-            m = re.search("^(true)$", HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] ,re.IGNORECASE)
-            #print type(m)
+    if "ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY" in HashInstructions:
+        if isinstance(
+            HashInstructions["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"], str
+        ):
+            m = re.search(
+                "^(true)$",
+                HashInstructions["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"],
+                re.IGNORECASE,
+            )
+            # print type(m)
             if m is None:
-                HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] = False    # no match
-                #print "assigned false"
+                HashInstructions["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = (
+                    False  # no match
+                )
+                # print "assigned false"
             else:
-                HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] = True     # matched string true
-                #print "assigned true"
+                HashInstructions["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = (
+                    True  # matched string true
+                )
+                # print "assigned true"
     else:
-        HashInstructions['ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY'] = False
+        HashInstructions["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = False
 
-    if 'USE_GPT_PARTITIONING' in HashInstructions:
-        if isinstance(HashInstructions['USE_GPT_PARTITIONING'], str):
-            m = re.search("^(true)$", HashInstructions['USE_GPT_PARTITIONING'] ,re.IGNORECASE)
-            #print type(m)
+    if "USE_GPT_PARTITIONING" in HashInstructions:
+        if isinstance(HashInstructions["USE_GPT_PARTITIONING"], str):
+            m = re.search(
+                "^(true)$", HashInstructions["USE_GPT_PARTITIONING"], re.IGNORECASE
+            )
+            # print type(m)
             if m is None:
-                HashInstructions['USE_GPT_PARTITIONING'] = False    # no match
-                #print "assigned false"
+                HashInstructions["USE_GPT_PARTITIONING"] = False  # no match
+                # print "assigned false"
             else:
-                HashInstructions['USE_GPT_PARTITIONING'] = True     # matched string true
-                #print "assigned true"
+                HashInstructions["USE_GPT_PARTITIONING"] = True  # matched string true
+                # print "assigned true"
     else:
-        HashInstructions['USE_GPT_PARTITIONING'] = False
+        HashInstructions["USE_GPT_PARTITIONING"] = False
 
-
-    if 'DISK_SIGNATURE' in HashInstructions:
-        if isinstance(HashInstructions['DISK_SIGNATURE'], str):
-            m = re.search(r'^0x([\da-fA-F]+)$', HashInstructions['DISK_SIGNATURE'])
+    if "DISK_SIGNATURE" in HashInstructions:
+        if isinstance(HashInstructions["DISK_SIGNATURE"], str):
+            m = re.search(r"^0x([\da-fA-F]+)$", HashInstructions["DISK_SIGNATURE"])
             if m is None:
-                print("WARNING: DISK_SIGNATURE is not formed correctly, expected format is 0x12345678\n")
-                HashInstructions['DISK_SIGNATURE'] = 0x00000000
+                print(
+                    "WARNING: DISK_SIGNATURE is not formed correctly, expected format is 0x12345678\n"
+                )
+                HashInstructions["DISK_SIGNATURE"] = 0x00000000
             else:
-                HashInstructions['DISK_SIGNATURE'] = int(HashInstructions['DISK_SIGNATURE'],16)
+                HashInstructions["DISK_SIGNATURE"] = int(
+                    HashInstructions["DISK_SIGNATURE"], 16
+                )
     else:
         print("DISK_SIGNATURE does not exist")
-        HashInstructions['DISK_SIGNATURE'] = 0x00000000
+        HashInstructions["DISK_SIGNATURE"] = 0x00000000
 
-    if 'ALIGN_BOUNDARY_IN_KB' in HashInstructions:
-        if isinstance(HashInstructions['ALIGN_BOUNDARY_IN_KB'], str):
-            m = re.search(r'^(\d+)$', HashInstructions['ALIGN_BOUNDARY_IN_KB'])
+    if "ALIGN_BOUNDARY_IN_KB" in HashInstructions:
+        if isinstance(HashInstructions["ALIGN_BOUNDARY_IN_KB"], str):
+            m = re.search(r"^(\d+)$", HashInstructions["ALIGN_BOUNDARY_IN_KB"])
             if m is None:
                 ## we didn't match, so assign deafult
-                HashInstructions['ALIGN_BOUNDARY_IN_KB'] = HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']
+                HashInstructions["ALIGN_BOUNDARY_IN_KB"] = HashInstructions[
+                    "WRITE_PROTECT_BOUNDARY_IN_KB"
+                ]
             else:
-                HashInstructions['ALIGN_BOUNDARY_IN_KB'] = int(HashInstructions['ALIGN_BOUNDARY_IN_KB'])
+                HashInstructions["ALIGN_BOUNDARY_IN_KB"] = int(
+                    HashInstructions["ALIGN_BOUNDARY_IN_KB"]
+                )
     else:
-        #print "ALIGN_BOUNDARY_IN_KB does not exist"
-        HashInstructions['ALIGN_BOUNDARY_IN_KB'] = HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']
+        # print "ALIGN_BOUNDARY_IN_KB does not exist"
+        HashInstructions["ALIGN_BOUNDARY_IN_KB"] = HashInstructions[
+            "WRITE_PROTECT_BOUNDARY_IN_KB"
+        ]
 
-    root = ET.parse( XMLFile )
+    root = ET.parse(XMLFile)
 
-    #Create an iterator
+    # Create an iterator
     iter = list(root.iter())
 
     ## Need to count how many partitions
-    CheckPartitionCount = [0,0,0,0,0,0,0,0]
-    CurrentPartition    = -1
+    CheckPartitionCount = [0, 0, 0, 0, 0, 0, 0, 0]
+    CurrentPartition = -1
 
     for element in iter:
         ##print "\nElement:" , element.tag   # thins like image,primary,extended etc
         if element.tag == "physical_partition":
-            CurrentPartition+=1
-            #print "Now on CurrentPartition=",CurrentPartition
+            CurrentPartition += 1
+            # print "Now on CurrentPartition=",CurrentPartition
         if element.tag == "partition":
             CheckPartitionCount[CurrentPartition] += 1
-            #print "CheckPartitionCount[%d]=%d" % (CurrentPartition,CheckPartitionCount[CurrentPartition])
+            # print "CheckPartitionCount[%d]=%d" % (CurrentPartition,CheckPartitionCount[CurrentPartition])
 
-    for p in range(CurrentPartition+1):
-        print("CheckPartitionCount[%d]=%d" % (p,CheckPartitionCount[p]))
+    for p in range(CurrentPartition + 1):
+        print("CheckPartitionCount[%d]=%d" % (p, CheckPartitionCount[p]))
 
-    CurrentPartition    = -1
+    CurrentPartition = -1
     for element in iter:
-        #print "\nElement:" , element.tag   # thins like image,primary,extended etc
+        # print "\nElement:" , element.tag   # thins like image,primary,extended etc
 
-        if element.tag=="physical_partition":
+        if element.tag == "physical_partition":
             # We can have this scenario meaning NumPhyPartitions++ but len(PhyPartition) doesn't increase
             # <physical_partition>
             # </physical_partition>
             # Thus if NumPhyPartitions > len(PhyPartition) by 2, then we need to increase it
 
-            NumPhyPartitions            += 1
-            CurrentPartition            = 0 ## Using this to count partitions
+            NumPhyPartitions += 1
+            CurrentPartition = 0  ## Using this to count partitions
 
-            PartitionCollection          = []    # Reset, we've found a new physical partition
+            PartitionCollection = []  # Reset, we've found a new physical partition
 
-            if NumPhyPartitions-len(PhyPartition)>=2:
+            if NumPhyPartitions - len(PhyPartition) >= 2:
                 print("\n\n")
-                print("*"*78)
-                print("ERROR: Empty <physical_partition></physical_partition> tags detected\n")
+                print("*" * 78)
+                print(
+                    "ERROR: Empty <physical_partition></physical_partition> tags detected\n"
+                )
                 print("Please replace with")
                 print("<physical_partition>")
-                print("<partition label='placeholder' size_in_kb='0' type='00000000-0000-0000-0000-000000000001' bootable='false' readonly='false' filename='' />")
+                print(
+                    "<partition label='placeholder' size_in_kb='0' type='00000000-0000-0000-0000-000000000001' bootable='false' readonly='false' filename='' />"
+                )
                 print("</physical_partition>\n")
                 sys.exit()
 
-            print("\nFound a physical_partition, NumPhyPartitions=%d" % NumPhyPartitions)
+            print(
+                "\nFound a physical_partition, NumPhyPartitions=%d" % NumPhyPartitions
+            )
             print("\nlen(PhyPartition)=%d" % len(PhyPartition))
 
+        elif (
+            element.tag == "partition"
+            or element.tag == "primary"
+            or element.tag == "extended"
+        ):
 
-        elif element.tag=="partition" or element.tag=="primary" or element.tag=="extended":
-
-            CurrentPartition+=1
+            CurrentPartition += 1
 
             if list(element.keys()):
-                #print "\tAttributes:"
+                # print "\tAttributes:"
 
                 # Reset all variables to defaults
                 Partition = {}
@@ -1229,175 +1986,197 @@ def ParseXML(XMLFile):
                 # This partition could have more than 1 file, so these are arrays
                 # However, as I loop through the elements, *if* there is more than 1 file
                 # it will have it's own <file> tag
-                Partition['filename']            = [""]
-                Partition['fileoffset']          = [0]
-                Partition['appsbin']             = ["false"]
-                Partition['sparse']              = ["false"]
-                Partition['filepartitionoffset'] = [0]
+                Partition["filename"] = [""]
+                Partition["fileoffset"] = [0]
+                Partition["appsbin"] = ["false"]
+                Partition["sparse"] = ["false"]
+                Partition["filepartitionoffset"] = [0]
 
-                Partition['size_in_kb']         = 0
-                Partition['original_size_in_kb']= 0
-                Partition['readonly']           = "false"
-                Partition['label']              = "false"
-                Partition['type']               = "false"
-                Partition['uguid']              = "false"   ## unique guid
-                Partition['align']              = "false"
-                Partition['hidden']             = "false"
-                Partition['system']             = "false"
-                Partition['dontautomount']      = "false"
-                Partition['partofsingleimage']  = "false"
-                Partition['readbackverify']     = "false"
-                Partition['tries_remaining']    = 0
-                Partition['priority']           = 0
+                Partition["size_in_kb"] = 0
+                Partition["original_size_in_kb"] = 0
+                Partition["readonly"] = "false"
+                Partition["label"] = "false"
+                Partition["type"] = "false"
+                Partition["uguid"] = "false"  ## unique guid
+                Partition["align"] = "false"
+                Partition["hidden"] = "false"
+                Partition["system"] = "false"
+                Partition["dontautomount"] = "false"
+                Partition["partofsingleimage"] = "false"
+                Partition["readbackverify"] = "false"
+                Partition["tries_remaining"] = 0
+                Partition["priority"] = 0
 
                 ##import pdb; pdb.set_trace()
 
-                if 'PERFORMANCE_BOUNDARY_IN_KB' in HashInstructions:
-                    Partition['PERFORMANCE_BOUNDARY_IN_KB']  = int(HashInstructions['PERFORMANCE_BOUNDARY_IN_KB'])
+                if "PERFORMANCE_BOUNDARY_IN_KB" in HashInstructions:
+                    Partition["PERFORMANCE_BOUNDARY_IN_KB"] = int(
+                        HashInstructions["PERFORMANCE_BOUNDARY_IN_KB"]
+                    )
                 else:
-                    Partition['PERFORMANCE_BOUNDARY_IN_KB']  = 0
-
+                    Partition["PERFORMANCE_BOUNDARY_IN_KB"] = 0
 
                 print(" ")
 
                 for name, value in list(element.items()):
-                    #print "\t\tName: '%s'=>'%s' " % (name,value)
+                    # print "\t\tName: '%s'=>'%s' " % (name,value)
 
-                    if name=='name' or name=='filename' :
-                        Partition['filename'][-1] = value
+                    if name == "name" or name == "filename":
+                        Partition["filename"][-1] = value
                         print("Found a file tag '%s'" % value)
-                    elif name=='fileoffset':
-                        Partition['fileoffset'][-1] = value
-                    elif name=='label':
-                        Partition['label'] = value
-                        print("LABEL:",value)
-                    elif name=='offset' or name=='filepartitionoffset':
-                        Partition['filepartitionoffset'][-1] = int(value)
-                    elif name=='appsbin':
-                        Partition['appsbin'][-1] = value
-                    elif name=='sparse':
-                        Partition['sparse'][-1] = value
-                    elif name=='PERFORMANCE_BOUNDARY_IN_KB':
-                        Partition['PERFORMANCE_BOUNDARY_IN_KB'] = int(value)
-                    elif name=='type':
+                    elif name == "fileoffset":
+                        Partition["fileoffset"][-1] = value
+                    elif name == "label":
+                        Partition["label"] = value
+                        print("LABEL:", value)
+                    elif name == "offset" or name == "filepartitionoffset":
+                        Partition["filepartitionoffset"][-1] = int(value)
+                    elif name == "appsbin":
+                        Partition["appsbin"][-1] = value
+                    elif name == "sparse":
+                        Partition["sparse"][-1] = value
+                    elif name == "PERFORMANCE_BOUNDARY_IN_KB":
+                        Partition["PERFORMANCE_BOUNDARY_IN_KB"] = int(value)
+                    elif name == "type":
                         if ValidGUIDForm(value) is True:
                             if OutputToCreate is None:
                                 OutputToCreate = "gpt"
                             elif OutputToCreate == "mbr":
-                                PrintBigError("ERROR: Your partition.xml is possibly corrupt, please check the GUID TYPE field")
-                            Partition['type'] = ValidateGUID(value)
+                                PrintBigError(
+                                    "ERROR: Your partition.xml is possibly corrupt, please check the GUID TYPE field"
+                                )
+                            Partition["type"] = ValidateGUID(value)
                         else:
                             if OutputToCreate is None:
                                 OutputToCreate = "mbr"
                             elif OutputToCreate == "gpt":
-                                PrintBigError("ERROR: Your partition.xml is possibly corrupt, please check the TYPE field")
-                            Partition['type'] = ValidateTYPE(value)
-                    elif name=='uniqueguid':
+                                PrintBigError(
+                                    "ERROR: Your partition.xml is possibly corrupt, please check the TYPE field"
+                                )
+                            Partition["type"] = ValidateTYPE(value)
+                    elif name == "uniqueguid":
                         if ValidGUIDForm(value) is True:
-                            Partition['uguid'] = ValidateGUID(value)
+                            Partition["uguid"] = ValidateGUID(value)
                         else:
-                            PrintBigError("ERROR: Your partition.xml is possibly corrupt, please check the TYPE field")
-                    elif name=="triesremaining":
-                        Partition['tries_remaining'] = int(value)
-                    elif name=="priority":
-                        Partition['priority']       = int(value)
-                    elif name=="size":
-                        if len(value)==0:
+                            PrintBigError(
+                                "ERROR: Your partition.xml is possibly corrupt, please check the TYPE field"
+                            )
+                    elif name == "triesremaining":
+                        Partition["tries_remaining"] = int(value)
+                    elif name == "priority":
+                        Partition["priority"] = int(value)
+                    elif name == "size":
+                        if len(value) == 0:
                             PrintBigError("\nERROR: Invalid partition size")
 
                         ## 'size' means in terms of sectors
-                        TempSizeInBytes = int(value)//2        # force as even number
-                        if TempSizeInBytes<2:
+                        TempSizeInBytes = int(value) // 2  # force as even number
+                        if TempSizeInBytes < 2:
                             TempSizeInBytes = 2
-                        TempSizeInBytes = TempSizeInBytes*SECTOR_SIZE_IN_BYTES  ## either 1K or 8K
+                        TempSizeInBytes = (
+                            TempSizeInBytes * SECTOR_SIZE_IN_BYTES
+                        )  ## either 1K or 8K
 
-                        Partition["size_in_kb"]=TempSizeInBytes//1024
-                        Partition["original_size_in_kb"]=TempSizeInBytes//1024
-                    elif name=="size_in_kb":
-                        if len(value)==0:
+                        Partition["size_in_kb"] = TempSizeInBytes // 1024
+                        Partition["original_size_in_kb"] = TempSizeInBytes // 1024
+                    elif name == "size_in_kb":
+                        if len(value) == 0:
                             PrintBigError("\nERROR: Invalid partition size")
 
-
-                        if value=='0':
-                            if CheckPartitionCount[NumPhyPartitions-1] == CurrentPartition:
+                        if value == "0":
+                            if (
+                                CheckPartitionCount[NumPhyPartitions - 1]
+                                == CurrentPartition
+                            ):
                                 ## To be here means they have size_in_kb='0' BUT this is ok since it is the LAST partition
                                 pass
                             else:
-                                PrintBigError("\nERROR: Invalid size_in_kb='0' detected on partition %d of %d. This is usually a mistake. Did you mean this to be the *last* partition"%(CurrentPartition,CheckPartitionCount[NumPhyPartitions-1]))
+                                PrintBigError(
+                                    "\nERROR: Invalid size_in_kb='0' detected on partition %d of %d. This is usually a mistake. Did you mean this to be the *last* partition"
+                                    % (
+                                        CurrentPartition,
+                                        CheckPartitionCount[NumPhyPartitions - 1],
+                                    )
+                                )
 
-##timmy
+                        ##timmy
 
                         TempSizeInBytes = math.ceil(float(value)) * 1024
                         if TempSizeInBytes < SECTOR_SIZE_IN_BYTES:
                             ## smaller than a sector, which is possible if sector size is 4KB
                             TempSizeInBytes = SECTOR_SIZE_IN_BYTES
-                        Partition["size_in_kb"]=TempSizeInBytes//1024
-                        Partition["original_size_in_kb"]=TempSizeInBytes//1024
+                        Partition["size_in_kb"] = TempSizeInBytes // 1024
+                        Partition["original_size_in_kb"] = TempSizeInBytes // 1024
 
                     else:
-                        print("Just assigned %s to %s" % (name,value))
-                        Partition[name]=value
+                        print("Just assigned %s to %s" % (name, value))
+                        Partition[name] = value
 
-        # No longer appending blank filename data for Trace32. Programming based on Label now
-                #if FileFound == 1:
+                # No longer appending blank filename data for Trace32. Programming based on Label now
+                # if FileFound == 1:
                 #    Partition['filename'].append("")
                 #    Partition['fileoffset'].append(0)
                 #    Partition['filepartitionoffset'].append(0)
                 #    Partition['appsbin'].append("false")
                 #    Partition['sparse'].append("false")
 
-
-
                 ## done with all the elements, now ensure that size matches with size_in_kb
-                Partition["size"] = ConvertKBtoSectors(Partition["size_in_kb"]) # Still 512 bytes/sector here since "size" is a legacy field
+                Partition["size"] = ConvertKBtoSectors(
+                    Partition["size_in_kb"]
+                )  # Still 512 bytes/sector here since "size" is a legacy field
 
                 ## Now add this "Partition" object to the PartitionCollection
                 ## unless it's the label EXT, which is a left over legacy tag
 
-                if Partition['label'] != 'EXT':
-                    #print "\nJust added %s" % Partition['label']
-                    PartitionCollection.append( Partition )
+                if Partition["label"] != "EXT":
+                    # print "\nJust added %s" % Partition['label']
+                    PartitionCollection.append(Partition)
 
-                    print("="*40)
-                    print("storing at %d" % (NumPhyPartitions-1))
+                    print("=" * 40)
+                    print("storing at %d" % (NumPhyPartitions - 1))
                     ##import pdb; pdb.set_trace()
 
-                    print("Adding PartitionCollection to \"PhyPartition\" of size %i" % (NumPhyPartitions-1))
-                    PhyPartition[(NumPhyPartitions-1)]          = PartitionCollection
+                    print(
+                        'Adding PartitionCollection to "PhyPartition" of size %i'
+                        % (NumPhyPartitions - 1)
+                    )
+                    PhyPartition[(NumPhyPartitions - 1)] = PartitionCollection
 
-                    #print "\nPartition stored (%i partitions total)" % len(PartitionCollection)
+                    # print "\nPartition stored (%i partitions total)" % len(PartitionCollection)
 
             else:
-                PrintBigError("ERROR: element.tag was partition, primary or extended, but it had no keys!")
+                PrintBigError(
+                    "ERROR: element.tag was partition, primary or extended, but it had no keys!"
+                )
 
-        elif element.tag=="file":
-            #print "element.tag=='file' Found a file, NumPhyPartitions=",NumPhyPartitions    ## i.e. just a file tag (usually in legacy)
-            #print PhyPartition[(NumPhyPartitions-1)]
-            #print "Current partition is \"%s\"\n" % Partition['label']
+        elif element.tag == "file":
+            # print "element.tag=='file' Found a file, NumPhyPartitions=",NumPhyPartitions    ## i.e. just a file tag (usually in legacy)
+            # print PhyPartition[(NumPhyPartitions-1)]
+            # print "Current partition is \"%s\"\n" % Partition['label']
 
             if list(element.keys()):
                 for name, value in list(element.items()):
-                    if name=='name' or name=='filename' :
-                        Partition['filename'][-1] = value
-                    if name=='fileoffset':
-                        Partition['fileoffset'][-1] = value
-                    if name=='offset' or name=='filepartitionoffset':
-                        Partition['filepartitionoffset'][-1] = int(value)
-                    if name=='appsbin':
-                        Partition['appsbin'][-1] = value
-                    if name=='sparse':
-                        Partition['sparse'][-1] = value
+                    if name == "name" or name == "filename":
+                        Partition["filename"][-1] = value
+                    if name == "fileoffset":
+                        Partition["fileoffset"][-1] = value
+                    if name == "offset" or name == "filepartitionoffset":
+                        Partition["filepartitionoffset"][-1] = int(value)
+                    if name == "appsbin":
+                        Partition["appsbin"][-1] = value
+                    if name == "sparse":
+                        Partition["sparse"][-1] = value
 
-                    #Partition[name]=value
+                    # Partition[name]=value
 
-            #print Partition['filename']
-            Partition['filename'].append("")
-            Partition['fileoffset'].append(0)
-            Partition['filepartitionoffset'].append(0)
-            Partition['appsbin'].append("false")
-            Partition['sparse'].append("false")
+            # print Partition['filename']
+            Partition["filename"].append("")
+            Partition["fileoffset"].append(0)
+            Partition["filepartitionoffset"].append(0)
+            Partition["appsbin"].append("false")
+            Partition["sparse"].append("false")
 
-        #try:
+        # try:
         #    if len(Partition['filename'])>1:
         #        print "="*78
         #        print "="*78
@@ -1409,251 +2188,369 @@ def ParseXML(XMLFile):
         #            print "Partition['sparse'][",z,"]=",Partition['sparse'][z]
         #            print "-"*78
         #        print "="*78
-        #except:
+        # except:
         #    print " "
-        #print "Showing the changes to PartitionCollection"
-        #print PartitionCollection[-1]
-
+        # print "Showing the changes to PartitionCollection"
+        # print PartitionCollection[-1]
 
     # Must update this if the user has updated WRITE_PROTECT_BOUNDARY_IN_KB in partition.xml
-    hash_w[NumWPregions]['num_sectors'] = (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
-    hash_w[NumWPregions]['end_sector']  = (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)-1
+    hash_w[NumWPregions]["num_sectors"] = (
+        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] * 1024 / SECTOR_SIZE_IN_BYTES
+    )
+    hash_w[NumWPregions]["end_sector"] = (
+        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] * 1024 / SECTOR_SIZE_IN_BYTES
+    ) - 1
 
-    if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'] == 0:
-        hash_w[NumWPregions]['num_sectors']             = 0
-        hash_w[NumWPregions]['end_sector']              = 0
-        hash_w[NumWPregions]['num_boundaries_covered']  = 0
+    if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] == 0:
+        hash_w[NumWPregions]["num_sectors"] = 0
+        hash_w[NumWPregions]["end_sector"] = 0
+        hash_w[NumWPregions]["num_boundaries_covered"] = 0
 
-    if OutputToCreate == "gpt" and HashInstructions['WRITE_PROTECT_GPT_PARTITION_TABLE'] is False:
-        hash_w[NumWPregions]['num_sectors']             = 0
-        hash_w[NumWPregions]['end_sector']              = 0
-        hash_w[NumWPregions]['num_boundaries_covered']  = 0
+    if (
+        OutputToCreate == "gpt"
+        and HashInstructions["WRITE_PROTECT_GPT_PARTITION_TABLE"] is False
+    ):
+        hash_w[NumWPregions]["num_sectors"] = 0
+        hash_w[NumWPregions]["end_sector"] = 0
+        hash_w[NumWPregions]["num_boundaries_covered"] = 0
 
-    print("HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']    =%d" % HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
-    print("HashInstructions['ALIGN_BOUNDARY_IN_KB']            =%d" % HashInstructions['ALIGN_BOUNDARY_IN_KB'])
-    print("HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']=%s" % HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'])
-    print("HashInstructions['DISK_SIGNATURE']=0x%X" % HashInstructions['DISK_SIGNATURE'])
+    print(
+        "HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']    =%d"
+        % HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+    )
+    print(
+        "HashInstructions['ALIGN_BOUNDARY_IN_KB']            =%d"
+        % HashInstructions["ALIGN_BOUNDARY_IN_KB"]
+    )
+    print(
+        "HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']=%s"
+        % HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]
+    )
+    print(
+        "HashInstructions['DISK_SIGNATURE']=0x%X" % HashInstructions["DISK_SIGNATURE"]
+    )
 
-    #for j in range(len(PhyPartition)):
-    #for j in range(1):
+    # for j in range(len(PhyPartition)):
+    # for j in range(1):
     #    print "\n\nPhyPartition[%d] ========================================================= " % (j)
     #    PrintPartitionCollection( PhyPartition[j] )
 
+    print("len(PhyPartition)=", len(PhyPartition))
 
-    print("len(PhyPartition)=",len(PhyPartition))
-
-    if not HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']:
+    if not HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]:
         ## to be here means we're *not* growing final partition, thereore, obey the sizes they've specified
         for j in range(len(PhyPartition)):
             TempNumPartitions = len(PhyPartition[j])
-            if TempNumPartitions>4:
-                MinSectorsNeeded = 1 + (TempNumPartitions-3) # need MBR + TempNumPartitions-3 EBRs
+            if TempNumPartitions > 4:
+                MinSectorsNeeded = 1 + (
+                    TempNumPartitions - 3
+                )  # need MBR + TempNumPartitions-3 EBRs
             else:
-                MinSectorsNeeded = 1    # need MBR only
+                MinSectorsNeeded = 1  # need MBR only
 
             for Partition in PhyPartition[j]:
-                print("LABEL: '%s' with %d sectors " % (Partition['label'],ConvertKBtoSectors(Partition["size_in_kb"])))
+                print(
+                    "LABEL: '%s' with %d sectors "
+                    % (Partition["label"], ConvertKBtoSectors(Partition["size_in_kb"]))
+                )
 
                 MinSectorsNeeded += ConvertKBtoSectors(Partition["size_in_kb"])
 
-                #print "LABEL '%s' with size %d sectors" % (Partition['label'],Partition['size_in_kb']/2)
-
+                # print "LABEL '%s' with size %d sectors" % (Partition['label'],Partition['size_in_kb']/2)
 
     print("MinSectorsNeeded=%d" % MinSectorsNeeded)
-    #sys.exit()  #
+    # sys.exit()  #
 
-
-    if OutputToCreate == 'gpt':
+    if OutputToCreate == "gpt":
         PrintBanner("GPT GUID discovered in XML file, Output will be GPT")
-    if OutputToCreate == 'mbr':
+    if OutputToCreate == "mbr":
         PrintBanner("MBR type discovered in XML file, Output will be MBR")
 
 
 #    PrintPartitionCollection( PhyPartition[0] )
 def PrintPartitionCollection(PartitionCollection):
 
-    #print PartitionCollection
+    # print PartitionCollection
 
     for Partition in PartitionCollection:
         print(Partition)
         print(" ")
         for key in Partition:
-            print(key,"\t=>\t",Partition[key])
+            print(key, "\t=>\t", Partition[key])
 
-    #for j in range(NumMBRPartitions):
+    # for j in range(NumMBRPartitions):
+
 
 def ParseCommandLine():
-    global XMLFile,OutputToCreate,PhysicalPartitionNumber
+    global XMLFile, OutputToCreate, PhysicalPartitionNumber
 
     print("\nArgs")
     for i in range(len(sys.argv)):
-        print("sys.argv[%d]=%s" % (i,sys.argv[i]))
+        print("sys.argv[%d]=%s" % (i, sys.argv[i]))
 
     print(" ")
 
     XMLFile = sys.argv[1]
 
     if len(sys.argv) >= 3:
-        m = re.search("mbr|gpt", sys.argv[2] )
+        m = re.search("mbr|gpt", sys.argv[2])
 
         if m is not None:
             OutputToCreate = sys.argv[2]
         else:
-            print("Unrecognized option '%s', only 'mbr' or 'gpt' expected" % sys.argv[2])
+            print(
+                "Unrecognized option '%s', only 'mbr' or 'gpt' expected" % sys.argv[2]
+            )
     else:
-        print("\nUser *did* not explicitly specify partition table format (i.e. mbr|gpt)")
+        print(
+            "\nUser *did* not explicitly specify partition table format (i.e. mbr|gpt)"
+        )
         print("\nWill AUTO-DETECT from file")
 
     if len(sys.argv) >= 4:  # Should mean PHY partition was specified
-        m = re.search(r'^\d+$', sys.argv[3] )
+        m = re.search(r"^\d+$", sys.argv[3])
         if m is not None:
             PhysicalPartitionNumber = int(sys.argv[3])
             print("PhysicalPartitionNumber specified as %d" % PhysicalPartitionNumber)
         else:
-            PrintBigError("ERROR: PhysicalPartitionNumber of disk must only contain numbers, '%s' is not valid" % sys.argv[3])
+            PrintBigError(
+                "ERROR: PhysicalPartitionNumber of disk must only contain numbers, '%s' is not valid"
+                % sys.argv[3]
+            )
 
     print(" ")
 
-# Updates the WriteProtect hash that is used in creating emmc_lock_regions.xml
-def UpdateWPhash(Start,Size):
-    global hash_w,NumWPregions
 
-    if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']==0:
+# Updates the WriteProtect hash that is used in creating emmc_lock_regions.xml
+def UpdateWPhash(Start, Size):
+    global hash_w, NumWPregions
+
+    if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] == 0:
         return
 
-    #print "\nUpdateWPhash(%i,%i) and currently NumWPregions=%i" % (Start,Size,NumWPregions)
-    #print "hash_w[%i]['start_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["start_sector"])
-    #print "hash_w[%i]['end_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["end_sector"])
-    #print "hash_w[%i]['num_sectors']=%i" % (NumWPregions,hash_w[NumWPregions]["num_sectors"])
+    # print "\nUpdateWPhash(%i,%i) and currently NumWPregions=%i" % (Start,Size,NumWPregions)
+    # print "hash_w[%i]['start_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["start_sector"])
+    # print "hash_w[%i]['end_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["end_sector"])
+    # print "hash_w[%i]['num_sectors']=%i" % (NumWPregions,hash_w[NumWPregions]["num_sectors"])
 
-    if Start-1 <= hash_w[NumWPregions]["end_sector"]:
-        #print "\n\tCurrent Write Protect region already covers the start of this partition (start=%i)" % hash_w[NumWPregions]["start_sector"]
+    if Start - 1 <= hash_w[NumWPregions]["end_sector"]:
+        # print "\n\tCurrent Write Protect region already covers the start of this partition (start=%i)" % hash_w[NumWPregions]["start_sector"]
 
         if (Start + Size - 1) > hash_w[NumWPregions]["end_sector"]:
-            print("\n\tCurrent Write Protect region is not big enough at %i sectors, needs to be at least %i sectors" % (hash_w[NumWPregions]["end_sector"]-hash_w[NumWPregions]["start_sector"]+1,Start + Size - 1,))
+            print(
+                "\n\tCurrent Write Protect region is not big enough at %i sectors, needs to be at least %i sectors"
+                % (
+                    hash_w[NumWPregions]["end_sector"]
+                    - hash_w[NumWPregions]["start_sector"]
+                    + 1,
+                    Start + Size - 1,
+                )
+            )
             while (Start + Size - 1) > hash_w[NumWPregions]["end_sector"]:
-                hash_w[NumWPregions]["num_sectors"] += (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
-                hash_w[NumWPregions]["end_sector"]  += (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
-                if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']>0:
-                    hash_w[NumWPregions]["num_boundaries_covered"] = hash_w[NumWPregions]["num_sectors"] / (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
+                hash_w[NumWPregions]["num_sectors"] += (
+                    HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                    * 1024
+                    / SECTOR_SIZE_IN_BYTES
+                )
+                hash_w[NumWPregions]["end_sector"] += (
+                    HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                    * 1024
+                    / SECTOR_SIZE_IN_BYTES
+                )
+                if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] > 0:
+                    hash_w[NumWPregions]["num_boundaries_covered"] = hash_w[
+                        NumWPregions
+                    ]["num_sectors"] / (
+                        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                        * 1024
+                        / SECTOR_SIZE_IN_BYTES
+                    )
                 else:
                     hash_w[NumWPregions]["num_boundaries_covered"] = 0
 
-            print("\t\tend_sector increased to %i sectors" % hash_w[NumWPregions]["end_sector"])
-            print("\t\tnum_sectors increased to %i sectors" % hash_w[NumWPregions]["num_sectors"])
+            print(
+                "\t\tend_sector increased to %i sectors"
+                % hash_w[NumWPregions]["end_sector"]
+            )
+            print(
+                "\t\tnum_sectors increased to %i sectors"
+                % hash_w[NumWPregions]["num_sectors"]
+            )
 
-        #print "\n\tCurrent Write Protect region covers this partition (num_sectors=%i)\n" % hash_w[NumWPregions]["num_sectors"]
+        # print "\n\tCurrent Write Protect region covers this partition (num_sectors=%i)\n" % hash_w[NumWPregions]["num_sectors"]
 
     else:
         print("\n\tNew write protect region needed")
-        #print "\tStart-1\t\t\t\t=%i" % (Start-1)
-        #print "\tLAST hash_w[NumWPregions][end_sector]=%i\n" % hash_w[NumWPregions]["end_sector"]
+        # print "\tStart-1\t\t\t\t=%i" % (Start-1)
+        # print "\tLAST hash_w[NumWPregions][end_sector]=%i\n" % hash_w[NumWPregions]["end_sector"]
 
+        NumWPregions += 1
 
-        NumWPregions+=1
+        hash_w.append(
+            {
+                "start_sector": Start,
+                "num_sectors": (
+                    HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                    * 1024
+                    / SECTOR_SIZE_IN_BYTES
+                ),
+                "end_sector": Start
+                + (
+                    HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                    * 1024
+                    / SECTOR_SIZE_IN_BYTES
+                )
+                - 1,
+                "physical_partition_number": 0,
+                "boundary_num": 0,
+                "num_boundaries_covered": 1,
+            }
+        )
 
-        hash_w.append( {'start_sector':Start,'num_sectors':(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES),'end_sector':Start+(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)-1,'physical_partition_number':0,'boundary_num':0,'num_boundaries_covered':1} )
-
-        hash_w[NumWPregions]["boundary_num"] = Start / (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
+        hash_w[NumWPregions]["boundary_num"] = Start / (
+            HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            * 1024
+            / SECTOR_SIZE_IN_BYTES
+        )
 
         while (Start + Size - 1) > hash_w[NumWPregions]["end_sector"]:
-            #print "\n\tThis region is not big enough though, needs to be %i sectors, but currently only %i" % (Start + Size - 1,hash_w[NumWPregions]["end_sector"])
-            hash_w[NumWPregions]["num_sectors"] += (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
-            hash_w[NumWPregions]["end_sector"]  += (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
-            #print "\t\tend_sector increased to %i sectors" % hash_w[NumWPregions]["end_sector"]
-            #print "\t\tnum_sectors increased to %i sectors" % hash_w[NumWPregions]["num_sectors"]
+            # print "\n\tThis region is not big enough though, needs to be %i sectors, but currently only %i" % (Start + Size - 1,hash_w[NumWPregions]["end_sector"])
+            hash_w[NumWPregions]["num_sectors"] += (
+                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                * 1024
+                / SECTOR_SIZE_IN_BYTES
+            )
+            hash_w[NumWPregions]["end_sector"] += (
+                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                * 1024
+                / SECTOR_SIZE_IN_BYTES
+            )
+            # print "\t\tend_sector increased to %i sectors" % hash_w[NumWPregions]["end_sector"]
+            # print "\t\tnum_sectors increased to %i sectors" % hash_w[NumWPregions]["num_sectors"]
 
-        hash_w[NumWPregions]["num_boundaries_covered"] = hash_w[NumWPregions]["num_sectors"] / (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']*1024/SECTOR_SIZE_IN_BYTES)
+        hash_w[NumWPregions]["num_boundaries_covered"] = hash_w[NumWPregions][
+            "num_sectors"
+        ] / (
+            HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            * 1024
+            / SECTOR_SIZE_IN_BYTES
+        )
 
         print("\t\tstart_sector = %i sectors" % hash_w[NumWPregions]["start_sector"])
         print("\t\tend_sector = %i sectors" % hash_w[NumWPregions]["end_sector"])
         print("\t\tnum_sectors = %i sectors\n" % hash_w[NumWPregions]["num_sectors"])
 
+
 # A8h reflected is 15h, i.e. 10101000 <--> 00010101
 
-def HexPrettyPrint(data,Length):
-   szNum = ""
-   szAsc = ""
-   digest= ""
 
-   ## Called during DLOAD and STREAM
-   #log_info("In HexPrettyPrint() len(data)=%d" % len(data))
+def HexPrettyPrint(data, Length):
+    szNum = ""
+    szAsc = ""
+    digest = ""
 
-   ##return  " "## hack
+    ## Called during DLOAD and STREAM
+    # log_info("In HexPrettyPrint() len(data)=%d" % len(data))
 
-   try:
-       if len(data)==0:
-           return " "
-   except TypeError:
-       print("Hit Exception in HexPrettyPrint, data is %s" % type(data))
-       return " "
+    ##return  " "## hack
 
-   digest = ""
+    try:
+        if len(data) == 0:
+            return " "
+    except TypeError:
+        print("Hit Exception in HexPrettyPrint, data is %s" % type(data))
+        return " "
 
-   TempAddress = 0
-   szHexDump = "\n\tShowing %d bytes\n\t" % (Length)
-   for i in range(int(Length)):
-       v = data[i]
+    digest = ""
 
-       if v == 0x7 and i==0 and Length>5:
-           ## Get next 4 bytes
-           ##print "Length=",Length
-           TempAddress = data[i+4]<<24 | data[i+3]<<16 | data[i+2]<<8 | data[i+1]
-           szHexDump += "Suspected Write, Address would be 0x%.8X\n\t" % (TempAddress)
+    TempAddress = 0
+    szHexDump = "\n\tShowing %d bytes\n\t" % (Length)
+    for i in range(int(Length)):
+        v = data[i]
 
-       if i>0 and i % 16==0:
-           szHexDump += "%-48s\t%s\n\t" % (szNum,szAsc)
-           szNum = ""
-           szAsc = ""
+        if v == 0x7 and i == 0 and Length > 5:
+            ## Get next 4 bytes
+            ##print "Length=",Length
+            TempAddress = (
+                data[i + 4] << 24 | data[i + 3] << 16 | data[i + 2] << 8 | data[i + 1]
+            )
+            szHexDump += "Suspected Write, Address would be 0x%.8X\n\t" % (TempAddress)
 
-       ##print "v=",v," type",type(v)
-       ##import pdb; pdb.set_trace()
-       #if type(v) is not int:    ## HACK
-       #    v = ord(v)  ## convert to unsigned char (integers in python)
-       szNum += "%.2X " % v
-       if v>=0x20 and v<=0x7E:
-           szAsc += "%c"    % v
-       else:
-           szAsc += "."
+        if i > 0 and i % 16 == 0:
+            szHexDump += "%-48s\t%s\n\t" % (szNum, szAsc)
+            szNum = ""
+            szAsc = ""
 
-   ##import pdb; pdb.set_trace()
+        ##print "v=",v," type",type(v)
+        ##import pdb; pdb.set_trace()
+        # if type(v) is not int:    ## HACK
+        #    v = ord(v)  ## convert to unsigned char (integers in python)
+        szNum += "%.2X " % v
+        if v >= 0x20 and v <= 0x7E:
+            szAsc += "%c" % v
+        else:
+            szAsc += "."
 
-   szHexDump += "%-48s\t%s\n%s\n\n" % (szNum,szAsc,digest)
+    ##import pdb; pdb.set_trace()
 
-   return szHexDump
+    szHexDump += "%-48s\t%s\n%s\n\n" % (szNum, szAsc, digest)
+
+    return szHexDump
 
 
 def ReturnLow32bits(var):
     return var & 0xFFFFFFFF
 
+
 def ReturnHigh32bits(var):
-    return (var>>32) & 0xFFFFFFFF
+    return (var >> 32) & 0xFFFFFFFF
+
 
 def PrintBanner(sz):
-    print("\n"+"="*78)
+    print("\n" + "=" * 78)
     print(sz)
-    print("="*78+"\n")
+    print("=" * 78 + "\n")
+
 
 def ShowUsage():
     PrintBanner("Basic Usage")
     print("python ptool.py -x partition.xml")
     PrintBanner("Advanced Usage")
     print("%-44s\t\tpython ptool.py -x partition.xml" % ("Basic Usage"))
-    print("%-44s\t\tpython ptool.py -x partition.xml -s c:\\windows" % ("Search path to find partition.xml"))
-    print("%-44s\tpython ptool.py -x partition.xml -p 0" % ("Specify PHY Partition 0, (creates rawprogram0.xml)"))
-    print("%-44s\tpython ptool.py -x partition.xml -p 1" % ("Specify PHY Partition 1, (creates rawprogram1.xml)"))
-    print("%-44s\tpython ptool.py -x partition.xml -p 2" % ("Specify PHY Partition 2, (creates rawprogram2.xml)"))
+    print(
+        "%-44s\t\tpython ptool.py -x partition.xml -s c:\\windows"
+        % ("Search path to find partition.xml")
+    )
+    print(
+        "%-44s\tpython ptool.py -x partition.xml -p 0"
+        % ("Specify PHY Partition 0, (creates rawprogram0.xml)")
+    )
+    print(
+        "%-44s\tpython ptool.py -x partition.xml -p 1"
+        % ("Specify PHY Partition 1, (creates rawprogram1.xml)")
+    )
+    print(
+        "%-44s\tpython ptool.py -x partition.xml -p 2"
+        % ("Specify PHY Partition 2, (creates rawprogram2.xml)")
+    )
     print("%-44s\t\tpython ptool.py -x partition.xml -v" % ("Verbose output"))
-    print("%-44s\t\tpython ptool.py -x partition.xml -t c:\\temp" % ("Specify place to put output"))
-    print("%-44s\t\tpython ptool.py -x partition.xml -n" % ("Don't require the use of patch file"))
+    print(
+        "%-44s\t\tpython ptool.py -x partition.xml -t c:\\temp"
+        % ("Specify place to put output")
+    )
+    print(
+        "%-44s\t\tpython ptool.py -x partition.xml -n"
+        % ("Don't require the use of patch file")
+    )
+
 
 def CreateFinalPartitionBin():
     global OutputFolder
 
     with open("%spartition.bin" % OutputFolder, "wb") as opfile:
         for i in range(3):
-            FileName = "%spartition%i.bin" % (OutputFolder,i)
-            size     = 0
+            FileName = "%spartition%i.bin" % (OutputFolder, i)
+            size = 0
 
             if os.path.isfile(FileName):
                 size = os.path.getsize(FileName)
@@ -1663,303 +2560,446 @@ def CreateFinalPartitionBin():
                 opfile.write(temp)
 
             if size < 8192:
-                MyArray = [0]*(8192-size)
+                MyArray = [0] * (8192 - size)
                 for b in MyArray:
                     opfile.write(struct.pack("B", b))
 
 
-
 def prettify(elem):
-    """Return a pretty-printed XML string for the Element.
-    """
-    rough_string = ET.tostring(elem, 'utf-8')
+    """Return a pretty-printed XML string for the Element."""
+    rough_string = ET.tostring(elem, "utf-8")
     reparsed = minidom.parseString(rough_string)
     return reparsed.toprettyxml(indent="  ")
 
 
-def UpdatePartitionTable(Bootable,Type,StartSector,Size,Offset,Record):
+def UpdatePartitionTable(Bootable, Type, StartSector, Size, Offset, Record):
 
-    #print "Size = %i" % Size
+    # print "Size = %i" % Size
 
-    if Bootable=="true":
+    if Bootable == "true":
         Bootable = 0x80
     else:
         Bootable = 0x00
 
     Type = ValidateTYPE(Type)
 
-    #print "\tAt Offset=0x%.4X (%d) (%d bytes left)" % (Offset,Offset,len(Record)-Offset)
+    # print "\tAt Offset=0x%.4X (%d) (%d bytes left)" % (Offset,Offset,len(Record)-Offset)
 
-    Record[Offset]         = Bootable
-    Offset+=1
+    Record[Offset] = Bootable
+    Offset += 1
 
-    Record[Offset:Offset+3]= [0,0,0]
-    Offset+=3
+    Record[Offset : Offset + 3] = [0, 0, 0]
+    Offset += 3
 
-    Record[Offset]         = Type
-    Offset+=1
+    Record[Offset] = Type
+    Offset += 1
 
-    Record[Offset:Offset+3]= [0,0,0]
-    Offset+=3
-
-    # First StartSector
-    for b in range(4):
-        Record[Offset] = ((StartSector>>(b*8)) & 0xFF)
-        Offset+=1
+    Record[Offset : Offset + 3] = [0, 0, 0]
+    Offset += 3
 
     # First StartSector
     for b in range(4):
-        Record[Offset] = ((Size>>(b*8)) & 0xFF)
-        Offset+=1
+        Record[Offset] = (StartSector >> (b * 8)) & 0xFF
+        Offset += 1
 
-    #print "\t\tBoot:0x%.2X, ID:0x%.2X, 0x%.8X, 0x%.8X (%.2fMB)" % (Bootable,Type,StartSector,Size,Size/2048.0)
+    # First StartSector
+    for b in range(4):
+        Record[Offset] = (Size >> (b * 8)) & 0xFF
+        Offset += 1
+
+    # print "\t\tBoot:0x%.2X, ID:0x%.2X, 0x%.8X, 0x%.8X (%.2fMB)" % (Bootable,Type,StartSector,Size,Size/2048.0)
 
     return Record
 
+
 # This function called first, then calls CreateMasterBootRecord and CreateExtendedBootRecords
 def CreateMBRPartitionTable(PhysicalPartitionNumber):
-    global PhyPartition,opfile,RawProgramXML,HashInstructions,ExtendedPartitionBegins,MBR,PARTITIONBIN, MBRBIN, EBRBIN, PATCHES, RAW_PROGRAM
+    global PhyPartition, opfile, RawProgramXML, HashInstructions, ExtendedPartitionBegins, MBR, PARTITIONBIN, MBRBIN, EBRBIN, PATCHES, RAW_PROGRAM
 
     k = PhysicalPartitionNumber
 
-    if(k>=len(PhyPartition)):
-        print("PHY Partition %i of %i not found" % (k,len(PhyPartition)))
+    if k >= len(PhyPartition):
+        print("PHY Partition %i of %i not found" % (k, len(PhyPartition)))
         sys.exit()
 
     NumPartitions = len(PhyPartition[k])
 
-    print("\n\nOn PHY Partition %d that has %d partitions" % (k,NumPartitions))
+    print("\n\nOn PHY Partition %d that has %d partitions" % (k, NumPartitions))
 
     print("\n------------\n")
 
     print("\nFor PHY Partition %i" % k)
-    if(NumPartitions<=4):
+    if NumPartitions <= 4:
         print("\tWe can get away with only an MBR")
-        CreateMasterBootRecord(k, NumPartitions )
+        CreateMasterBootRecord(k, NumPartitions)
     else:
-        print("\tWe will need an MBR and %d EBRs" % (NumPartitions-3))
-        CreateMasterBootRecord(k, 3 )
+        print("\tWe will need an MBR and %d EBRs" % (NumPartitions - 3))
+        CreateMasterBootRecord(k, 3)
 
         ## Now the EXTENDED PARTITION
-        print("\nAbout to make EBR, FirstLBA=%i, LastLBA=%i" % (FirstLBA,LastLBA))
-        CreateExtendedBootRecords(k,NumPartitions-3)
+        print("\nAbout to make EBR, FirstLBA=%i, LastLBA=%i" % (FirstLBA, LastLBA))
+        CreateExtendedBootRecords(k, NumPartitions - 3)
 
+    PARTITIONBIN = "%spartition%i.bin" % (OutputFolder, k)
+    MBRBIN = "%sMBR%i.bin" % (OutputFolder, k)
+    EBRBIN = "%sEBR%i.bin" % (OutputFolder, k)
+    PATCHES = "%spatch%i.xml" % (OutputFolder, k)
+    RAW_PROGRAM = "%srawprogram%i.xml" % (OutputFolder, k)
 
-    PARTITIONBIN    = '%spartition%i.bin'   % (OutputFolder,k)
-    MBRBIN          = '%sMBR%i.bin'         % (OutputFolder,k)
-    EBRBIN          = '%sEBR%i.bin'         % (OutputFolder,k)
-    PATCHES         = '%spatch%i.xml'       % (OutputFolder,k)
-    RAW_PROGRAM     = '%srawprogram%i.xml'  % (OutputFolder,k)
+    UpdateRawProgram(
+        RawProgramXML,
+        0,
+        1 * SECTOR_SIZE_IN_BYTES / 1024.0,
+        k,
+        0,
+        1,
+        MBRBIN,
+        "false",
+        "MBR",
+    )
 
-    UpdateRawProgram(RawProgramXML,0, 1*SECTOR_SIZE_IN_BYTES/1024.0, k, 0, 1, MBRBIN, 'false', 'MBR')
-
-    if(NumPartitions>4):
+    if NumPartitions > 4:
         ## There was more than 4 partitions, so EXT partition had to be used
-        UpdateRawProgram(RawProgramXML,ExtendedPartitionBegins, (NumPartitions-3)*SECTOR_SIZE_IN_BYTES/1024.0, k, 0, NumPartitions-3, EBRBIN, 'false', 'EXT')          # note file offset is 0
+        UpdateRawProgram(
+            RawProgramXML,
+            ExtendedPartitionBegins,
+            (NumPartitions - 3) * SECTOR_SIZE_IN_BYTES / 1024.0,
+            k,
+            0,
+            NumPartitions - 3,
+            EBRBIN,
+            "false",
+            "EXT",
+        )  # note file offset is 0
 
     print("\nptool.py is running from CWD: ", os.getcwd(), "\n")
 
     with open(PARTITIONBIN, "wb") as opfile:
         WriteMBR()
         WriteEBR()
-    print("Created \"%s\"" % PARTITIONBIN)
+    print('Created "%s"' % PARTITIONBIN)
 
     with open(MBRBIN, "wb") as opfile:
         WriteMBR()
-    print("Created \"%s\"" % MBRBIN)
+    print('Created "%s"' % MBRBIN)
 
     with open(EBRBIN, "wb") as opfile:
         WriteEBR()
-    print("Created \"%s\"" % EBRBIN)
+    print('Created "%s"' % EBRBIN)
 
     with open(RAW_PROGRAM, "w") as opfile:
-        opfile.write( prettify(RawProgramXML) )
-    print("Created \"%s\"" % RAW_PROGRAM)
+        opfile.write(prettify(RawProgramXML))
+    print('Created "%s"' % RAW_PROGRAM)
 
     with open(PATCHES, "w") as opfile:
-        opfile.write( prettify(PatchesXML) )
-    print("Created \"%s\"" % PATCHES)
+        opfile.write(prettify(PatchesXML))
+    print('Created "%s"' % PATCHES)
 
     for mydict in hash_w:
-        #print mydict
-        SubElement(EmmcLockRegionsXML, 'program', {'start_sector':"%X" % mydict['start_sector'],'start_sector_dec':str(mydict['start_sector']),
-                                       'num_sectors':"%X" % mydict['num_sectors'],'num_sectors_dec':str(mydict['num_sectors']),
-                                       'boundary_num':str(mydict['boundary_num']),
-                                       'num_boundaries_covered':str(mydict['num_boundaries_covered']),
-                                       'physical_partition_number':str(mydict['physical_partition_number']) })
+        # print mydict
+        SubElement(
+            EmmcLockRegionsXML,
+            "program",
+            {
+                "start_sector": "%X" % mydict["start_sector"],
+                "start_sector_dec": str(mydict["start_sector"]),
+                "num_sectors": "%X" % mydict["num_sectors"],
+                "num_sectors_dec": str(mydict["num_sectors"]),
+                "boundary_num": str(mydict["boundary_num"]),
+                "num_boundaries_covered": str(mydict["num_boundaries_covered"]),
+                "physical_partition_number": str(mydict["physical_partition_number"]),
+            },
+        )
 
-
-    SubElement(EmmcLockRegionsXML, 'information', {'WRITE_PROTECT_BOUNDARY_IN_KB':str(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']) })
+    SubElement(
+        EmmcLockRegionsXML,
+        "information",
+        {
+            "WRITE_PROTECT_BOUNDARY_IN_KB": str(
+                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            )
+        },
+    )
 
     with open("%semmc_lock_regions.xml" % OutputFolder, "w") as opfile:
-        opfile.write( prettify(EmmcLockRegionsXML) )
-    print("Created \"%semmc_lock_regions.xml\"" % OutputFolder)
+        opfile.write(prettify(EmmcLockRegionsXML))
+    print('Created "%semmc_lock_regions.xml"' % OutputFolder)
 
     print("\nUse msp tool to write this information to SD/eMMC card")
     print("\ti.e.")
 
     if sys.platform.startswith("linux"):
-        print("\tsudo python msp.py rawprogram0.xml /dev/sdb    <---- where /dev/sdb is assumed to be your SD/eMMC card")
-        print("\tsudo python msp.py patch0.xml /dev/sdb    <---- where /dev/sdb is assumed to be your SD/eMMC card\n\n")
+        print(
+            "\tsudo python msp.py rawprogram0.xml /dev/sdb    <---- where /dev/sdb is assumed to be your SD/eMMC card"
+        )
+        print(
+            "\tsudo python msp.py patch0.xml /dev/sdb    <---- where /dev/sdb is assumed to be your SD/eMMC card\n\n"
+        )
     else:
-        print("\tpython msp.py rawprogram0.xml \\\\.\\PHYSICALDRIVE2    <---- where \\\\.\\PHYSICALDRIVE2 is")
-        print("\tpython msp.py patch0.xml \\\\.\\PHYSICALDRIVE2    <---- assumed to be your SD/eMMC card\n\n")
+        print(
+            "\tpython msp.py rawprogram0.xml \\\\.\\PHYSICALDRIVE2    <---- where \\\\.\\PHYSICALDRIVE2 is"
+        )
+        print(
+            "\tpython msp.py patch0.xml \\\\.\\PHYSICALDRIVE2    <---- assumed to be your SD/eMMC card\n\n"
+        )
 
 
-  # CreateMasterBootRecord(k,len(PhyPartition[k]) )
-def CreateMasterBootRecord(k,NumMBRPartitions):
-    global PhyPartition,HashInstructions,MBR,FirstLBA,LastLBA
-    print("\nInside CreateMasterBootRecord(%d) -------------------------------------" % NumMBRPartitions)
+# CreateMasterBootRecord(k,len(PhyPartition[k]) )
+def CreateMasterBootRecord(k, NumMBRPartitions):
+    global PhyPartition, HashInstructions, MBR, FirstLBA, LastLBA
+    print(
+        "\nInside CreateMasterBootRecord(%d) -------------------------------------"
+        % NumMBRPartitions
+    )
 
-    MBR             = [0]*SECTOR_SIZE_IN_BYTES
-    MBR[440]        = (HashInstructions['DISK_SIGNATURE'])&0xFF
-    MBR[441]        = (HashInstructions['DISK_SIGNATURE']>>8)&0xFF
-    MBR[442]        = (HashInstructions['DISK_SIGNATURE']>>16)&0xFF
-    MBR[443]        = (HashInstructions['DISK_SIGNATURE']>>24)&0xFF
+    MBR = [0] * SECTOR_SIZE_IN_BYTES
+    MBR[440] = (HashInstructions["DISK_SIGNATURE"]) & 0xFF
+    MBR[441] = (HashInstructions["DISK_SIGNATURE"] >> 8) & 0xFF
+    MBR[442] = (HashInstructions["DISK_SIGNATURE"] >> 16) & 0xFF
+    MBR[443] = (HashInstructions["DISK_SIGNATURE"] >> 24) & 0xFF
 
-    MBR[510:512]    = [0x55,0xAA]           # magic byte for MBR partitioning - always at this location regardless of SECTOR_SIZE_IN_BYTES
+    MBR[510:512] = [
+        0x55,
+        0xAA,
+    ]  # magic byte for MBR partitioning - always at this location regardless of SECTOR_SIZE_IN_BYTES
 
     ## These two values used like so 'num_sectors':str(LastLBA-FirstLBA)
-    FirstLBA    = 1    ## the MBR is at 0, Partition 1 is at 1
-    LastLBA     = 1
+    FirstLBA = 1  ## the MBR is at 0, Partition 1 is at 1
+    LastLBA = 1
 
     PartitionSectorSize = 0
 
-    #print "\nOn PHY Partition %d that has %d partitions" % (k,len(PhyPartition[k]))
-    for j in range(NumMBRPartitions):   # typically this is 0,1,2
+    # print "\nOn PHY Partition %d that has %d partitions" % (k,len(PhyPartition[k]))
+    for j in range(NumMBRPartitions):  # typically this is 0,1,2
 
         ## ALL MBR partitions are marked as read-only
-        PhyPartition[k][j]['readonly'] = "true"
+        PhyPartition[k][j]["readonly"] = "true"
 
-        PartitionSectorSize = ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb'])    # in sector form, i.e. 1KB = 2 sectors
+        PartitionSectorSize = ConvertKBtoSectors(
+            PhyPartition[k][j]["size_in_kb"]
+        )  # in sector form, i.e. 1KB = 2 sectors
 
-        print("\n\n%d of %d \"%s\" (readonly=%s) and size=%dKB (%.2fMB or %i sectors)" % (j+1,len(PhyPartition[k]),PhyPartition[k][j]['label'],
-                                        PhyPartition[k][j]['readonly'],PhyPartition[k][j]['size_in_kb'],
-                                        PhyPartition[k][j]['size_in_kb']/1024.0,ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb'])))
-
+        print(
+            '\n\n%d of %d "%s" (readonly=%s) and size=%dKB (%.2fMB or %i sectors)'
+            % (
+                j + 1,
+                len(PhyPartition[k]),
+                PhyPartition[k][j]["label"],
+                PhyPartition[k][j]["readonly"],
+                PhyPartition[k][j]["size_in_kb"],
+                PhyPartition[k][j]["size_in_kb"] / 1024.0,
+                ConvertKBtoSectors(PhyPartition[k][j]["size_in_kb"]),
+            )
+        )
 
         # Is this sector aligned?
-        if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']>0:
-            AlignedRemainder = FirstLBA % HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']
+        if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] > 0:
+            AlignedRemainder = (
+                FirstLBA % HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            )
 
-            if AlignedRemainder==0:
-                print("\tThis partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)" % (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'],FirstLBA,FirstLBA/(ConvertKBtoSectors(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']))))
-
+            if AlignedRemainder == 0:
+                print(
+                    "\tThis partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)"
+                    % (
+                        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"],
+                        FirstLBA,
+                        FirstLBA
+                        / (
+                            ConvertKBtoSectors(
+                                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                            )
+                        ),
+                    )
+                )
 
         # are we on the very last partition, i.e. did user only specify 3 or less partitions?
-        if (j+1) == len(PhyPartition[k]):
+        if (j + 1) == len(PhyPartition[k]):
             print("\nTHIS IS THE LAST PARTITION")
-            print("HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = %s" % HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'])
-            if HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']:
+            print(
+                "HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = %s"
+                % HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]
+            )
+            if HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]:
                 SectorOffsetPatchBefore = 0
-                SectorOffsetPatchAfter  = 0
-                ByteOffset              = 0x1CA+j*16
-                UpdatePatch(str(SectorOffsetPatchBefore),str(ByteOffset),k,4,"NUM_DISK_SECTORS-%s." % str(FirstLBA),"partition%d.bin" % k, "Update last partition with actual size.")
-                UpdatePatch(str(SectorOffsetPatchBefore),str(ByteOffset),k,4,"NUM_DISK_SECTORS-%s." % str(FirstLBA),"MBR%d.bin" % k, "Update last partition with actual size.")
-                UpdatePatch(str(SectorOffsetPatchAfter), str(ByteOffset),k,4,"NUM_DISK_SECTORS-%s." % str(FirstLBA),"DISK", "Update 'Update last partition with actual size.")
+                SectorOffsetPatchAfter = 0
+                ByteOffset = 0x1CA + j * 16
+                UpdatePatch(
+                    str(SectorOffsetPatchBefore),
+                    str(ByteOffset),
+                    k,
+                    4,
+                    "NUM_DISK_SECTORS-%s." % str(FirstLBA),
+                    "partition%d.bin" % k,
+                    "Update last partition with actual size.",
+                )
+                UpdatePatch(
+                    str(SectorOffsetPatchBefore),
+                    str(ByteOffset),
+                    k,
+                    4,
+                    "NUM_DISK_SECTORS-%s." % str(FirstLBA),
+                    "MBR%d.bin" % k,
+                    "Update last partition with actual size.",
+                )
+                UpdatePatch(
+                    str(SectorOffsetPatchAfter),
+                    str(ByteOffset),
+                    k,
+                    4,
+                    "NUM_DISK_SECTORS-%s." % str(FirstLBA),
+                    "DISK",
+                    "Update 'Update last partition with actual size.",
+                )
 
         # Update the Write-Protect hash
-        if PhyPartition[k][j]['readonly']=="true":
+        if PhyPartition[k][j]["readonly"] == "true":
             UpdateWPhash(FirstLBA, PartitionSectorSize)
 
-        LastLBA += PartitionSectorSize ## increase by num sectors, LastLBA inclusive, so add 1 for size
+        LastLBA += PartitionSectorSize  ## increase by num sectors, LastLBA inclusive, so add 1 for size
 
         ## Default for each partition is no file
-        FileToProgram           = [""]
-        FileOffset              = [0]
-        FilePartitionOffset     = [0]
-        FileAppsbin             = ["false"]
-        FileSparse              = ["false"]
+        FileToProgram = [""]
+        FileOffset = [0]
+        FilePartitionOffset = [0]
+        FileAppsbin = ["false"]
+        FileSparse = ["false"]
 
-        if 'filename' in PhyPartition[k][j]:
+        if "filename" in PhyPartition[k][j]:
             ##print "filename exists"
-            #print PhyPartition[k][j]['filename']
-            #print FileToProgram[0]
+            # print PhyPartition[k][j]['filename']
+            # print FileToProgram[0]
 
+            FileToProgram[0] = PhyPartition[k][j]["filename"][0]
+            FileOffset[0] = PhyPartition[k][j]["fileoffset"][0]
+            FilePartitionOffset[0] = PhyPartition[k][j]["filepartitionoffset"][0]
+            FileAppsbin[0] = PhyPartition[k][j]["appsbin"][0]
+            FileSparse[0] = PhyPartition[k][j]["sparse"][0]
 
-            FileToProgram[0]            = PhyPartition[k][j]['filename'][0]
-            FileOffset[0]               = PhyPartition[k][j]['fileoffset'][0]
-            FilePartitionOffset[0]      = PhyPartition[k][j]['filepartitionoffset'][0]
-            FileAppsbin[0]              = PhyPartition[k][j]['appsbin'][0]
-            FileSparse[0]               = PhyPartition[k][j]['sparse'][0]
+            for z in range(1, len(PhyPartition[k][j]["filename"])):
+                FileToProgram.append(PhyPartition[k][j]["filename"][z])
+                FileOffset.append(PhyPartition[k][j]["fileoffset"][z])
+                FilePartitionOffset.append(PhyPartition[k][j]["filepartitionoffset"][z])
+                FileAppsbin.append(PhyPartition[k][j]["appsbin"][z])
+                FileSparse.append(PhyPartition[k][j]["sparse"][z])
 
-            for z in range(1,len(PhyPartition[k][j]['filename'])):
-                FileToProgram.append( PhyPartition[k][j]['filename'][z] )
-                FileOffset.append( PhyPartition[k][j]['fileoffset'][z] )
-                FilePartitionOffset.append( PhyPartition[k][j]['filepartitionoffset'][z] )
-                FileAppsbin.append( PhyPartition[k][j]['appsbin'][z] )
-                FileSparse.append( PhyPartition[k][j]['sparse'][z] )
+            # print PhyPartition[k][j]['fileoffset']
 
-            #print PhyPartition[k][j]['fileoffset']
-
-
-        #for z in range(len(FileToProgram)):
+        # for z in range(len(FileToProgram)):
         #    print "FileToProgram[",z,"]=",FileToProgram[z]
         #    print "FileOffset[",z,"]=",FileOffset[z]
         #    print " "
 
-        PartitionLabel  = ""
-        Type            = ""
-        Bootable        = "false"
+        PartitionLabel = ""
+        Type = ""
+        Bootable = "false"
 
         ## Now update with the real values
-        if 'label' in PhyPartition[k][j]:
-            PartitionLabel = PhyPartition[k][j]['label']
-        if 'type' in PhyPartition[k][j]:
-            Type = PhyPartition[k][j]['type']
-        if 'bootable' in PhyPartition[k][j]:
-            Bootable = PhyPartition[k][j]['bootable']
+        if "label" in PhyPartition[k][j]:
+            PartitionLabel = PhyPartition[k][j]["label"]
+        if "type" in PhyPartition[k][j]:
+            Type = PhyPartition[k][j]["type"]
+        if "bootable" in PhyPartition[k][j]:
+            Bootable = PhyPartition[k][j]["bootable"]
 
         ## Now it is time to update the partition table
-        offset = 0x1BE + (j*16)
+        offset = 0x1BE + (j * 16)
 
-        MBR = UpdatePartitionTable(Bootable,Type,FirstLBA,PartitionSectorSize,offset,MBR)
-
+        MBR = UpdatePartitionTable(
+            Bootable, Type, FirstLBA, PartitionSectorSize, offset, MBR
+        )
 
         for z in range(len(FileToProgram)):
-            #print "File: ",FileToProgram[z]
-            #print "FilePartitionOffset[z]=",FilePartitionOffset[z]
-            UpdateRawProgram(RawProgramXML, FirstLBA+FilePartitionOffset[z], PartitionSectorSize*SECTOR_SIZE_IN_BYTES/1024.0, k, FileOffset[z], PartitionSectorSize-FilePartitionOffset[z], FileToProgram[z], FileSparse[z], PartitionLabel)
+            # print "File: ",FileToProgram[z]
+            # print "FilePartitionOffset[z]=",FilePartitionOffset[z]
+            UpdateRawProgram(
+                RawProgramXML,
+                FirstLBA + FilePartitionOffset[z],
+                PartitionSectorSize * SECTOR_SIZE_IN_BYTES / 1024.0,
+                k,
+                FileOffset[z],
+                PartitionSectorSize - FilePartitionOffset[z],
+                FileToProgram[z],
+                FileSparse[z],
+                PartitionLabel,
+            )
 
-        FirstLBA = LastLBA      # getting ready for next partition, FirstLBA is now where we left off
+        FirstLBA = LastLBA  # getting ready for next partition, FirstLBA is now where we left off
+
 
 # CreateExtendedBootRecords(k,len(PhyPartition[k])-3)
-def CreateExtendedBootRecords(k,NumEBRPartitions):
-    global PhyPartition,HashInstructions,MBR,EBR,FirstLBA,LastLBA,ExtendedPartitionBegins
-    print("\nInside CreateExtendedBootRecords(%d) -----------------------------------------" % NumEBRPartitions)
+def CreateExtendedBootRecords(k, NumEBRPartitions):
+    global PhyPartition, HashInstructions, MBR, EBR, FirstLBA, LastLBA, ExtendedPartitionBegins
+    print(
+        "\nInside CreateExtendedBootRecords(%d) -----------------------------------------"
+        % NumEBRPartitions
+    )
 
     ## Step 1 is to update the MBR with the size of the EXT partition
     ## in which logical partitions will be created
 
     EBROffset = 0
 
-    print("EBROffset=",EBROffset)
+    print("EBROffset=", EBROffset)
 
     ExtendedPartitionBegins = FirstLBA
 
-    if HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']:
+    if HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]:
         print("Extended Partition begins at FirstLBA=%i\n" % (ExtendedPartitionBegins))
-        MBR=UpdatePartitionTable("false","05",FirstLBA,0x0,0x1EE,MBR)  ## offset at 0x1EE is the last entry in MBR
+        MBR = UpdatePartitionTable(
+            "false", "05", FirstLBA, 0x0, 0x1EE, MBR
+        )  ## offset at 0x1EE is the last entry in MBR
     else:
-        print("Extended Partition begins at FirstLBA=%i, size is %i\n" % (ExtendedPartitionBegins,MinSectorsNeeded-FirstLBA))
-        MBR=UpdatePartitionTable("false","05",FirstLBA,MinSectorsNeeded-FirstLBA,0x1EE,MBR)  ## offset at 0x1EE is the last entry in MBR
+        print(
+            "Extended Partition begins at FirstLBA=%i, size is %i\n"
+            % (ExtendedPartitionBegins, MinSectorsNeeded - FirstLBA)
+        )
+        MBR = UpdatePartitionTable(
+            "false", "05", FirstLBA, MinSectorsNeeded - FirstLBA, 0x1EE, MBR
+        )  ## offset at 0x1EE is the last entry in MBR
 
     ## Still patch no matter what, since this can still go on any size card
-    UpdatePatch('0',str(0x1FA),PhysicalPartitionNumber,4,"NUM_DISK_SECTORS-%s." % str(ExtendedPartitionBegins),"partition%d.bin" % k, "Update MBR with the length of the EXT Partition.")
-    UpdatePatch('0',str(0x1FA),PhysicalPartitionNumber,4,"NUM_DISK_SECTORS-%s." % str(ExtendedPartitionBegins),"MBR%d.bin" % k, "Update MBR with the length of the EXT Partition.")
-    UpdatePatch('0',str(0x1FA),PhysicalPartitionNumber,4,"NUM_DISK_SECTORS-%s." % str(ExtendedPartitionBegins),"DISK", "Update MBR with the length of the EXT Partition.")
+    UpdatePatch(
+        "0",
+        str(0x1FA),
+        PhysicalPartitionNumber,
+        4,
+        "NUM_DISK_SECTORS-%s." % str(ExtendedPartitionBegins),
+        "partition%d.bin" % k,
+        "Update MBR with the length of the EXT Partition.",
+    )
+    UpdatePatch(
+        "0",
+        str(0x1FA),
+        PhysicalPartitionNumber,
+        4,
+        "NUM_DISK_SECTORS-%s." % str(ExtendedPartitionBegins),
+        "MBR%d.bin" % k,
+        "Update MBR with the length of the EXT Partition.",
+    )
+    UpdatePatch(
+        "0",
+        str(0x1FA),
+        PhysicalPartitionNumber,
+        4,
+        "NUM_DISK_SECTORS-%s." % str(ExtendedPartitionBegins),
+        "DISK",
+        "Update MBR with the length of the EXT Partition.",
+    )
 
     UpdateWPhash(FirstLBA, NumEBRPartitions)
 
     ## Need to make room for the EBR tables
-    FirstLBA        += NumEBRPartitions
-    LastLBA         += NumEBRPartitions
+    FirstLBA += NumEBRPartitions
+    LastLBA += NumEBRPartitions
 
-    print("FirstLBA now equals %d since NumEBRPartitions=%d" % (FirstLBA,NumEBRPartitions))
+    print(
+        "FirstLBA now equals %d since NumEBRPartitions=%d"
+        % (FirstLBA, NumEBRPartitions)
+    )
 
-    offset                  = 0     # offset to EBR array which gets EBR.extend( [0]*SECTOR_SIZE_IN_BYTES ) for each EBR
-    SectorsTillNextBoundary = 0     # reset
-
+    offset = 0  # offset to EBR array which gets EBR.extend( [0]*SECTOR_SIZE_IN_BYTES ) for each EBR
+    SectorsTillNextBoundary = 0  # reset
 
     # EBROffset is the num sectors from the location of the EBR to the actual logical partition
     # and because we group all the EBRs together,
@@ -1975,202 +3015,329 @@ def CreateExtendedBootRecords(k,NumEBRPartitions):
     ## meaning 3 primary and then 2 extended. Thus everything here is offset from 3
     ## since the first 3 primary partitions were 0,1,2
     EBR = []
-    for j in range(3,(NumEBRPartitions+3)):
+    for j in range(3, (NumEBRPartitions + 3)):
         SectorsTillNextBoundary = 0
-        EBR.extend( [0]*SECTOR_SIZE_IN_BYTES )
+        EBR.extend([0] * SECTOR_SIZE_IN_BYTES)
 
-        #print "hash_w[%i]['start_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["start_sector"])
-        #print "hash_w[%i]['end_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["end_sector"])
-        #print "hash_w[%i]['num_sectors']=%i" % (NumWPregions,hash_w[NumWPregions]["num_sectors"])
+        # print "hash_w[%i]['start_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["start_sector"])
+        # print "hash_w[%i]['end_sector']=%i" % (NumWPregions,hash_w[NumWPregions]["end_sector"])
+        # print "hash_w[%i]['num_sectors']=%i" % (NumWPregions,hash_w[NumWPregions]["num_sectors"])
 
-        PartitionSectorSize = ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb'])
+        PartitionSectorSize = ConvertKBtoSectors(PhyPartition[k][j]["size_in_kb"])
 
         ##print "\nPartition name='%s' (readonly=%s)" % (PhyPartition[k][j]['label'], PhyPartition[k][j]['readonly'])
-        print("\n\n%d of %d \"%s\" (readonly=%s) and size=%dKB (%.2fMB or %i sectors)" %(j+1,len(PhyPartition[k]),PhyPartition[k][j]['label'],PhyPartition[k][j]['readonly'],PhyPartition[k][j]['size_in_kb'],PhyPartition[k][j]['size_in_kb']/1024.0,ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb'])))
-        print("\tFirstLBA=%d (with size %d sectors) and LastLBA=%d" % (FirstLBA,ConvertKBtoSectors(PhyPartition[k][j]['size_in_kb']),LastLBA))
+        print(
+            '\n\n%d of %d "%s" (readonly=%s) and size=%dKB (%.2fMB or %i sectors)'
+            % (
+                j + 1,
+                len(PhyPartition[k]),
+                PhyPartition[k][j]["label"],
+                PhyPartition[k][j]["readonly"],
+                PhyPartition[k][j]["size_in_kb"],
+                PhyPartition[k][j]["size_in_kb"] / 1024.0,
+                ConvertKBtoSectors(PhyPartition[k][j]["size_in_kb"]),
+            )
+        )
+        print(
+            "\tFirstLBA=%d (with size %d sectors) and LastLBA=%d"
+            % (FirstLBA, ConvertKBtoSectors(PhyPartition[k][j]["size_in_kb"]), LastLBA)
+        )
 
-        if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']>0:
-            SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(FirstLBA,HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'])
+        if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] > 0:
+            SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(
+                FirstLBA, HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            )
 
         # Only the last partition can be re-sized. Are we on the very last partition?
-        if (j+1) == len(PhyPartition[k]):
+        if (j + 1) == len(PhyPartition[k]):
             print("\n\tTHIS IS THE LAST PARTITION")
 
-            if PhyPartition[k][j]['readonly']=="true":
-                PhyPartition[k][j]['readonly']="false"
+            if PhyPartition[k][j]["readonly"] == "true":
+                PhyPartition[k][j]["readonly"] = "false"
                 print("\tIt cannot be marked as read-only, it is now set to writeable")
 
-            if HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK']:
+            if HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]:
                 ## Here I'd want a patch for this
-                print("\tHashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = %s" % HashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'])
+                print(
+                    "\tHashInstructions['GROW_LAST_PARTITION_TO_FILL_DISK'] = %s"
+                    % HashInstructions["GROW_LAST_PARTITION_TO_FILL_DISK"]
+                )
 
-                print("\njust set LAST PartitionSectorSize = 0 (it was %d)" % PartitionSectorSize)
+                print(
+                    "\njust set LAST PartitionSectorSize = 0 (it was %d)"
+                    % PartitionSectorSize
+                )
                 PartitionSectorSize = 0
                 print("This means the partition table will have a zero in it")
 
-            NumEBRs = (len(PhyPartition[k])-3)
+            NumEBRs = len(PhyPartition[k]) - 3
             SectorOffsetPatchBefore = NumEBRs
-            SectorOffsetPatchAfter  = ExtendedPartitionBegins+NumEBRs-1
-            ByteOffset              = 0x1CA
+            SectorOffsetPatchAfter = ExtendedPartitionBegins + NumEBRs - 1
+            ByteOffset = 0x1CA
 
             ## Patch no matter what
-            UpdatePatch(str(SectorOffsetPatchBefore),str(ByteOffset),PhysicalPartitionNumber,4,"NUM_DISK_SECTORS-%s." % str(FirstLBA+1),"partition%d.bin" % k, "Update last partition with actual size.")
-            UpdatePatch(str(SectorOffsetPatchBefore-1),str(ByteOffset),PhysicalPartitionNumber,4,"NUM_DISK_SECTORS-%s." % str(FirstLBA+1),"EBR%d.bin" % k, "Update last partition with actual size.")
-            UpdatePatch(str(SectorOffsetPatchAfter), str(ByteOffset),PhysicalPartitionNumber,4,"NUM_DISK_SECTORS-%s." % str(FirstLBA+1),"DISK", "Update last partition with actual size.")
+            UpdatePatch(
+                str(SectorOffsetPatchBefore),
+                str(ByteOffset),
+                PhysicalPartitionNumber,
+                4,
+                "NUM_DISK_SECTORS-%s." % str(FirstLBA + 1),
+                "partition%d.bin" % k,
+                "Update last partition with actual size.",
+            )
+            UpdatePatch(
+                str(SectorOffsetPatchBefore - 1),
+                str(ByteOffset),
+                PhysicalPartitionNumber,
+                4,
+                "NUM_DISK_SECTORS-%s." % str(FirstLBA + 1),
+                "EBR%d.bin" % k,
+                "Update last partition with actual size.",
+            )
+            UpdatePatch(
+                str(SectorOffsetPatchAfter),
+                str(ByteOffset),
+                PhysicalPartitionNumber,
+                4,
+                "NUM_DISK_SECTORS-%s." % str(FirstLBA + 1),
+                "DISK",
+                "Update last partition with actual size.",
+            )
 
+        print("\tPhyPartition[k][j]['align']=", PhyPartition[k][j]["align"])
+        print("\tSectorsTillNextBoundary=", SectorsTillNextBoundary)
 
-        print("\tPhyPartition[k][j]['align']=",PhyPartition[k][j]['align'])
-        print("\tSectorsTillNextBoundary=",SectorsTillNextBoundary)
-
-        if PhyPartition[k][j]['readonly']=="true":
+        if PhyPartition[k][j]["readonly"] == "true":
             ## to be here means this partition is read-only, so see if we need to move the start
             if FirstLBA <= hash_w[NumWPregions]["end_sector"]:
-                print("Great, We *don't* need to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"]))
+                print(
+                    "Great, We *don't* need to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)"
+                    % (FirstLBA, hash_w[NumWPregions]["end_sector"])
+                )
                 pass
             else:
-                print("\tFirstLBA (%d) is *not* covered by the end of the WP region (%d),\n\tit needs to be moved to be aligned to %d" % (FirstLBA,hash_w[NumWPregions]["end_sector"],FirstLBA + SectorsTillNextBoundary))
+                print(
+                    "\tFirstLBA (%d) is *not* covered by the end of the WP region (%d),\n\tit needs to be moved to be aligned to %d"
+                    % (
+                        FirstLBA,
+                        hash_w[NumWPregions]["end_sector"],
+                        FirstLBA + SectorsTillNextBoundary,
+                    )
+                )
                 FirstLBA += SectorsTillNextBoundary
-        elif PhyPartition[k][j]['align']=="true":
+        elif PhyPartition[k][j]["align"] == "true":
             ## to be here means this partition *must* be on an ALIGN boundary
-            SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(FirstLBA,HashInstructions['ALIGN_BOUNDARY_IN_KB'])
-            if SectorsTillNextBoundary>0:
-                print("\tSectorsTillNextBoundary=%d, FirstLBA=%d it needs to be moved to be aligned to %d" % (SectorsTillNextBoundary,FirstLBA,FirstLBA + SectorsTillNextBoundary))
-                print("\tHashInstructions['ALIGN_BOUNDARY_IN_KB']=",HashInstructions['ALIGN_BOUNDARY_IN_KB'])
+            SectorsTillNextBoundary = ReturnNumSectorsTillBoundary(
+                FirstLBA, HashInstructions["ALIGN_BOUNDARY_IN_KB"]
+            )
+            if SectorsTillNextBoundary > 0:
+                print(
+                    "\tSectorsTillNextBoundary=%d, FirstLBA=%d it needs to be moved to be aligned to %d"
+                    % (
+                        SectorsTillNextBoundary,
+                        FirstLBA,
+                        FirstLBA + SectorsTillNextBoundary,
+                    )
+                )
+                print(
+                    "\tHashInstructions['ALIGN_BOUNDARY_IN_KB']=",
+                    HashInstructions["ALIGN_BOUNDARY_IN_KB"],
+                )
                 FirstLBA += SectorsTillNextBoundary
 
-                AlignedRemainder = FirstLBA % HashInstructions['ALIGN_BOUNDARY_IN_KB']
+                AlignedRemainder = FirstLBA % HashInstructions["ALIGN_BOUNDARY_IN_KB"]
 
-                if AlignedRemainder==0:
-                    print("\tThis partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)" % (HashInstructions['ALIGN_BOUNDARY_IN_KB'],FirstLBA,FirstLBA/(ConvertKBtoSectors(HashInstructions['ALIGN_BOUNDARY_IN_KB']))))
+                if AlignedRemainder == 0:
+                    print(
+                        "\tThis partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)"
+                        % (
+                            HashInstructions["ALIGN_BOUNDARY_IN_KB"],
+                            FirstLBA,
+                            FirstLBA
+                            / (
+                                ConvertKBtoSectors(
+                                    HashInstructions["ALIGN_BOUNDARY_IN_KB"]
+                                )
+                            ),
+                        )
+                    )
 
         else:
-            print("\n\tThis partition is *NOT* readonly (or does not have align='true')")
+            print(
+                "\n\tThis partition is *NOT* readonly (or does not have align='true')"
+            )
             ## to be here means this partition is writeable, so see if we need to move the start
             if FirstLBA <= hash_w[NumWPregions]["end_sector"]:
-                print("\tWe *need* to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"]))
-                print("\nhash_w[NumWPregions]['end_sector']=%i" % hash_w[NumWPregions]["end_sector"])
-                print("FirstLBA=%i\n" %FirstLBA)
+                print(
+                    "\tWe *need* to move FirstLBA (%d) since it's covered by the end of the current WP region (%d)"
+                    % (FirstLBA, hash_w[NumWPregions]["end_sector"])
+                )
+                print(
+                    "\nhash_w[NumWPregions]['end_sector']=%i"
+                    % hash_w[NumWPregions]["end_sector"]
+                )
+                print("FirstLBA=%i\n" % FirstLBA)
                 FirstLBA += SectorsTillNextBoundary
 
                 print("\tFirstLBA is now %d" % (FirstLBA))
             else:
-                #print "Great, We *don't* need to move FirstLBA (%d) since it's *not* covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"])
+                # print "Great, We *don't* need to move FirstLBA (%d) since it's *not* covered by the end of the current WP region (%d)" % (FirstLBA,hash_w[NumWPregions]["end_sector"])
                 pass
 
-        if HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']>0:
-            AlignedRemainder = FirstLBA % HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']
+        if HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"] > 0:
+            AlignedRemainder = (
+                FirstLBA % HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+            )
 
-            if AlignedRemainder==0:
-                print("\tThis partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)" % (HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'],FirstLBA,FirstLBA/(ConvertKBtoSectors(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']))))
+            if AlignedRemainder == 0:
+                print(
+                    "\tThis partition is ** ALIGNED ** to a %i KB boundary at sector %i (boundary %i)"
+                    % (
+                        HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"],
+                        FirstLBA,
+                        FirstLBA
+                        / (
+                            ConvertKBtoSectors(
+                                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]
+                            )
+                        ),
+                    )
+                )
 
-        if PhyPartition[k][j]['readonly']=="true":
+        if PhyPartition[k][j]["readonly"] == "true":
             UpdateWPhash(FirstLBA, PartitionSectorSize)
 
         LastLBA = FirstLBA + PartitionSectorSize
 
-        print("\n\tFirstLBA=%u, LastLBA=%u, PartitionSectorSize=%u" % (FirstLBA,LastLBA,PartitionSectorSize))
+        print(
+            "\n\tFirstLBA=%u, LastLBA=%u, PartitionSectorSize=%u"
+            % (FirstLBA, LastLBA, PartitionSectorSize)
+        )
 
         print("\tLastLBA is currently %i sectors" % LastLBA)
-        print("\tCard size of at least %.1fMB needed (%u sectors)" % (LastLBA/2048.0,LastLBA))
-        PhyPartition[k][j]['size_in_kb'] = PartitionSectorSize/2
+        print(
+            "\tCard size of at least %.1fMB needed (%u sectors)"
+            % (LastLBA / 2048.0, LastLBA)
+        )
+        PhyPartition[k][j]["size_in_kb"] = PartitionSectorSize / 2
 
         ## Default for each partition is no file
-        FileToProgram           = [""]
-        FileOffset              = [0]
-        FilePartitionOffset     = [0]
-        FileAppsbin             = ["false"]
-        FileSparse              = ["false"]
+        FileToProgram = [""]
+        FileOffset = [0]
+        FilePartitionOffset = [0]
+        FileAppsbin = ["false"]
+        FileSparse = ["false"]
 
-        if 'filename' in PhyPartition[k][j]:
+        if "filename" in PhyPartition[k][j]:
             ##print "filename exists"
-            #print PhyPartition[k][j]['filename']
-            #print FileToProgram[0]
+            # print PhyPartition[k][j]['filename']
+            # print FileToProgram[0]
 
-            FileToProgram[0]            = PhyPartition[k][j]['filename'][0]
-            FileOffset[0]               = PhyPartition[k][j]['fileoffset'][0]
-            FilePartitionOffset[0]      = PhyPartition[k][j]['filepartitionoffset'][0]
-            FileAppsbin[0]              = PhyPartition[k][j]['appsbin'][0]
-            FileSparse[0]               = PhyPartition[k][j]['sparse'][0]
+            FileToProgram[0] = PhyPartition[k][j]["filename"][0]
+            FileOffset[0] = PhyPartition[k][j]["fileoffset"][0]
+            FilePartitionOffset[0] = PhyPartition[k][j]["filepartitionoffset"][0]
+            FileAppsbin[0] = PhyPartition[k][j]["appsbin"][0]
+            FileSparse[0] = PhyPartition[k][j]["sparse"][0]
 
-            for z in range(1,len(PhyPartition[k][j]['filename'])):
-                FileToProgram.append( PhyPartition[k][j]['filename'][z] )
-                FileOffset.append( PhyPartition[k][j]['fileoffset'][z] )
-                FilePartitionOffset.append( PhyPartition[k][j]['filepartitionoffset'][z] )
-                FileAppsbin.append( PhyPartition[k][j]['appsbin'][z] )
-                FileSparse.append( PhyPartition[k][j]['sparse'][z] )
+            for z in range(1, len(PhyPartition[k][j]["filename"])):
+                FileToProgram.append(PhyPartition[k][j]["filename"][z])
+                FileOffset.append(PhyPartition[k][j]["fileoffset"][z])
+                FilePartitionOffset.append(PhyPartition[k][j]["filepartitionoffset"][z])
+                FileAppsbin.append(PhyPartition[k][j]["appsbin"][z])
+                FileSparse.append(PhyPartition[k][j]["sparse"][z])
 
-            #print PhyPartition[k][j]['fileoffset']
+            # print PhyPartition[k][j]['fileoffset']
 
-
-        #for z in range(len(FileToProgram)):
+        # for z in range(len(FileToProgram)):
         #    print "FileToProgram[",z,"]=",FileToProgram[z]
         #    print "FileOffset[",z,"]=",FileOffset[z]
         #    print " "
 
-        PartitionLabel  = ""
-        Type            = ""
-        Bootable        = "false"
+        PartitionLabel = ""
+        Type = ""
+        Bootable = "false"
 
-
-        if 'label' in PhyPartition[k][j]:
-            PartitionLabel = PhyPartition[k][j]['label']
-        if 'type' in PhyPartition[k][j]:
-            Type = PhyPartition[k][j]['type']
-        if 'bootable' in PhyPartition[k][j]:
-            Bootable = PhyPartition[k][j]['bootable']
-
+        if "label" in PhyPartition[k][j]:
+            PartitionLabel = PhyPartition[k][j]["label"]
+        if "type" in PhyPartition[k][j]:
+            Type = PhyPartition[k][j]["type"]
+        if "bootable" in PhyPartition[k][j]:
+            Bootable = PhyPartition[k][j]["bootable"]
 
         ## Update main logical partition
-        offset += 0x1BE     ## this naturally increments to 0x200, then 0x400 etc
+        offset += 0x1BE  ## this naturally increments to 0x200, then 0x400 etc
 
         ##UpdatePartitionTable(Bootable,Type,EBROffset,PartitionSectorSize,offset) ; offset +=16
-        EBR = UpdatePartitionTable(Bootable,Type,FirstLBA-ExtendedPartitionBegins-EBROffset,PartitionSectorSize,offset,EBR)
-        offset +=16
+        EBR = UpdatePartitionTable(
+            Bootable,
+            Type,
+            FirstLBA - ExtendedPartitionBegins - EBROffset,
+            PartitionSectorSize,
+            offset,
+            EBR,
+        )
+        offset += 16
 
         ## Update EXT, i.e. are there more partitions to come?
-        if (j+1) == (NumEBRPartitions+3):
+        if (j + 1) == (NumEBRPartitions + 3):
             ## No, this is the very last so indicate no more logical partitions
-            EBR = UpdatePartitionTable("false","00",0,0,offset,EBR)
-            offset +=16  ## on last partition, so no more
+            EBR = UpdatePartitionTable("false", "00", 0, 0, offset, EBR)
+            offset += 16  ## on last partition, so no more
         else:
             ## Yes, at least one more, so indicate EXT type of 05
-            EBR = UpdatePartitionTable("false","05",j-2,1,offset,EBR)
-            offset +=16
+            EBR = UpdatePartitionTable("false", "05", j - 2, 1, offset, EBR)
+            offset += 16
 
         ## Update last 2 which are always blank
-        EBR = UpdatePartitionTable("false","00",0,0,offset,EBR)
-        offset +=16
-        EBR = UpdatePartitionTable("false","00",0,0,offset,EBR)
-        offset +=16
+        EBR = UpdatePartitionTable("false", "00", 0, 0, offset, EBR)
+        offset += 16
+        EBR = UpdatePartitionTable("false", "00", 0, 0, offset, EBR)
+        offset += 16
 
-        EBR[offset]     = 0x55
-        offset +=1
-        EBR[offset]     = 0xAA
-        offset +=1
-
+        EBR[offset] = 0x55
+        offset += 1
+        EBR[offset] = 0xAA
+        offset += 1
 
         ## Now update EBROffset
-        EBROffset += 1                      # Each EBR gets us one closer
+        EBROffset += 1  # Each EBR gets us one closer
 
         for z in range(len(FileToProgram)):
-            #print "File: ",FileToProgram[z]
-            #print "FilePartitionOffset[z]=",FilePartitionOffset[z]
-            UpdateRawProgram(RawProgramXML,FirstLBA+FilePartitionOffset[z], PartitionSectorSize*SECTOR_SIZE_IN_BYTES/1024.0, k, FileOffset[z], PartitionSectorSize-FilePartitionOffset[z], FileToProgram[z], FileSparse[z], PartitionLabel)
+            # print "File: ",FileToProgram[z]
+            # print "FilePartitionOffset[z]=",FilePartitionOffset[z]
+            UpdateRawProgram(
+                RawProgramXML,
+                FirstLBA + FilePartitionOffset[z],
+                PartitionSectorSize * SECTOR_SIZE_IN_BYTES / 1024.0,
+                k,
+                FileOffset[z],
+                PartitionSectorSize - FilePartitionOffset[z],
+                FileToProgram[z],
+                FileSparse[z],
+                PartitionLabel,
+            )
 
-        FirstLBA = LastLBA      # getting ready for next partition, FirstLBA is now where we left off
+        FirstLBA = LastLBA  # getting ready for next partition, FirstLBA is now where we left off
 
-
-    print("\n------------------------------------------------------------------------------")
+    print(
+        "\n------------------------------------------------------------------------------"
+    )
     print("             LastLBA is currently %i sectors" % (LastLBA))
-    print("       Card size of at least %.1fMB needed (%u sectors)" % (LastLBA/2048.0,LastLBA))
-    print("------------------------------------------------------------------------------")
+    print(
+        "       Card size of at least %.1fMB needed (%u sectors)"
+        % (LastLBA / 2048.0, LastLBA)
+    )
+    print(
+        "------------------------------------------------------------------------------"
+    )
+
 
 def ReturnNumSectorsTillBoundary(CurrentLBA, BoundaryInKB):
-    #Say BoundaryInKB is 65536 (64MB)
+    # Say BoundaryInKB is 65536 (64MB)
     #    if SECTOR_SIZE_IN_BYTES=512,  BoundaryLBA=131072
     #    if SECTOR_SIZE_IN_BYTES=4096, BoundaryLBA=16384
 
-    #Say were at the 63MB boundary, then
+    # Say were at the 63MB boundary, then
     #    if SECTOR_SIZE_IN_BYTES=512,  CurrentLBA=129024
     #    if SECTOR_SIZE_IN_BYTES=4096, CurrentLBA=16128
 
@@ -2181,42 +3348,47 @@ def ReturnNumSectorsTillBoundary(CurrentLBA, BoundaryInKB):
     ##import pdb; pdb.set_trace()
 
     x = 0
-    if BoundaryInKB>0:
-        if (CurrentLBA%ConvertKBtoSectors(BoundaryInKB)) > 0:
-            x = ConvertKBtoSectors(BoundaryInKB) - (CurrentLBA%ConvertKBtoSectors(BoundaryInKB))
+    if BoundaryInKB > 0:
+        if (CurrentLBA % ConvertKBtoSectors(BoundaryInKB)) > 0:
+            x = ConvertKBtoSectors(BoundaryInKB) - (
+                CurrentLBA % ConvertKBtoSectors(BoundaryInKB)
+            )
 
     ##print "\tFYI: Increase by %dKB (%d sectors) if you want to align to %i KB boundary at sector %d" % (x/2,x,BoundaryInKB,CurrentLBA+x)
     return x
 
 
 def WriteMBR():
-    global opfile,MBR
+    global opfile, MBR
     for b in MBR:
         opfile.write(struct.pack("B", b))
 
+
 def WriteEBR():
-    global opfile,EBR
+    global opfile, EBR
     for b in EBR:
         opfile.write(struct.pack("B", b))
 
+
 def find_file(filename, search_paths):
-    print("\n\n\tLooking for ",filename)
-    print("\t"+"-"*40)
+    print("\n\n\tLooking for ", filename)
+    print("\t" + "-" * 40)
     for x in search_paths:
-        print("\tSearching ",x)
+        print("\tSearching ", x)
         temp = os.path.join(x, filename)
         if os.path.exists(temp):
-            print("\n\t**Found %s (%i bytes)" % (temp,os.path.getsize(temp)))
+            print("\n\t**Found %s (%i bytes)" % (temp, os.path.getsize(temp)))
             return temp
 
     ## search cwd last
-    print("\tSearching ",os.getcwd())
+    print("\tSearching ", os.getcwd())
     if os.path.exists(filename):
-        print("\n\t**Found %s (%i bytes)" % (filename,os.path.getsize(filename)))
+        print("\n\t**Found %s (%i bytes)" % (filename, os.path.getsize(filename)))
         return filename
 
     print("\tCound't find file\n")
     return None
+
 
 ## ==============================================================================================
 ## ==============================================================================================
@@ -2229,29 +3401,44 @@ def find_file(filename, search_paths):
 if len(sys.argv) < 2:
     CreateErasingRawProgramFiles()
     ShowUsage()
-    sys.exit() # error
+    sys.exit()  # error
 
 print("\nCWD: ", os.getcwd(), "\n")
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "x:f:p:s:t:g:k:v:en", ["xml=", "format=", "partition=", "search_path=", "location=", "sequentialguid=", "use128partitions=", "verbose=","erasefirst","nopatch"])
+    opts, args = getopt.getopt(
+        sys.argv[1:],
+        "x:f:p:s:t:g:k:v:en",
+        [
+            "xml=",
+            "format=",
+            "partition=",
+            "search_path=",
+            "location=",
+            "sequentialguid=",
+            "use128partitions=",
+            "verbose=",
+            "erasefirst",
+            "nopatch",
+        ],
+    )
 except getopt.GetoptError as err:
     # print help information and exit:
-    print(str(err)) # will print something like "option -a not recognized"
+    print(str(err))  # will print something like "option -a not recognized"
     ShowUsage()
     sys.exit(1)
 
-XMLFile= "adalovelace"
-OutputToCreate          = None ## sys.argv[2]
-PhysicalPartitionNumber = 0     ## sys.argv[3]
-search_paths            = []
+XMLFile = "adalovelace"
+OutputToCreate = None  ## sys.argv[2]
+PhysicalPartitionNumber = 0  ## sys.argv[3]
+search_paths = []
 
-verbose                 = False
-UsingGetOpts            = False
-sequentialguid          = 0
-force128partitions      = 0
+verbose = False
+UsingGetOpts = False
+sequentialguid = 0
+force128partitions = 0
 PhysicalPartitionNumber = -1
-erasefirst              = 0
+erasefirst = 0
 
 for o, a in opts:
     if o in ("-x", "--xml"):
@@ -2259,23 +3446,27 @@ for o, a in opts:
         XMLFile = a
     elif o in ("-t", "--location"):
         OutputFolder = a
-        OutputFolder = re.sub(r"\\$","",OutputFolder)    # remove final slash if it exists
-        OutputFolder = re.sub(r"/$","",OutputFolder)     # remove final slash if it exists
+        OutputFolder = re.sub(
+            r"\\$", "", OutputFolder
+        )  # remove final slash if it exists
+        OutputFolder = re.sub(
+            r"/$", "", OutputFolder
+        )  # remove final slash if it exists
 
-        OutputFolder += "/"     # slashes will all be corrected below
+        OutputFolder += "/"  # slashes will all be corrected below
 
         if sys.platform.startswith("linux"):
-            OutputFolder = re.sub(r"\\","/",OutputFolder)   # correct slashes
+            OutputFolder = re.sub(r"\\", "/", OutputFolder)  # correct slashes
         else:
-            OutputFolder = re.sub(r"/","\\\\",OutputFolder) # correct slashes
+            OutputFolder = re.sub(r"/", "\\\\", OutputFolder)  # correct slashes
 
-        print("OutputFolder=",OutputFolder)
-        EnsureDirectoryExists(OutputFolder) # only need to call once
+        print("OutputFolder=", OutputFolder)
+        EnsureDirectoryExists(OutputFolder)  # only need to call once
 
     elif o in ("-f", "--format"):
         UsingGetOpts = True
         OutputToCreate = a
-        m = re.search("^(mbr|gpt)$", a)     #mbr|gpt
+        m = re.search("^(mbr|gpt)$", a)  # mbr|gpt
         if m is None:
             PrintBigError("ERROR: Only MBR or GPT is supported")
         else:
@@ -2288,7 +3479,7 @@ for o, a in opts:
 
     elif o in ("-k", "--use128partitions"):
         ## Force there to be 128 partitions in the partition table
-        m = re.search(r'\d', a)     #mbr|gpt
+        m = re.search(r"\d", a)  # mbr|gpt
         if m is None:
             force128partitions = 0
         else:
@@ -2302,7 +3493,7 @@ for o, a in opts:
 
     elif o in ("-g", "--sequentialguid"):
         ## also allow seperating commas
-        m = re.search(r'\d', a)     #mbr|gpt
+        m = re.search(r"\d", a)  # mbr|gpt
         if m is None:
             sequentialguid = 0
         else:
@@ -2311,30 +3502,34 @@ for o, a in opts:
     elif o in ("-p", "--partition"):
         UsingGetOpts = True
         PhysicalPartitionNumber = a
-        m = re.search(r'^(\d)$', a)     #0|1|2
+        m = re.search(r"^(\d)$", a)  # 0|1|2
         if m is None:
-            PrintBigError("ERROR: PhysicalPartitionNumber (-p) must be a number, you supplied *",a,"*")
+            PrintBigError(
+                "ERROR: PhysicalPartitionNumber (-p) must be a number, you supplied *",
+                a,
+                "*",
+            )
         else:
             PhysicalPartitionNumber = int(m.group(1))
     elif o in ("-v", "--verbose"):
         UsingGetOpts = True
         verbose = True
     else:
-        print("o=",o)
+        print("o=", o)
         assert False, "unhandled option"
 
 if UsingGetOpts is False:
-    #ParseCommandLine()
+    # ParseCommandLine()
     PrintBanner("NEW USAGE - Note this program will auto-detect if it's GPT or MBR")
     ShowUsage()
     sys.exit(1)
 
-print("XMLFile=",XMLFile)
-if len(OutputFolder)>0:
-    print("OutputFolder=",OutputFolder)
-print("OutputToCreate",OutputToCreate)
-print("PhysicalPartitionNumber",PhysicalPartitionNumber)
-print("verbose",verbose)
+print("XMLFile=", XMLFile)
+if len(OutputFolder) > 0:
+    print("OutputFolder=", OutputFolder)
+print("OutputToCreate", OutputToCreate)
+print("PhysicalPartitionNumber", PhysicalPartitionNumber)
+print("verbose", verbose)
 
 
 XMLFile = find_file(XMLFile, search_paths)
@@ -2345,50 +3540,96 @@ ParseXML(XMLFile)  # parses XMLFile, discovers if GPT or MBR
 
 PrintBanner("OutputToCreate ===> '%s'" % OutputToCreate)
 
+
 def InitializeXMLFileVars():
-    global EmmcLockRegionsXML,RawProgramXML,RawProgramXML_Wipe,PatchesXML,RawProgramXML_Blank,PatchesXML_Blank
+    global EmmcLockRegionsXML, RawProgramXML, RawProgramXML_Wipe, PatchesXML, RawProgramXML_Blank, PatchesXML_Blank
 
-    EmmcLockRegionsXML = Element('protect')
+    EmmcLockRegionsXML = Element("protect")
     EmmcLockRegionsXML.append(Comment("NOTE: This is an ** Autogenerated file **"))
-    EmmcLockRegionsXML.append(Comment('NOTE: Sector size is %ibytes, WRITE_PROTECT_BOUNDARY_IN_KB=%i, WRITE_PROTECT_BOUNDARY_IN_SECTORS=%i' % (SECTOR_SIZE_IN_BYTES,HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB'],ConvertKBtoSectors(HashInstructions['WRITE_PROTECT_BOUNDARY_IN_KB']))))
-    EmmcLockRegionsXML.append(Comment("NOTE: \"num_sectors\" in HEX \"start_sector\" in HEX, i.e. 10 really equals 16 !!"))
+    EmmcLockRegionsXML.append(
+        Comment(
+            "NOTE: Sector size is %ibytes, WRITE_PROTECT_BOUNDARY_IN_KB=%i, WRITE_PROTECT_BOUNDARY_IN_SECTORS=%i"
+            % (
+                SECTOR_SIZE_IN_BYTES,
+                HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"],
+                ConvertKBtoSectors(HashInstructions["WRITE_PROTECT_BOUNDARY_IN_KB"]),
+            )
+        )
+    )
+    EmmcLockRegionsXML.append(
+        Comment(
+            'NOTE: "num_sectors" in HEX "start_sector" in HEX, i.e. 10 really equals 16 !!'
+        )
+    )
 
-    RawProgramXML = Element('data')
-    RawProgramXML.append(Comment('NOTE: This is an ** Autogenerated file **'))
-    RawProgramXML.append(Comment('NOTE: Sector size is %ibytes'%SECTOR_SIZE_IN_BYTES))
+    RawProgramXML = Element("data")
+    RawProgramXML.append(Comment("NOTE: This is an ** Autogenerated file **"))
+    RawProgramXML.append(Comment("NOTE: Sector size is %ibytes" % SECTOR_SIZE_IN_BYTES))
 
-    RawProgramXML_Wipe = Element('data')
-    RawProgramXML_Wipe.append(Comment('NOTE: This is an ** Autogenerated file **'))
-    RawProgramXML_Wipe.append(Comment('NOTE: Sector size is %ibytes'%SECTOR_SIZE_IN_BYTES))
+    RawProgramXML_Wipe = Element("data")
+    RawProgramXML_Wipe.append(Comment("NOTE: This is an ** Autogenerated file **"))
+    RawProgramXML_Wipe.append(
+        Comment("NOTE: Sector size is %ibytes" % SECTOR_SIZE_IN_BYTES)
+    )
 
-    PatchesXML = Element('patches')
-    PatchesXML.append(Comment('NOTE: This is an ** Autogenerated file **'))
-    PatchesXML.append(Comment('NOTE: Patching is in little endian format, i.e. 0xAABBCCDD will look like DD CC BB AA in the file or on disk'))
-    PatchesXML.append(Comment('NOTE: This file is used by Trace32 - So make sure to add decimals, i.e. 0x10-10=0, *but* 0x10-10.=6.'))
+    PatchesXML = Element("patches")
+    PatchesXML.append(Comment("NOTE: This is an ** Autogenerated file **"))
+    PatchesXML.append(
+        Comment(
+            "NOTE: Patching is in little endian format, i.e. 0xAABBCCDD will look like DD CC BB AA in the file or on disk"
+        )
+    )
+    PatchesXML.append(
+        Comment(
+            "NOTE: This file is used by Trace32 - So make sure to add decimals, i.e. 0x10-10=0, *but* 0x10-10.=6."
+        )
+    )
 
-    RawProgramXML_Blank = Element('data')
-    RawProgramXML_Blank.append(Comment('NOTE: This is an ** Autogenerated file **'))
-    RawProgramXML_Blank.append(Comment('NOTE: This file writes a VALID but EMPTY partition table to sector 0 **'))
-    RawProgramXML_Blank.append(Comment('NOTE: Sector size is %ibytes'%SECTOR_SIZE_IN_BYTES))
+    RawProgramXML_Blank = Element("data")
+    RawProgramXML_Blank.append(Comment("NOTE: This is an ** Autogenerated file **"))
+    RawProgramXML_Blank.append(
+        Comment(
+            "NOTE: This file writes a VALID but EMPTY partition table to sector 0 **"
+        )
+    )
+    RawProgramXML_Blank.append(
+        Comment("NOTE: Sector size is %ibytes" % SECTOR_SIZE_IN_BYTES)
+    )
 
-    PatchesXML_Blank = Element('patches')
-    PatchesXML_Blank.append(Comment('NOTE: This is an ** Autogenerated file **'))
-    PatchesXML_Blank.append(Comment('NOTE: Patching is in little endian format, i.e. 0xAABBCCDD will look like DD CC BB AA in the file or on disk'))
-    PatchesXML_Blank.append(Comment('NOTE: This file is used by Trace32 - So make sure to add decimals, i.e. 0x10-10=0, *but* 0x10-10.=6.'))
+    PatchesXML_Blank = Element("patches")
+    PatchesXML_Blank.append(Comment("NOTE: This is an ** Autogenerated file **"))
+    PatchesXML_Blank.append(
+        Comment(
+            "NOTE: Patching is in little endian format, i.e. 0xAABBCCDD will look like DD CC BB AA in the file or on disk"
+        )
+    )
+    PatchesXML_Blank.append(
+        Comment(
+            "NOTE: This file is used by Trace32 - So make sure to add decimals, i.e. 0x10-10=0, *but* 0x10-10.=6."
+        )
+    )
+
 
 if OutputToCreate == "gpt":
     if PhysicalPartitionNumber == -1:
-        for PhysicalPartitionNumber in range(0,len(PhyPartition)):  ## where len(PhyPartition) is typically a maximum of 8
+        for PhysicalPartitionNumber in range(
+            0, len(PhyPartition)
+        ):  ## where len(PhyPartition) is typically a maximum of 8
             InitializeXMLFileVars()
-            CreateGPTPartitionTable( PhysicalPartitionNumber ) ## wants it in LBA format, i.e. 1KB = 2 sectors of size SECTOR_SIZE_IN_BYTES
+            CreateGPTPartitionTable(
+                PhysicalPartitionNumber
+            )  ## wants it in LBA format, i.e. 1KB = 2 sectors of size SECTOR_SIZE_IN_BYTES
         CreateErasingRawProgramFiles()
-        print("\n\nNOTE: All Physical Partitions / LUNs were created since user did not use -p 0 option\n\n")
+        print(
+            "\n\nNOTE: All Physical Partitions / LUNs were created since user did not use -p 0 option\n\n"
+        )
     else:
         InitializeXMLFileVars()
-        CreateGPTPartitionTable( PhysicalPartitionNumber, True ) ## wants it in LBA format, i.e. 1KB = 2 sectors of size SECTOR_SIZE_IN_BYTES
+        CreateGPTPartitionTable(
+            PhysicalPartitionNumber, True
+        )  ## wants it in LBA format, i.e. 1KB = 2 sectors of size SECTOR_SIZE_IN_BYTES
         CreateErasingRawProgramFiles()
 else:
     InitializeXMLFileVars()
-    CreateMBRPartitionTable( PhysicalPartitionNumber )
+    CreateMBRPartitionTable(PhysicalPartitionNumber)
     CreateFinalPartitionBin()
-

--- a/utils.py
+++ b/utils.py
@@ -43,16 +43,16 @@ def reflect(data, nBits):
     reflection = 0x00000000
     for bit in range(nBits):
         if data & 0x01:
-            reflection |= (1 << ((nBits - 1) - bit))
+            reflection |= 1 << ((nBits - 1) - bit)
         data = data >> 1
     return reflection
 
 
 def CalcCRC32(array, Len):
-    k        = 8            # length of unit (i.e. byte)
-    MSB      = 0
-    gx       = 0x04C11DB7  # IEEE 32bit polynomial
-    regs     = 0xFFFFFFFF  # init to all ones
+    k = 8  # length of unit (i.e. byte)
+    MSB = 0
+    gx = 0x04C11DB7  # IEEE 32bit polynomial
+    regs = 0xFFFFFFFF  # init to all ones
     regsMask = 0xFFFFFFFF  # ensure only 32 bit answer
 
     for i in range(int(Len)):
@@ -60,21 +60,21 @@ def CalcCRC32(array, Len):
         DataByte = reflect(DataByte, 8)
 
         for j in range(k):
-            MSB  = DataByte >> (k - 1)  ## get MSB
-            MSB &= 1                    ## ensure just 1 bit
+            MSB = DataByte >> (k - 1)  ## get MSB
+            MSB &= 1  ## ensure just 1 bit
 
             regsMSB = (regs >> 31) & 1
 
-            regs = regs << 1            ## shift regs for CRC-CCITT
+            regs = regs << 1  ## shift regs for CRC-CCITT
 
-            if regsMSB ^ MSB:           ## MSB is a 1
-                regs = regs ^ gx        ## XOR with generator poly
+            if regsMSB ^ MSB:  ## MSB is a 1
+                regs = regs ^ gx  ## XOR with generator poly
 
-            regs = regs & regsMask      ## Mask off excess upper bits
+            regs = regs & regsMask  ## Mask off excess upper bits
 
-            DataByte <<= 1              ## get to next bit
+            DataByte <<= 1  ## get to next bit
 
-    regs          = regs & regsMask
+    regs = regs & regsMask
     ReflectedRegs = reflect(regs, 32) ^ 0xFFFFFFFF
 
     return ReflectedRegs


### PR DESCRIPTION
Applies automated code-quality tooling across all Python sources.
No functional changes.

- Extract duplicated helpers (EnsureDirectoryExists, reflect,
  CalcCRC32, PrintBigWarning, PrintBigError) into a shared utils.py
- Sort imports consistently using [isort](https://github.com/PyCQA/isort)
- Fix 95 lint violations (unused imports, bare except, undefined names,
  dead variables, boolean/identity comparisons, trailing semicolons)
  reported by [ruff](https://github.com/astral-sh/ruff)
- Reformat all sources with [black](https://github.com/psf/black)