### PR TITLE
platforms: add emmc version of iq-9075-evk files

### DIFF
--- a/platforms/iq-9075-evk/emmc/contents.xml.in
+++ b/platforms/iq-9075-evk/emmc/contents.xml.in
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<!--
+========================================================================
+  contents.xml.in
+
+  General Description
+     Contains information about component builds for this target.
+     It will clone as contents.xml during build compilation process.
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  SPDX-License-Identifier: BSD-3-Clause
+
+========================================================================
+-->
+
+<contents>
+  <product_flavors cmm_pf_var="PRODUCT_FLAVORS">
+    <pf>
+      <name>default</name>
+      <component>
+        <name>common</name>
+        <flavor>default</flavor>
+      </component>
+      <component>
+        <name>apps</name>
+        <flavor>default</flavor>
+      </component>
+    </pf>
+  </product_flavors>
+  <product_info>
+    <product_name>QCS9100.LE.0.0</product_name>
+    <chipid flavor="default" storage_type="emmc" flash_phase="1">QCS9100</chipid>
+    <additional_chipid>SA8775P,QCS9075</additional_chipid>
+    <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
+  </product_info>
+  <builds_flat>
+    <build>
+      <name>apps</name>
+      <role>apps</role>
+      <chipset>QCS9100</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>apps_proc</image_dir>
+    </build>
+    <build>
+      <name>common</name>
+      <role>common</role>
+      <chipset>QCS9100</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>common</image_dir>
+      <device_programmer>
+        <file_name>prog_firehose_ddr.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <device_programmer firehose_type="lite">
+        <file_name>prog_firehose_lite.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <download_file>
+        <fastboot_complete>{partition_name}</fastboot_complete>
+        <file_name>{image_name}</file_name>
+        <file_path>.</file_path>
+      </download_file>
+      <partition_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_file>
+      <partition_patch_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_patch_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_patch_file>
+   </build>
+  </builds_flat>
+</contents>

--- a/platforms/iq-9075-evk/emmc/partitions.conf
+++ b/platforms/iq-9075-evk/emmc/partitions.conf
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# options if not explicitly provide
+#
+# The eMMC hardware uses at least 2 physical partitions on this platform:
+#   - Physical Partition 0 (no --phys-part, or --phys-part=0): Main storage with all partitions (JEDEC "User Data Area")
+#   - Physical Partition 1 (--phys-part=1): OTP storage with cdt partition only (JEDEC "Boot Area Partition 1")
+
+--disk --type=emmc --size=76841669632 --write-protect-boundary=65536 --sector-size-in-bytes=512 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --phys-part (specifies physical partition number for eMMC/UFS)
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --attributes  1000000000000004
+#   --filename    ""
+#   --readonly    true
+#   --sparse      false
+
+# Physical Partition 0 (--phys-part=0) - Main storage partition (JEDEC "User Data Area")
+# Boot partitions
+--partition --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --name=shrm_a --size=80KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --name=xbl_b --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --name=xbl_config_b --size=512KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
+--partition --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+
+# OTP / Misc partitions (on PHY 0)
+--partition --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
+
+# Firmware partitions
+# A/B partitions
+--partition --name=aop_a --size=256KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
+--partition --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --name=core_nhlos_a --size=174080KB --type-guid=6690B4CE-70E9-4817-B9F1-25D64D888357
+--partition --name=core_nhlos_b --size=174080KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
+--partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
+--partition --name=xbl_ramdump_b --size=2048KB --type-guid=C3E58B09-ABCB-42EA-9F0C-3FA453FA892E --filename=XblRamdump.elf
+--partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --name=tz_a --size=4000KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --name=hyp_a --size=65536KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
+--partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
+--partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
+--partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F
+--partition --name=qupfw_b --size=128KB --type-guid=04BA8D53-5091-4958-9CA1-0FE0941D2CBC
+--partition --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
+--partition --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
+--partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
+--partition --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=multi_image_qti.mbn
+--partition --name=imagefv_a --size=1024KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
+--partition --name=usb4fw_a --size=61KB --type-guid=3FA03C7A-9FDC-498B-A2A8-DE11EE339790
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+--partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
+--partition --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
+--partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
+--partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
+--partition --name=uefivarstore --size=512KB --type-guid=165BD6BC-9250-4AC8-95A7-A93F4A440066
+--partition --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
+--partition --name=softsku --size=8KB --type-guid=69CFD37F-3D6B-48ED-9739-23015606BE65
+--partition --name=gearvm_a --size=16000KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27
+--partition --name=diag_log --size=65536KB --type-guid=3989AF30-5C02-4154-AD00-1D34C816CAC1
+--partition --name=pvm_log --size=65536KB --type-guid=2889C942-FF80-4DA8-A5B8-3F32F285C0D8
+--partition --name=gvm_log --size=65536KB --type-guid=78EBFD49-E8B1-4E75-ABC0-3F2DBC7428DD
+--partition --name=aop_b --size=256KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
+--partition --name=tz_b --size=4000KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --name=hyp_b --size=65536KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=hypvm.mbn
+--partition --name=keymaster_b --size=512KB --type-guid=441EEF80-DE15-4522-9995-563398D94889
+--partition --name=devcfg_b --size=128KB --type-guid=4E820A31-17E3-447D-B32D-FB339F7EA1A2 --filename=devcfg_iot.mbn
+--partition --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
+--partition --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
+--partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
+--partition --name=multiimgqti_b --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=multi_image_qti.mbn
+--partition --name=imagefv_b --size=1024KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
+--partition --name=gearvm_b --size=16000KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003
+--partition --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+--partition --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
+--partition --name=xbl_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
+--partition --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+
+# HLOS partitions
+--partition --name=persist --size=30720KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
+--partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+
+# Physical Partition 1 (--phys-part=1) - OTP storage partition (JEDEC "Boot Area Partition 1")
+--partition --phys-part=1 --name=cdt --size=4KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
+--partition --phys-part=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Add partitions.conf and contents.xml.in for IQ-9075-EVK booting from eMMC, to maintain parity with QLI 1.x.