### PR TITLE
gen_partition.py: fix integer division in partition_size_in_kb()

### DIFF
--- a/gen_partition.py
+++ b/gen_partition.py
@@ -89,7 +89,7 @@ def disk_options(argv):
 
 def partition_size_in_kb(size):
     if not re.search('[a-zA-Z]+', size):
-        return int(size)/1024
+        return int(size)//1024
     if re.search('([0-9])*(?=([Kk]([Bb])*))', size):
         return int(re.search('([0-9])*(?=([Kk]([Bb])*))', size).group(0))
     if re.search('([0-9])*(?=([Mm]([Bb])*))', size):


### PR DESCRIPTION
Python3 changed the '/' operator to always return a float, so, say int(1536)/1024 returns 1.5 instead of 1.
This float value is then written into the XML as size_in_kb="1.5", causing ptool.py to crash with ValueError when it later calls int("1.5").

Use floor division '//' to restore the Python 2 integer semantics.