### PR TITLE
gen_partition.py: fix phys_part type inconsistency in partition_options

### DIFF
--- a/gen_partition.py
+++ b/gen_partition.py
@@ -99,7 +99,7 @@ def partition_size_in_kb(size):
 
 def partition_options(argv):
    partition_entry = partition_entry_defaults.copy()
-   phys_part = 0
+   phys_part = "0"
    for (opt, arg) in argv:
       if opt in ['--lun', '--phys-part']:
          phys_part = arg


### PR DESCRIPTION
When --lun is absent, phys_part defaulted to integer 0, but when --lun=N is provided it is set to the string arg "N". This mixed typing causes a UFS config that has both an explicit --lun=0 partition and a partition with no --lun to produce two separate <physical_partition> elements for the same LUN 0 in the output XML.

Default phys_part to the string "0" so it is always the same type as the value assigned from --lun/--phys-part arguments.