### PR TITLE
ptool.py: fix MBR disk signature written in wrong byte order

### DIFF
--- a/ptool.py
+++ b/ptool.py
@@ -807,10 +807,10 @@ def CreateGPTPartitionTable(PhysicalPartitionNumber,UserProvided=False):
     PrimaryGPT[i+8:i+8+4]   = [0x01,0x00,0x00,0x00] # starting sector
     PrimaryGPT[i+12:i+12+4] = [0xFF,0xFF,0xFF,0xFF] # starting sector
 
-    PrimaryGPT[440]         = (HashInstructions['DISK_SIGNATURE']>>24)&0xFF
-    PrimaryGPT[441]         = (HashInstructions['DISK_SIGNATURE']>>16)&0xFF
-    PrimaryGPT[442]         = (HashInstructions['DISK_SIGNATURE']>>8)&0xFF
-    PrimaryGPT[443]         = (HashInstructions['DISK_SIGNATURE'])&0xFF
+    PrimaryGPT[440]         = (HashInstructions['DISK_SIGNATURE'])&0xFF
+    PrimaryGPT[441]         = (HashInstructions['DISK_SIGNATURE']>>8)&0xFF
+    PrimaryGPT[442]         = (HashInstructions['DISK_SIGNATURE']>>16)&0xFF
+    PrimaryGPT[443]         = (HashInstructions['DISK_SIGNATURE']>>24)&0xFF
 
     PrimaryGPT[510:512]     = [0x55,0xAA]           # magic byte for MBR partitioning - always at this location regardless of SECTOR_SIZE_IN_BYTES
 
@@ -1863,10 +1863,10 @@ def CreateMasterBootRecord(k,NumMBRPartitions):
     print("\nInside CreateMasterBootRecord(%d) -------------------------------------" % NumMBRPartitions)
 
     MBR             = [0]*SECTOR_SIZE_IN_BYTES
-    MBR[440]        = (HashInstructions['DISK_SIGNATURE']>>24)&0xFF
-    MBR[441]        = (HashInstructions['DISK_SIGNATURE']>>16)&0xFF
-    MBR[442]        = (HashInstructions['DISK_SIGNATURE']>>8)&0xFF
-    MBR[443]        = (HashInstructions['DISK_SIGNATURE'])&0xFF
+    MBR[440]        = (HashInstructions['DISK_SIGNATURE'])&0xFF
+    MBR[441]        = (HashInstructions['DISK_SIGNATURE']>>8)&0xFF
+    MBR[442]        = (HashInstructions['DISK_SIGNATURE']>>16)&0xFF
+    MBR[443]        = (HashInstructions['DISK_SIGNATURE']>>24)&0xFF
 
     MBR[510:512]    = [0x55,0xAA]           # magic byte for MBR partitioning - always at this location regardless of SECTOR_SIZE_IN_BYTES
 


### PR DESCRIPTION
The MBR disk signature field at bytes 440-443 (offset 0x1B8) is a 32-bit little-endian value per the MBR specification, but both CreateGPTPartitionTable() and CreateMasterBootRecord() wrote it big-endian (MSB at byte 440, LSB at byte 443).

Per the UEFI Specification (section 5.2.1, Table 20 "Protective MBR"), the Unique Disk ID at offset 0x1B8 is a 4-byte little-endian field. The same byte order is described in the Master Boot Record format documentation (see https://wiki.osdev.org/MBR_(x86)#MBR_Format, "Disk Timestamp / OEM ID / Disk Signature").

With the default DISK_SIGNATURE of 0x0 the output was identical, so the bug was latent. Any non-zero DISK_SIGNATURE set via the XML would produce a protective MBR with the signature bytes in the wrong order, potentially preventing firmware or host tools from recognising the disk layout correctly.

Fix both sites by reversing the shift order so LSB goes to byte 440.