### PR TITLE
platforms/contents.xml.in: add missing component for glymur-crd

### DIFF
--- a/platforms/glymur-crd/spinor/contents.xml.in
+++ b/platforms/glymur-crd/spinor/contents.xml.in
@@ -28,6 +28,10 @@
         <name>apps</name>
         <flavor>qcom_server</flavor>
       </component>
+      <component>
+        <name>common</name>
+        <flavor>qcom_server</flavor>
+      </component>
     </pf>
   </product_flavors>
   <product_info>


### PR DESCRIPTION
Axiom build was failing with below error dur to the missing "common" component in contents.xml.in file, so adding it in the file to resolve the issue.

```
No download files found or files missing for device WS84801D110995003
PartitionFiles list is null or empty
```