### PR TITLE
platforms/iq-9075-evk: add additional chipid for iq-9075-evk

### DIFF
--- a/platforms/iq-9075-evk/ufs/contents.xml.in
+++ b/platforms/iq-9075-evk/ufs/contents.xml.in
@@ -38,7 +38,7 @@
     <product_name>QCS9100.LE.0.0</product_name>
     <chipid flavor="default" storage_type="ufs" flash_phase="1">QCS9100</chipid>
     <chipid flavor="sail_nor" storage_type="spinor" flash_phase="2">QCS9100</chipid>
-    <additional_chipid>SA8775P,QCS9075</additional_chipid>
+    <additional_chipid>SA8775P,QCS9075,QCS9075M,QCS9100M</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
     <build_type>K2L</build_type>
   </product_info>


### PR DESCRIPTION
Due to missing chipid, jobs are not getting picked in axiom. So adding "QCS9075M,QCS9100M" to additional chipid in contents.xml.in.

Fixes [issue#92](https://github.com/qualcomm-linux/qcom-ptool/issues/92)