### PR TITLE
platforms: add emmc version of qcm6490-idp

### DIFF
--- a/platforms/qcm6490-idp/emmc/contents.xml.in
+++ b/platforms/qcm6490-idp/emmc/contents.xml.in
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<!--
+========================================================================
+  contents.in
+
+  General Description
+     Contains information about component builds for this target.
+     It will clone as contents.xml during build compilation process.
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  SPDX-License-Identifier: BSD-3-Clause
+
+========================================================================
+-->
+
+<contents>
+  <product_flavors cmm_pf_var="PRODUCT_FLAVORS">
+    <pf>
+      <name>default</name>
+      <component>
+        <name>common</name>
+        <flavor>default</flavor>
+      </component>
+      <component>
+        <name>apps</name>
+        <flavor>default</flavor>
+      </component>
+    </pf>
+  </product_flavors>
+  <product_info>
+    <product_name>QCM6490.LE.0.0</product_name>
+    <chipid flavor="default" storage_type="emmc" flash_phase="1">QCM6490</chipid>
+    <additional_chipid>SM7325,QCS6490</additional_chipid>
+    <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
+  </product_info>
+  <builds_flat>
+    <build>
+      <name>apps</name>
+      <role>apps</role>
+      <chipset>QCM6490</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>apps_proc</image_dir>
+    </build>
+    <build>
+      <name>common</name>
+      <role>common</role>
+      <chipset>QCM6490</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>common</image_dir>
+      <device_programmer>
+        <file_name>prog_firehose_ddr.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <device_programmer firehose_type="lite">
+        <file_name>prog_firehose_lite.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <download_file>
+        <fastboot_complete>{partition_name}</fastboot_complete>
+        <file_name>{image_name}</file_name>
+        <file_path>.</file_path>
+      </download_file>
+      <partition_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_file>
+      <partition_patch_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_patch_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_patch_file>
+   </build>
+  </builds_flat>
+</contents>

--- a/platforms/qcm6490-idp/emmc/partitions.conf
+++ b/platforms/qcm6490-idp/emmc/partitions.conf
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# options if not explicitly provid
+--disk --type=ufs --size=137438953472 --write-protect-boundary=0 --sector-size-in-bytes=4096 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --lun (mandatory for UFS, emmc no need this)
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --attributes  1000000000000004
+#   --filename    ""
+#   --readonly    true
+#   --sparse      false
+
+# Physical Partition 0 (--phys-part=0) - Main storage partition (JEDEC "User Data Area")
+# Boot partitions
+--partition --name=xbl_a --size=3604KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --name=xbl_b --size=3604KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --name=xbl_config_a --size=512KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --name=xbl_config_b --size=512KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
+--partition --name=shrm_a --size=128KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --name=shrm_b --size=128KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+
+# OTP / Misc partitions (on PHY 0)
+--partition --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
+
+# Firmware partitions
+# A/B partitions
+--partition --name=aop_a --size=512KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
+--partition --name=apdp_a --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507 --filename=zeros_33sectors.bin
+--partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=XblRamdump.elf
+--partition --name=uefi_a --size=5120KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=tz_a --size=4096KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
+--partition --name=qupfw_a --size=80KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
+--partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
+--partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F --filename=imagefv.elf
+--partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
+--partition --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
+--partition --name=qweslicstore_a  --size=256KB --type-guid=7BAB3C93-5F73-4D02-B8CB-5B9F899D29A8
+--partition --name=aop_b --size=512KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
+--partition --name=apdp_b --size=256KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9 --filename=zeros_33sectors.bin
+--partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --name=xbl_ramdump_b --size=2048KB --type-guid=FF608BF6-AEDF-4084-BEC5-C92AB4E4534D --filename=XblRamdump.elf
+--partition --name=uefi_b --size=5120KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg.mbn
+--partition --name=qupfw_b --size=80KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C --filename=qupv3fw.elf
+--partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687 --filename=imagefv.elf
+--partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
+--partition --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
+--partition --name=qweslicstore_b --size=256KB --type-guid=225AF6E5-C009-4B6F-A240-625D1510D1FF
+--partition --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+--partition --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+--partition --name=questdatafv --size=16384KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
+--partition --name=qmcs --size=30720KB --type-guid=358740B1-34BD-4E4C-9656-3454F0A8FDD9
+--partition --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
+--partition --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --name=limits-cdsp --size=4KB --type-guid=545D3707-8329-40E8-8B5E-3E554CBDC786
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=tools.fv
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
+--partition --name=quantumsdk --size=40960KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+--partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=quantumfv --size=512KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09
+--partition --name=catecontentfv --size=1024KB  --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
+--partition --name=vm-data --size=33424KB --type-guid=21ADB864-C9E7-4C76-BE68-568E20C58439
+--partition --name=modemst1 --size=3072KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=modemst2 --size=3072KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=fsg --size=3072KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=fsc --size=128KB --type-guid=57B90A16-22C9-E33B-8F5D-0E81686A68CB
+
+# HLOS partitions
+--partition --name=persist --size=30720KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
+--partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --name=rootfs --size=10485760KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+
+# Physical Partition 1 (--phys-part=1) - OTP storage partition (JEDEC "Boot Area Partition 1")
+--partition --phys-part=1 --name=cdt --size=4KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
+--partition --phys-part=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Add partitions.conf and contents.xml.in for QCM6490-IDP booting from eMMC

Fixes [issue#85](https://github.com/qualcomm-linux/qcom-ptool/issues/85)