### PR TITLE
platforms: set storage_type as ufs in contents.xml.in for IQ-X7181 EVK

### DIFF
--- a/platforms/iq-x7181-evk/spinor/contents.xml.in
+++ b/platforms/iq-x7181-evk/spinor/contents.xml.in
@@ -37,7 +37,7 @@
   <product_info>
     <product_name>Hamoa_IOT.UBUN.1.0</product_name>
     <chipid flavor="default" storage_type="spinor" flash_phase="1">HAMOA</chipid>
-    <chipid flavor="ub_qcom_server" storage_type="NVME" flash_phase="2">HAMOA</chipid>
+    <chipid flavor="ub_qcom_server" storage_type="UFS" flash_phase="2">HAMOA</chipid>
     <additional_chipid>HAMOA,Hamoa_IOT,Purwa_IoT</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
     <build_type>K2L</build_type>
@@ -77,27 +77,27 @@
         <file_name>{partition_patch_file_name}</file_name>
         <file_path flavor="default">.</file_path>
       </partition_patch_file>
-      <download_file storage_type="nvme" fastboot_complete="efi">
+      <download_file storage_type="ufs" fastboot_complete="efi">
         <file_name>efi.bin</file_name>
         <file_path flavor="ub_qcom_server">../</file_path>
       </download_file>
-      <download_file storage_type="nvme" fastboot_complete="rootfs">
+      <download_file storage_type="ufs" fastboot_complete="rootfs">
         <file_name>rootfs.img</file_name>
         <file_path flavor="ub_qcom_server">../</file_path>
       </download_file>
-      <download_file storage_type="nvme" flavor="ub_qcom_server">
+      <download_file storage_type="ufs" flavor="ub_qcom_server">
         <file_name>gpt_main0.bin</file_name>
         <file_path flavor="ub_qcom_server">../</file_path>
       </download_file>
-      <download_file storage_type="nvme" flavor="ub_qcom_server">
+      <download_file storage_type="ufs" flavor="ub_qcom_server">
         <file_name>gpt_backup0.bin</file_name>
         <file_path flavor="ub_qcom_server">../</file_path>
       </download_file>
-      <partition_file storage_type="nvme" flavor="ub_qcom_server">
+      <partition_file storage_type="ufs" flavor="ub_qcom_server">
         <file_name>rawprogram0.xml</file_name>
         <file_path flavor="ub_qcom_server">../</file_path>
       </partition_file>
-      <partition_patch_file storage_type="nvme" flavor="ub_qcom_server">
+      <partition_patch_file storage_type="ufs" flavor="ub_qcom_server">
         <file_name>patch0.xml</file_name>
         <file_path flavor="ub_qcom_server">../</file_path>
       </partition_patch_file>


### PR DESCRIPTION
As UFS build get supported by default on IQ-X7181 EVK boards, update the storage type accordingly to ensure axiom flashing normally.