### PR TITLE
platforms: reduce SPI-NOR partition sizes for glymur-crd

### DIFF
--- a/platforms/glymur-crd/spinor/partitions.conf
+++ b/platforms/glymur-crd/spinor/partitions.conf
@@ -66,16 +66,16 @@
 --partition --name=ddr_debug --size=2160KB --type-guid=2D58205E-BA35-4BF9-B6C1-C6FDC80A373B
 --partition --name=APDP --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
 --partition --name=XBL_SC --size=2520KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl_s.melf
---partition --name=BOOT_FW1 --size=16500KB --type-guid=CD6CDFAB-B3F7-46C6-BFFE-1A1D2B8B7BA0 --filename=bootfw1.bin
+--partition --name=BOOT_FW1 --size=12288KB --type-guid=CD6CDFAB-B3F7-46C6-BFFE-1A1D2B8B7BA0 --filename=bootfw1.bin
 --partition --name=BOOT_FW2 --size=6200KB --type-guid=FA99213C-D1C9-4EA7-8689-EBC1C3EFAB7E --filename=bootfw2.bin
 --partition --name=XBL_RAMDUMP --size=512KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875
 --partition --name=TZAPPS --size=768KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
 --partition --name=MULTIIMGQTI --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
 --partition --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
---partition --name=dtb_a --size=8192KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8
+--partition --name=dtb_a --size=4096KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8
 --partition --name=APDP_BACKUP --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
 --partition --name=XBL_SC_BACKUP --size=2520KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl_s.melf
---partition --name=BOOT_FW1_BACKUP --size=16500KB --type-guid=08E98E12-0ACF-4D3F-B881-E7A2D87949DF --filename=bootfw1.bin
+--partition --name=BOOT_FW1_BACKUP --size=12288KB --type-guid=08E98E12-0ACF-4D3F-B881-E7A2D87949DF --filename=bootfw1.bin
 --partition --name=BOOT_FW2_BACKUP --size=6200KB --type-guid=0A849567-3DDF-409C-A9BB-26BC8CF8D079 --filename=bootfw2.bin
 --partition --name=QC_RESERVED --size=64KB --type-guid=5A62D5E4-2E26-4560-95DA-E86CDC7CC0D4
 --partition --name=QC_RESERVED_BACKUP --size=64KB --type-guid=8CF0B012-6EF8-44D9-ADF6-3892140979DA
@@ -84,4 +84,4 @@
 --partition --name=TZAPPS_BACKUP --size=768KB --type-guid=BE3719E5-48A7-4ABC-B494-304864D02148
 --partition --name=MULTIIMGQTI_BACKUP --size=32KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9
 --partition --name=SPU_PROD_BACKUP --size=1024KB --type-guid=C759F596-F8FE-4A1A-851E-5BF0F291793E
---partition --name=dtb_b --size=8192KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587
+--partition --name=dtb_b --size=4096KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587


### PR DESCRIPTION
The total SPI-NOR partition size exceeded the available SPI-NOR capacity (~64MB). Reduce BOOT_FW1 and BOOT_FW1_BACKUP sizes to 12288KB, although bootfw1.bin is currently 8192KB, additional space is reserved to accommodate potential future growth. Reduce dtb_a and dtb_b sizes to 4096KB to match current dtb.bin size.

The issue was discussed in [PR#338](https://github.com/qualcomm-linux/qcom-deb-images/pull/338) qcom-deb-images repo