### PR TITLE
platforms/contents.xml.in: add missing build_type field for glymur-crd

### DIFF
--- a/platforms/glymur-crd/spinor/contents.xml.in
+++ b/platforms/glymur-crd/spinor/contents.xml.in
@@ -40,6 +40,7 @@
     <chipid flavor="qcom_server" storage_type="NVME" flash_phase="2">GLYMUR</chipid>
     <additional_chipid>SC8480XP</additional_chipid>
     <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
   </product_info>
   <builds_flat>
     <build>


### PR DESCRIPTION
K2L is the type used by Axiom to identify Qualcomm Linux builds. Add missing build_type field in contents.xml.

Fixes [issue#101](https://github.com/qualcomm-linux/qcom-ptool/issues/101)