### PR TITLE
qrb2210-unoq: update partitions based on the edk2-downstream boot fir…

### DIFF
--- a/platforms/qrb2210-unoq/emmc-16GB-arduino/partitions.conf
+++ b/platforms/qrb2210-unoq/emmc-16GB-arduino/partitions.conf
@@ -28,25 +28,21 @@
 --partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
 --partition --name=rpm_b --size=512KB --type-guid=EDE665C0-9F65-47D9-A8C1-73D61EF3C7D6 --filename=rpm.mbn
---partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
---partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hyp.mbn
---partition --name=boot_a --size=4096KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
---partition --name=boot_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
---partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388
---partition --name=uefi_b --size=8192KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B
---partition --name=uefi_dtb_a --size=1024KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6
---partition --name=uefi_dtb_b --size=1024KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=8192KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --name=uefi_dtb_a --size=1024KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
+--partition --name=uefi_dtb_b --size=1024KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
 --partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=km4.mbn
---partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=km4.mbn
+--partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
 --partition --name=mdtpsecapp_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --name=mdtp_b --size=32768KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
---partition --name=abl_b --size=1024KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=abl.elf
 --partition --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
 --partition --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
 --partition --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
@@ -58,10 +54,8 @@
 --partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
 --partition --name=misc_boot --size=1024KB --type-guid=F4EEE7D9-AB97-4297-954B-1B8AF9C14B19 --filename=zeros_33sectors.bin
 --partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
---partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
---partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg.mbn
---partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7 --filename=featenabler.mbn
---partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=featenabler.mbn
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg_iot.mbn
 --partition --name=qupfw_a --size=64KB --type-guid=21d1219f-2ed1-4ab4-930a-41a16ae75f7f --filename=qupv3fw.elf
 --partition --name=qupfw_b --size=64KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=qupv3fw.elf
 --partition --name=frp --size=512KB --type-guid=91B72D4D-71E0-4CBF-9B8E-236381CFF17A
@@ -77,7 +71,6 @@
 --partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
 --partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
 --partition --name=logdump --size=65536KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --name=storsec --size=128KB --type-guid=02DB45FE-AD1B-4CB6-AECC-0042C637DEFA --filename=storsec.mbn
 --partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E

--- a/platforms/qrb2210-unoq/emmc-16GB/partitions.conf
+++ b/platforms/qrb2210-unoq/emmc-16GB/partitions.conf
@@ -28,25 +28,21 @@
 --partition --name=tz_b --size=4096KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
 --partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
 --partition --name=rpm_b --size=512KB --type-guid=EDE665C0-9F65-47D9-A8C1-73D61EF3C7D6 --filename=rpm.mbn
---partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hyp.mbn
---partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hyp.mbn
---partition --name=boot_a --size=4096KB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --filename=boot.img
---partition --name=boot_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=boot.img
---partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388
---partition --name=uefi_b --size=8192KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B
---partition --name=uefi_dtb_a --size=1024KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6
---partition --name=uefi_dtb_b --size=1024KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --name=uefi_a --size=8192KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=8192KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --name=uefi_dtb_a --size=1024KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
+--partition --name=uefi_dtb_b --size=1024KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
 --partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
 --partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
 --partition --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
---partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=km4.mbn
---partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=km4.mbn
+--partition --name=keymaster_a --size=512KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626
+--partition --name=keymaster_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
 --partition --name=mdtpsecapp_b --size=4096KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
 --partition --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
 --partition --name=mdtp_b --size=32768KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
---partition --name=abl_a --size=1024KB --type-guid=BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB --filename=abl.elf
---partition --name=abl_b --size=1024KB --type-guid=3D3E3AD2-8FF3-4975-A7E7-0E8A10B69F0D --filename=abl.elf
 --partition --name=ddr_a --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
 --partition --name=ddr_b --size=1024KB --type-guid=325DEF02-1305-44A3-AA8D-AC82FEBE220E
 --partition --name=ssd --size=8KB --type-guid=2C86E742-745E-4FDD-BFD8-B6A7AC638772
@@ -58,10 +54,8 @@
 --partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
 --partition --name=misc_boot --size=1024KB --type-guid=F4EEE7D9-AB97-4297-954B-1B8AF9C14B19 --filename=zeros_33sectors.bin
 --partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
---partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg.mbn
---partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg.mbn
---partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7 --filename=featenabler.mbn
---partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=featenabler.mbn
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg_iot.mbn
 --partition --name=qupfw_a --size=64KB --type-guid=21d1219f-2ed1-4ab4-930a-41a16ae75f7f --filename=qupv3fw.elf
 --partition --name=qupfw_b --size=64KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=qupv3fw.elf
 --partition --name=frp --size=512KB --type-guid=91B72D4D-71E0-4CBF-9B8E-236381CFF17A
@@ -77,7 +71,6 @@
 --partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
 --partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
 --partition --name=logdump --size=65536KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
---partition --name=storsec --size=128KB --type-guid=02DB45FE-AD1B-4CB6-AECC-0042C637DEFA --filename=storsec.mbn
 --partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=multi_image.mbn
 --partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=multi_image.mbn
 --partition --name=multiimgqti_a --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E


### PR DESCRIPTION
…mware

Update filenames based on the new edk2-downstream boot firmware release available at [1], and remove partitions which are not used / required anymore.

Removing should not cause any impact on current users, as they will simply not be used anymore.

[1]
https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/QRB2210_bootbinaries.1.0/qrb2210_bootbinaries.1.0-test-device-public/00010/Agatti_bootbinaries.zip