### PR TITLE
platforms: Add persist partition for QTEE secure storage on Talos

### DIFF
--- a/platforms/iq-615-evk/ufs/partitions.conf
+++ b/platforms/iq-615-evk/ufs/partitions.conf
@@ -97,3 +97,8 @@
 --partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
 --partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 5 - Protected Read-write LUN
+#QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
+--partition --lun=5 --name=persist --size=30720KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
+--partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/qcs615-ride/ufs/partitions.conf
+++ b/platforms/qcs615-ride/ufs/partitions.conf
@@ -97,3 +97,8 @@
 --partition --lun=4 --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
 --partition --lun=4 --name=SYSFW_VERSION --size=4KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
 --partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 5 - Protected Read-write LUN
+#QCOM development requirement: Ensure all partitions in LUN5 is a multiple of 128k.
+--partition --lun=5 --name=persist --size=30720KB --type-guid=6C95E238-E343-4BA8-B489-8681ED22AD0B
+--partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Add a 30 MB persist partition on protected RW LUN5 for both the IQ-615-EVK and QCS615-RIDE boards to provide a dedicated file storage area for QTEE.

Qualcomm's QTEE leverages a GPFS (Generic Persistent File System) interface library to enable encrypted file storage and secure data retrieval. The persist partition and QTEE operate independently, so no specific QTEE version dependency is introduced.

LUN5 is already provisioned on Talos boards; no reprovisioning is required. For partition layout reference, see: https://artifacts.codelinaro.org/ui/native/codelinaro-le/Qualcomm_Linux/QCS615/

The persist partition was discussed in [Issue87](https://github.com/qualcomm-linux/qcom-ptool/issues/87) , and approved add persist partition as LUN5 for UFS device.