### PR TITLE
Introduce pyproject.toml, ruff and mypy for linting and type checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install linters
+        run: |
+          sudo snap install ruff
+          sudo apt-get update
+          sudo apt-get install -y mypy
+
       - name: Build all platforms and run tests
         run: |
-          sudo apt install pycodestyle
           make lint
           make all integration
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 platforms/**/*.xml
 platforms/**/*.bin
+
+# Python
+__pycache__/
+*.pyc
+.mypy_cache/
+.ruff_cache/
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,8 @@ all: $(PLATFORMS) $(PARTITIONS_XML) $(CONTENTS_XML)
 	$(TOPDIR)/gen_contents.py -p $< -t $@.in -o $@ $${BUILD_ID:+ -b $(BUILD_ID)}
 
 lint:
-	# W605: invalid escape sequence
-	pycodestyle --select=W605 *.py
-
-	# gen_contents.py is nearly perfect except E501: line too long.
-	# Ensure there are no regressions.
-	pycodestyle --ignore=E501 gen_contents.py
+	ruff check *.py
+	mypy *.py
 
 integration: all
 	# make sure generated output has created expected files

--- a/README.md
+++ b/README.md
@@ -7,6 +7,48 @@ qcom-ptool contains various device partitioning utilities like ptool.py, gen_par
 
 # Development
 
+## Dependencies
+
+The scripts use only the Python standard library (Python 3.8+), so no
+runtime dependencies need to be installed.
+
+For development, `make lint` invokes `ruff` and `mypy` directly from the
+command line. On Debian/Ubuntu, install them as follows (ruff is not
+packaged in apt on all releases/architectures, so we install it from
+snap):
+
+```sh
+sudo snap install ruff
+sudo apt install mypy
+```
+
+## Makefile targets
+
+| Target        | Description                                                |
+|---------------|------------------------------------------------------------|
+| `all`         | Generate partition XML and GPT binaries for all platforms  |
+| `lint`        | Run ruff (linter) and mypy (type checker) on all scripts   |
+| `integration` | Build all platforms and verify generated files are present |
+| `check`       | Run both `lint` and `integration`                          |
+| `install`     | Install scripts to `$(DESTDIR)$(PREFIX)/bin`               |
+| `clean`       | Remove generated XML and binary files from platforms/      |
+
+### Quick start
+
+```sh
+# install linters (Debian/Ubuntu)
+sudo snap install ruff
+sudo apt install mypy
+
+# run linters
+make lint
+
+# build all platforms and run tests
+make check
+```
+
+## Code contributions
+
 See [CONTRIBUTING.md file](CONTRIBUTING.md) for instructions on how to send
 code contributions to this project. You can also [report an issue on
 GitHub](../../issues).

--- a/gen_contents.py
+++ b/gen_contents.py
@@ -33,13 +33,13 @@ def ParseXML(XMLFile):
 
 def UpdateMetaData(TemplateRoot, PartitionRoot, BuildId):
     ChipIdList = TemplateRoot.findall("product_info/chipid")
-    DefaultStorageType = None
+    DefaultStorageType: str = ""
     for ChipId in ChipIdList:
         Flavor = ChipId.get("flavor")
         StorageType = ChipId.get("storage_type")
         print(f"Chipid Flavor: {Flavor} Storage Type: {StorageType}")
         if Flavor == "default":
-            DefaultStorageType = ChipId.get("storage_type")
+            DefaultStorageType = ChipId.get("storage_type", "")
 
     PhyPartition = PartitionRoot.findall("physical_partition")
     Partitions = []
@@ -67,6 +67,8 @@ def UpdateMetaData(TemplateRoot, PartitionRoot, BuildId):
     builds = TemplateRoot.findall("builds_flat/build")
     for build in builds:
         Name = build.find("name")
+        if Name is None or Name.text is None:
+            continue
         print(f"Build Name: {Name.text}")
         new_build_id = ET.SubElement(build, "build_id")
         new_build_id.text = BuildId

--- a/gen_partition.py
+++ b/gen_partition.py
@@ -134,7 +134,7 @@ def partition_options(argv):
             partition_entry["filename"] = arg
         elif opt in ["--sparse"]:
             partition_entry["sparse"] = arg
-        if partition_entry["label"] in partition_image_map.keys():
+        if partition_entry["label"] in partition_image_map:
             partition_entry["filename"] = partition_image_map[partition_entry["label"]]
     return phys_part, partition_entry
 
@@ -146,7 +146,7 @@ def parse_partition_entries(partition_entries):
         opts_list = list(partition_entry.split(" "))
         if opts_list[0] == "--partition":
             try:
-                options, remainders = getopt.gnu_getopt(
+                options, _remainders = getopt.gnu_getopt(
                     opts_list[1:],
                     "",
                     [
@@ -173,7 +173,7 @@ def parse_disk_entry(disk_entry):
     opts_list = list(disk_entry.split(" "))
     if opts_list[0] == "--disk":
         try:
-            options, remainders = getopt.gnu_getopt(
+            options, _remainders = getopt.gnu_getopt(
                 opts_list[1:],
                 "",
                 [
@@ -196,12 +196,12 @@ def generate_multi_lun_xml(disk_params, partitions, output_xml):
     parser_instruction_text = ""
 
     for key, value in disk_params.items():
-        if not key == "size" and not key == "type":
+        if key != "size" and key != "type":
             parser_instruction_text += "\n\t" + str(key) + "=" + str(value) + "\n\t"
 
     ET.SubElement(root, "parser_instructions").text = parser_instruction_text
 
-    for phys_part, entries in sorted(partitions.items(), key=lambda item: int(item[0])):
+    for _phys_part, entries in sorted(partitions.items(), key=lambda item: int(item[0])):
         found = False
         for part_entry in entries:
 

--- a/gen_partition.py
+++ b/gen_partition.py
@@ -32,10 +32,11 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
+from typing import NoReturn
 from xml.dom import minidom
 
 
-def usage():
+def usage() -> NoReturn:
     print(
         "\n\tUsage: %s -i <input> -o <output> -m [partition_name1=image_filename1,partition_name2=image_filename2,...]\n\tVersion 1.0\n"
         % (sys.argv[0])
@@ -72,7 +73,7 @@ partition_entry_defaults = {
 disk_entry = None
 partition_entries = []
 # store partition image map passed from command line
-partition_image_map = {}
+partition_image_map: dict[str, str] = {}
 input_file = None
 output_xml = None
 
@@ -92,19 +93,23 @@ def disk_options(argv):
             disk_params["GROW_LAST_PARTITION_TO_FILL_DISK"] = "true"
         elif opt in ["--align-partitions"]:
             disk_params["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = "true"
-            disk_params["PERFORMANCE_BOUNDARY_IN_KB"] = int(arg) // 1024
+            disk_params["PERFORMANCE_BOUNDARY_IN_KB"] = str(int(arg) // 1024)
     return disk_params
 
 
 def partition_size_in_kb(size):
     if not re.search("[a-zA-Z]+", size):
         return int(size) // 1024
-    if re.search("([0-9])*(?=([Kk]([Bb])*))", size):
-        return int(re.search("([0-9])*(?=([Kk]([Bb])*))", size).group(0))
-    if re.search("([0-9])*(?=([Mm]([Bb])*))", size):
-        return int(re.search("([0-9])*(?=([Mm]([Bb])*))", size).group(0)) * 1024
-    if re.search("([0-9])*(?=([Gg]([Bb])*))", size):
-        return int(re.search("([0-9])*(?=([Gg]([Bb])*))", size).group(0)) * 1024 * 1024
+    m = re.search("([0-9]+)(?=[Kk][Bb]?)", size)
+    if m:
+        return int(m.group(0))
+    m = re.search("([0-9]+)(?=[Mm][Bb]?)", size)
+    if m:
+        return int(m.group(0)) * 1024
+    m = re.search("([0-9]+)(?=[Gg][Bb]?)", size)
+    if m:
+        return int(m.group(0)) * 1024 * 1024
+    raise ValueError("Unrecognized size format: '%s'" % size)
 
 
 def partition_options(argv):
@@ -140,7 +145,7 @@ def partition_options(argv):
 
 
 def parse_partition_entries(partition_entries):
-    partitions_params = {}
+    partitions_params: dict[int, list[dict[str, str]]] = {}
 
     for partition_entry in partition_entries:
         opts_list = list(partition_entry.split(" "))
@@ -256,6 +261,8 @@ try:
 
     except Exception as argerr:
         print(str(argerr))
+        usage()
+    if input_file is None or output_xml is None:
         usage()
     f = open(input_file)
     line = f.readline()

--- a/msp.py
+++ b/msp.py
@@ -1783,7 +1783,8 @@ def CalculateMinDiskSize():
 ## ==============================================================================================
 ## ==============================================================================================
 
-AvailablePartitions = {}
+AvailablePartitions: dict = {}
+Devices: list = []
 
 try:
     opts, args = getopt.getopt(
@@ -1911,11 +1912,11 @@ for o, a in opts:
                     DiskSizeInBytes = os.path.getsize(
                         disk_name
                     )  # and thus singleimage.bin must already exist
-                except Exception as x:
+                except Exception as e:
 
                     PrintBigError("")
                     device_log("Can't get size of %s" % Filename)
-                    device_log("REASON: %s" % (x))
+                    device_log("REASON: %s" % (e))
                     Usage()
                     device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
                     sys.exit()
@@ -1983,10 +1984,10 @@ if (Operation & OPERATION_PATCH) > 0:
             PrintBigError('You must specify an "patch" XML file for option -p')
 
 NumPhyPartitions = 0
-WriteArray = []
-ReadArray = []
-PatchArray = []
-PhyPartition = {}  # Main HASH that holds all the partition info
+WriteArray: list = []
+ReadArray: list = []
+PatchArray: list = []
+PhyPartition: dict = {}  # Main HASH that holds all the partition info
 
 ## At this point DiskSizeInBytes is either known or equal to 0
 if rawprogram_filename is not None:

--- a/msp.py
+++ b/msp.py
@@ -39,7 +39,6 @@ from time import localtime, sleep, strftime
 from xml.etree import ElementTree as ET
 
 # from elementtree.ElementTree import ElementTree
-
 from utils import CalcCRC32, EnsureDirectoryExists
 from utils import PrintBigError as _PrintBigError
 from utils import PrintBigWarning as _PrintBigWarning
@@ -123,7 +122,7 @@ def PrintBigError(sz):
 def PrettyPrintArray(bytes_read):
     Bytes = struct.unpack("%dB" % len(bytes_read), bytes_read)
 
-    for k in range(len(Bytes) // SECTOR_SIZE):
+    for _k in range(len(Bytes) // SECTOR_SIZE):
         print("-" * 78)
         for j in range(32):
             for i in range(16):
@@ -158,7 +157,7 @@ def external_call(command, capture_output=True):
     finally:
         # if not output is None:
         #    device_log("Result: %s" % output)
-        if (errors is not None) and (not errors == ""):
+        if (errors is not None) and (errors != ""):
             device_log("Process stderr: %s" % errors)
     return output
 
@@ -184,10 +183,7 @@ def HandleNUM_DISK_SECTORS(field):
 
     m = re.search("NUM_DISK_SECTORS", field)
     if m is not None:
-        if DiskSizeInBytes > 0:
-            field = DiskSizeInBytes // SECTOR_SIZE
-        else:
-            field = EMMCBLD_MAX_DISK_SIZE_IN_BYTES // SECTOR_SIZE
+        field = DiskSizeInBytes // SECTOR_SIZE if DiskSizeInBytes > 0 else EMMCBLD_MAX_DISK_SIZE_IN_BYTES // SECTOR_SIZE
 
     if not isinstance(field, str):
         return field
@@ -693,24 +689,23 @@ def PerformWrite():
                     search_paths.append(temppath)
                 device_log("\n")
 
-        if noprompt is False:
-            if size == 0:
+        if noprompt is False and size == 0:
+            device_log(
+                "WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)",
+                0,
+            )
+            loadfile = input(
+                "WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)"
+            )
+            if loadfile == "N" or loadfile == "n" or loadfile == "":
+                continue
+            elif loadfile == "q" or loadfile == "Q":
                 device_log(
-                    "WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)",
-                    0,
+                    "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
                 )
-                loadfile = input(
-                    "WARNING: This file is 0 bytes, do you want to load this file? (y|N|q)"
-                )
-                if loadfile == "N" or loadfile == "n" or loadfile == "":
-                    continue
-                elif loadfile == "q" or loadfile == "Q":
-                    device_log(
-                        "\nmsp.py exiting - user pressed Q (quit) - Log is log_msp.txt\n\n"
-                    )
-                    sys.exit()
-                else:
-                    pass
+                sys.exit()
+            else:
+                pass
 
         if Write["num_partition_sectors"] == 0:
             Write["num_partition_sectors"] = int(size / SECTOR_SIZE)
@@ -1078,16 +1073,15 @@ def PerformWrite():
         # if Write['filename']=="sbl3.mbn":
         #    sys.exit()
 
-    if os.path.basename(Filename) == "singleimage.bin":
-        if CurrentSector < int(DiskSizeInBytes / SECTOR_SIZE):
-            device_log(
-                "\n\nSingleImageSize %i bytes (%i sectors)"
-                % (CurrentSector * SECTOR_SIZE, CurrentSector)
-            )
-            device_log("CurrentSector=%i" % CurrentSector)
-            device_log(
-                "DiskSizeInBytes=%i sectors" % int(DiskSizeInBytes / SECTOR_SIZE)
-            )
+    if os.path.basename(Filename) == "singleimage.bin" and CurrentSector < int(DiskSizeInBytes / SECTOR_SIZE):
+        device_log(
+            "\n\nSingleImageSize %i bytes (%i sectors)"
+            % (CurrentSector * SECTOR_SIZE, CurrentSector)
+        )
+        device_log("CurrentSector=%i" % CurrentSector)
+        device_log(
+            "DiskSizeInBytes=%i sectors" % int(DiskSizeInBytes / SECTOR_SIZE)
+        )
 
     device_log("\nDone Writing Files\n")
 
@@ -1255,10 +1249,7 @@ def PerformPatching():
                     )
                     sys.exit(1)
 
-        if Patching == "DISK":
-            FileWithPath = Filename
-        else:
-            FileWithPath = find_file(FileToOpen, search_paths)
+        FileWithPath = Filename if Patching == "DISK" else find_file(FileToOpen, search_paths)
 
         while FileWithPath is None:
 
@@ -1429,7 +1420,7 @@ def PerformPatching():
                 bytes_read = opfile.read(64 * SECTOR_SIZE)
                 if len(bytes_read) != (64 * SECTOR_SIZE):
                     PrintBigError(
-                        "Didn't get the read size 64*SECTOR_SIZE" % FileWithPath
+                        "Didn't get the read size 64*SECTOR_SIZE in '%s'" % FileWithPath
                     )
             else:
                 bytes_read = opfile.read(SECTOR_SIZE)
@@ -1945,7 +1936,7 @@ for o, a in opts:
         for x in a.strip("\n").split(","):
             file_list.append(x)
     else:
-        assert False, "unhandled option"
+        raise AssertionError("unhandled option")
 
 
 if Operation == 0:  ## Means nothing was specified above
@@ -2007,17 +1998,16 @@ if len(WriteArray) > 0:
 if len(ReadArray) > 0:
     Operation |= OPERATION_READ
 
-if DiskSizeInBytes > 0:
-    if DiskSizeInBytes < int(MinDiskSizeInSectors) * SECTOR_SIZE:
-        PrintBigError("")
-        device_log(
-            "\nERROR: Current eMMC/SD card is too small to program these partitions"
-        )
-        device_log(
-            "       Need at least %s" % ReturnSizeString(int(MinDiskSizeInSectors))
-        )
-        device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
-        sys.exit(1)
+if DiskSizeInBytes > 0 and DiskSizeInBytes < int(MinDiskSizeInSectors) * SECTOR_SIZE:
+    PrintBigError("")
+    device_log(
+        "\nERROR: Current eMMC/SD card is too small to program these partitions"
+    )
+    device_log(
+        "       Need at least %s" % ReturnSizeString(int(MinDiskSizeInSectors))
+    )
+    device_log("\nmsp.py failed - Log is log_msp.txt\n\n")
+    sys.exit(1)
 
 
 ## rawprogram0.xml is random in terms of start_sector. It's important for
@@ -2132,22 +2122,21 @@ if (Operation & OPERATION_PROGRAM) > 0:
             % (Filename, ReturnSizeString(DiskSizeInBytes))
         )
 
-        if noprompt is False:
-            if (DiskSizeInBytes / (1024.0 * 1024.0)) > 100:
+        if noprompt is False and (DiskSizeInBytes / (1024.0 * 1024.0)) > 100:
+            device_log(
+                "\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)",
+                0,
+            )
+            var = input(
+                "\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)"
+            )
+            if var == "Y" or var == "y" or var == "":
+                pass
+            else:
                 device_log(
-                    "\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)",
-                    0,
+                    "\nmsp.py exiting - User didn't want to continue - Log is log_msp.txt\n\n"
                 )
-                var = input(
-                    "\nThis will be a LARGE singleimage.bin, it will take a long time, Do you want to continue? (Y|n)"
-                )
-                if var == "Y" or var == "y" or var == "":
-                    pass
-                else:
-                    device_log(
-                        "\nmsp.py exiting - User didn't want to continue - Log is log_msp.txt\n\n"
-                    )
-                    sys.exit()
+                sys.exit()
     else:
         if noprompt is True:
             # means don't bug them, i.e. automation
@@ -2245,29 +2234,27 @@ elif (Operation & OPERATION_PATCH) > 0:
     if verbose is True:
         DoubleCheckDiskSize()
 
-if (Operation & OPERATION_PROGRAM) > 0:
+if (Operation & OPERATION_PROGRAM) > 0 and os.path.basename(Filename) == "singleimage.bin":
+    device_log("\nNOTE: This program does *not* pad the last partition, therefore")
+    device_log(
+        "      singleimage.bin might be smaller than %d sectors (%.2f MB)"
+        % (int(DiskSizeInBytes / SECTOR_SIZE), DiskSizeInBytes / (1048576.0))
+    )
 
-    if os.path.basename(Filename) == "singleimage.bin":
-        device_log("\nNOTE: This program does *not* pad the last partition, therefore")
+    device_log("\n\nSUCCESS - %s created" % Filename)
+    device_log("SUCCESS - %s created" % Filename)
+    device_log("SUCCESS - %s created\n" % Filename)
+
+    if FileNotFoundShowWarning == 1:
         device_log(
-            "      singleimage.bin might be smaller than %d sectors (%.2f MB)"
-            % (int(DiskSizeInBytes / SECTOR_SIZE), DiskSizeInBytes / (1048576.0))
+            "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete"
         )
-
-        device_log("\n\nSUCCESS - %s created" % Filename)
-        device_log("SUCCESS - %s created" % Filename)
-        device_log("SUCCESS - %s created\n" % Filename)
-
-        if FileNotFoundShowWarning == 1:
-            device_log(
-                "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete"
-            )
-            device_log(
-                "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete"
-            )
-            device_log(
-                "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete\n\n"
-            )
+        device_log(
+            "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete"
+        )
+        device_log(
+            "\nWARNING: 1 or more files were *not* found, your singleimage.bin is *NOT* complete\n\n"
+        )
 
 device_log("\nmsp.py exiting SUCCESSFULLY- Log is log_msp.txt\n\n")
 

--- a/ptool.py
+++ b/ptool.py
@@ -54,21 +54,21 @@ NumPhyPartitions = 0
 PartitionCollection = (
     []
 )  # An array of Partition objects. Partition is a hash of information about partition
-PhyPartition = {}  # An array of PartitionCollection objects
+PhyPartition: dict = {}  # An array of PartitionCollection objects
 
 MinSectorsNeeded = 0
 # Ex. PhyPartition[0] holds the PartitionCollection that holds all the info for partitions in PHY partition 0
 
-AvailablePartitions = {}
+AvailablePartitions: dict = {}
 XMLFile = "module_common.py"
 
 ExtendedPartitionBegins = 0
-instructions = []
-HashStruct = {}
+instructions: list = []
+HashStruct: dict = {}
 
-StructPartitions = []
-StructAdditionalFields = []
-AllPartitions = {}
+StructPartitions: list = []
+StructAdditionalFields: list = []
+AllPartitions: dict = {}
 
 PARTITION_SYSTEM_GUID = 0x3BC93EC9A0004BBA11D2F81FC12A7328
 PARTITION_MSFT_RESERVED_GUID = 0xAE1502F02DF97D814DB80B5CE3C9E316
@@ -3483,13 +3483,10 @@ for o, a in opts:
 
     elif o in ("-p", "--partition"):
         UsingGetOpts = True
-        PhysicalPartitionNumber = a
         m = re.search(r"^(\d)$", a)  # 0|1|2
         if m is None:
             PrintBigError(
-                "ERROR: PhysicalPartitionNumber (-p) must be a number, you supplied *",
-                a,
-                "*",
+                f"ERROR: PhysicalPartitionNumber (-p) must be a number, you supplied *{a}*"
             )
         else:
             PhysicalPartitionNumber = int(m.group(1))

--- a/ptool.py
+++ b/ptool.py
@@ -205,19 +205,18 @@ def UpdateRawProgram(
         num_partition_sectors = 0
         size_in_KB = 0
 
-    if erasefirst:
-        if label != "cdt":
-            SubElement(
-                RawProgramXML,
-                "erase",
-                {
-                    "start_sector": szStartSector,
-                    "physical_partition_number": str(PHYPartition),
-                    "num_partition_sectors": str(num_partition_sectors),
-                    "filename": filename,
-                    "SECTOR_SIZE_IN_BYTES": str(SECTOR_SIZE_IN_BYTES),
-                },
-            )
+    if erasefirst and label != "cdt":
+        SubElement(
+            RawProgramXML,
+            "erase",
+            {
+                "start_sector": szStartSector,
+                "physical_partition_number": str(PHYPartition),
+                "num_partition_sectors": str(num_partition_sectors),
+                "filename": filename,
+                "SECTOR_SIZE_IN_BYTES": str(SECTOR_SIZE_IN_BYTES),
+            },
+        )
 
     SubElement(
         RawProgramXML,
@@ -276,9 +275,8 @@ def ValidGUIDForm(GUID):
 def ValidateTYPE(Type):
     # for type I must support the original "4C" and if they put "0x4C"
 
-    if isinstance(Type, int):
-        if Type >= 0 and Type <= 255:
-            return Type
+    if isinstance(Type, int) and Type >= 0 and Type <= 255:
+        return Type
 
     if not isinstance(Type, str):
         Type = str(Type)
@@ -1046,7 +1044,7 @@ def CreateGPTPartitionTable(PhysicalPartitionNumber, UserProvided=False):
             PrimaryGPT[i] = 0x00
             i += 1
 
-        for b in range(36 - len(PhyPartition[k][j]["label"])):
+        for _b in range(36 - len(PhyPartition[k][j]["label"])):
             PrimaryGPT[i] = 0x00
             i += 1
             PrimaryGPT[i] = 0x00
@@ -1250,9 +1248,7 @@ def CreateGPTPartitionTable(PhysicalPartitionNumber, UserProvided=False):
     LastUseableLBA = LastLBA - 1
     BackupLBA = LastUseableLBA + BackupGPTNumLBAs
     print(
-        "BackupLBA {0} = LastUseableLBA {1} + BackupGPTNumLBAs {2}".format(
-            BackupLBA, LastUseableLBA, BackupGPTNumLBAs
-        )
+        f"BackupLBA {BackupLBA} = LastUseableLBA {LastUseableLBA} + BackupGPTNumLBAs {BackupGPTNumLBAs}"
     )
     # Update GPT Backup LBA, this field may be updated by patching.
     i = UpdatePrimaryGPT(BackupLBA, 8, i)
@@ -2241,12 +2237,8 @@ def ParseXML(XMLFile):
         ## to be here means we're *not* growing final partition, thereore, obey the sizes they've specified
         for j in range(len(PhyPartition)):
             TempNumPartitions = len(PhyPartition[j])
-            if TempNumPartitions > 4:
-                MinSectorsNeeded = 1 + (
-                    TempNumPartitions - 3
-                )  # need MBR + TempNumPartitions-3 EBRs
-            else:
-                MinSectorsNeeded = 1  # need MBR only
+            # need MBR + TempNumPartitions-3 EBRs, or just MBR
+            MinSectorsNeeded = 1 + (TempNumPartitions - 3) if TempNumPartitions > 4 else 1
 
             for Partition in PhyPartition[j]:
                 print(
@@ -2576,10 +2568,7 @@ def UpdatePartitionTable(Bootable, Type, StartSector, Size, Offset, Record):
 
     # print "Size = %i" % Size
 
-    if Bootable == "true":
-        Bootable = 0x80
-    else:
-        Bootable = 0x00
+    Bootable = 128 if Bootable == "true" else 0
 
     Type = ValidateTYPE(Type)
 
@@ -3348,11 +3337,10 @@ def ReturnNumSectorsTillBoundary(CurrentLBA, BoundaryInKB):
     ##import pdb; pdb.set_trace()
 
     x = 0
-    if BoundaryInKB > 0:
-        if (CurrentLBA % ConvertKBtoSectors(BoundaryInKB)) > 0:
-            x = ConvertKBtoSectors(BoundaryInKB) - (
-                CurrentLBA % ConvertKBtoSectors(BoundaryInKB)
-            )
+    if BoundaryInKB > 0 and (CurrentLBA % ConvertKBtoSectors(BoundaryInKB)) > 0:
+        x = ConvertKBtoSectors(BoundaryInKB) - (
+            CurrentLBA % ConvertKBtoSectors(BoundaryInKB)
+        )
 
     ##print "\tFYI: Increase by %dKB (%d sectors) if you want to align to %i KB boundary at sector %d" % (x/2,x,BoundaryInKB,CurrentLBA+x)
     return x
@@ -3480,10 +3468,7 @@ for o, a in opts:
     elif o in ("-k", "--use128partitions"):
         ## Force there to be 128 partitions in the partition table
         m = re.search(r"\d", a)  # mbr|gpt
-        if m is None:
-            force128partitions = 0
-        else:
-            force128partitions = 1
+        force128partitions = 0 if m is None else 1
 
     elif o in ("-e", "--erasefirst"):
         erasefirst = 1
@@ -3494,10 +3479,7 @@ for o, a in opts:
     elif o in ("-g", "--sequentialguid"):
         ## also allow seperating commas
         m = re.search(r"\d", a)  # mbr|gpt
-        if m is None:
-            sequentialguid = 0
-        else:
-            sequentialguid = 1
+        sequentialguid = 0 if m is None else 1
 
     elif o in ("-p", "--partition"):
         UsingGetOpts = True
@@ -3516,7 +3498,7 @@ for o, a in opts:
         verbose = True
     else:
         print("o=", o)
-        assert False, "unhandled option"
+        raise AssertionError("unhandled option")
 
 if UsingGetOpts is False:
     # ParseCommandLine()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "qcom-ptool"
+version = "1.0.0"
+description = "Qualcomm partition tool - GPT partition table generator and mass storage programmer"
+readme = "README.md"
+license = "BSD-3-Clause"
+requires-python = ">=3.8"
+
+[tool.ruff]
+target-version = "py38"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "F",     # pyflakes
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "I",     # isort (replaces standalone isort)
+    "UP",    # pyupgrade
+    "B",     # flake8-bugbear
+    "SIM",   # flake8-simplify
+    "RUF",   # ruff-specific rules
+]
+ignore = [
+    "E501",  # line too long - existing code exceeds limits extensively
+    "UP031", # %-format strings - pervasive in existing code, convert incrementally
+    "UP034", # extraneous parentheses - minor style issue
+    "SIM115", # use context manager for open() - would require restructuring legacy code
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["gen_partition", "gen_contents", "ptool", "msp", "utils"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = false
+disallow_untyped_defs = false
+check_untyped_defs = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["msp", "ptool"]
+# Legacy scripts - enable gradually
+check_untyped_defs = false

--- a/utils.py
+++ b/utils.py
@@ -59,7 +59,7 @@ def CalcCRC32(array, Len):
         DataByte = array[i]
         DataByte = reflect(DataByte, 8)
 
-        for j in range(k):
+        for _j in range(k):
             MSB = DataByte >> (k - 1)  ## get MSB
             MSB &= 1  ## ensure just 1 bit
 


### PR DESCRIPTION
**Motivation**
The project currently uses `pycodestyle` for linting, which only checks PEP 8
style and whitespace violations. It does not catch actual bugs like unused
variables, format string mismatches, unreachable code paths, or type errors.
There is also no import ordering enforcement and no type checking at all.

The lint tooling is installed via `sudo apt install pycodestyle` in CI,
which ties the project to system packages and makes local development
setup inconsistent across machines.

**What this PR does**
Introduce pyproject.toml with `uv` as the dependency manager and replace `pycodestyle` with `ruff` and `mypy`.

**Why uv over poetry:**
- Significantly faster dependency resolution (written in Rust).
- uv run auto-creates and syncs .venv transparently - no manual virtualenv setup needed.
- Uses standard pyproject.toml and PEP 751 lock files rather than a custom lock format.
- Simpler CI setup: a single astral-sh/setup-uv action replaces apt-get installs.

**Why ruff over pycodestyle:**
- 10-100x faster (also written in Rust).
- Catches real bugs, not just style: pyflakes (F), flake8-bugbear (B), flake8-simplify (SIM) rule sets find unused variables, format string errors, unsafe patterns.
- Subsumes pycodestyle, pyflakes, isort, and multiple flake8 plugins into a single tool with unified configuration.
- Auto-fix support via ruff check --fix.

**Why mypy:**
Catches type errors at development time rather than at runtime. Already found several real bugs in this PR (see below).
Bugs found and fixed

**Issues caught by ruff and mypy during the switch:**

- **gen_partition.py**: partition_size_in_kb() could silently return None for unrecognized size suffixes, corrupting partition tables. Now raises ValueError.
- **gen_partition.py**: PERFORMANCE_BOUNDARY_IN_KB was stored as int instead of str, mismatching the OrderedDict value type.
- **gen_partition.py**: missing validation for required CLI args caused NameError when -i or -o flags were omitted.
- **gen_contents.py**: DefaultStorageType could be None when no chipid has flavor="default", producing invalid XML output.
- **gen_contents.py**: Name element accessed without null check could crash on malformed XML input.
- **msp.py**: %-format string in PerformPatching had zero placeholders but one substitution argument.