### PR TITLE
platforms: tag device programmer with FIREHOSE_DDR_ELF

### DIFF
--- a/platforms/kaanapali-mtp/ufs/contents.xml.in
+++ b/platforms/kaanapali-mtp/ufs/contents.xml.in
@@ -50,7 +50,7 @@
       <windows_root_path>.\</windows_root_path>
       <linux_root_path>./</linux_root_path>
       <image_dir>common</image_dir>
-      <device_programmer>
+      <device_programmer cmm_file_var="FIREHOSE_DDR_ELF">
         <file_name>qsahara_device_programmer.xml</file_name>
         <file_path>.</file_path>
       </device_programmer>

--- a/platforms/sm8750-mtp/ufs/contents.xml.in
+++ b/platforms/sm8750-mtp/ufs/contents.xml.in
@@ -50,7 +50,7 @@
       <windows_root_path>.\</windows_root_path>
       <linux_root_path>./</linux_root_path>
       <image_dir>common</image_dir>
-      <device_programmer>
+      <device_programmer cmm_file_var="FIREHOSE_DDR_ELF">
         <file_name>xbl_s_devprg_ns.melf</file_name>
         <file_path>.</file_path>
       </device_programmer>


### PR DESCRIPTION
Axiom parses contents.xml.in to determine supported build download types. It considers firehose as a supported download type only if:
  - the <device_programmer> fileName contains the term "firehose", OR
  - the cmm_file_var attribute value contains "firehose"

As firehose term is not present in device programmer name, add cmm_file_var="FIREHOSE_DDR_ELF" to the device_programmer entries for Kaanapali-MTP and SM8750-MTP contents.xml.in file to enable the firehose option in the Axiom build loading UI.