### PR TITLE
ptool: fix tries_remaining shift to bit 51

### DIFF
--- a/qcom_ptool/ptool.py
+++ b/qcom_ptool/ptool.py
@@ -1017,7 +1017,8 @@ def CreateGPTPartitionTable(PhysicalPartitionNumber, UserProvided=False):
         if PhyPartition[k][j]["system"] == "true":
             Attributes |= 1 << 0
         if PhyPartition[k][j]["tries_remaining"] > 0:
-            Attributes |= PhyPartition[k][j]["tries_remaining"] << 52
+            # max_retry counter is bits 51-53 (gpt-utils.h PART_ATT_MAX_RETRY_CNT_BIT)
+            Attributes |= PhyPartition[k][j]["tries_remaining"] << 51
         if PhyPartition[k][j]["priority"] > 0:
             Attributes |= PhyPartition[k][j]["priority"] << 48
 


### PR DESCRIPTION
The A/B max_retry counter occupies bits 51-53 per gpt-utils.h (`PART_ATT_MAX_RETRY_CNT_BIT`). ptool shifts `tries_remaining` by 52, placing the counter one bit high. Shift by 51.