### PR TITLE
tests: add pytest-based unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,12 @@ readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.8"
 
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/unit"]
+
 [project.scripts]
 qcom-ptool = "qcom_ptool.cli:main"
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,71 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the qcom-ptool CLI dispatcher."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from qcom_ptool import __version__
+from qcom_ptool.cli import SUBCOMMANDS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def subprocess_env():
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(REPO_ROOT)
+        if not existing
+        else os.pathsep.join((str(REPO_ROOT), existing))
+    )
+    return env
+
+
+def run_cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "qcom_ptool.cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_version_flag():
+    result = run_cli("--version")
+    assert result.returncode == 0
+    assert __version__ in result.stdout
+
+
+def test_help_lists_all_subcommands():
+    result = run_cli("--help")
+    assert result.returncode == 0
+    for name in SUBCOMMANDS:
+        assert name in result.stdout
+
+
+def test_unknown_subcommand_rejected():
+    result = run_cli("frobnicate")
+    assert result.returncode == 2
+    assert "frobnicate" in result.stderr
+
+
+@pytest.mark.parametrize("name", sorted(SUBCOMMANDS))
+def test_subcommand_dispatch(name, tmp_path):
+    # Scripts exit non-zero without args; tmp_path because ptool writes files to CWD.
+    result = subprocess.run(
+        [sys.executable, "-m", "qcom_ptool.cli", name],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=subprocess_env(),
+        timeout=10,
+    )
+    assert result.returncode != 0
+    if name != "ptool":
+        assert "usage" in (result.stdout + result.stderr).lower()

--- a/tests/unit/test_gen_partition.py
+++ b/tests/unit/test_gen_partition.py
@@ -1,0 +1,150 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for qcom_ptool.gen_partition."""
+
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+import pytest
+
+BASIC_CONF = """\
+# comment lines and blank lines are ignored
+
+--disk --type=emmc --size=16777216 --sector-size-in-bytes=512
+
+--partition --name=cdt --size=2KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
+--partition --name=boot --size=64MB --type-guid=20117F86-E985-4357-B9EE-374BC1D8487D --attributes=0x0000000000000004
+--partition --name=rootfs --size=1GB --type-guid=97D7B011-54DA-4835-B3C4-917AD6E73D74 --attributes=0x1000000000000000
+"""
+
+
+def run_gen_partition(tmp_path, conf_text, extra_args=()):
+    conf = tmp_path / "partitions.conf"
+    out = tmp_path / "partitions.xml"
+    conf.write_text(conf_text, encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "qcom_ptool.gen_partition",
+            "-i",
+            str(conf),
+            "-o",
+            str(out),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result, out
+
+
+@pytest.fixture(scope="module")
+def basic_output(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("gen_partition")
+    result, out = run_gen_partition(tmp_path, BASIC_CONF)
+    assert result.returncode == 0, result.stdout + result.stderr
+    return ET.parse(out).getroot()
+
+
+def get_partitions(root):
+    return {
+        p.get("label"): p
+        for phys in root.findall("physical_partition")
+        for p in phys.findall("partition")
+    }
+
+
+def test_generates_configuration_root(basic_output):
+    assert basic_output.tag == "configuration"
+    assert basic_output.find("parser_instructions") is not None
+    assert len(basic_output.findall("physical_partition")) == 1
+
+
+def test_sector_size_in_parser_instructions(basic_output):
+    text = basic_output.find("parser_instructions").text
+    assert "SECTOR_SIZE_IN_BYTES=512" in text
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_kb"),
+    [("cdt", "2"), ("boot", str(64 * 1024)), ("rootfs", str(1024 * 1024))],
+)
+def test_size_suffix_parsing(basic_output, label, expected_kb):
+    # KB / MB / GB suffixes must all normalize to size_in_kb.
+    assert get_partitions(basic_output)[label].get("size_in_kb") == expected_kb
+
+
+def test_plain_size_is_interpreted_as_bytes(tmp_path):
+    conf = """\
+--disk --type=emmc --size=16777216
+--partition --name=data --size=4096
+"""
+    result, out = run_gen_partition(tmp_path, conf)
+    assert result.returncode == 0, result.stdout + result.stderr
+    part = get_partitions(ET.parse(out).getroot())["data"]
+    assert part.get("size_in_kb") == "4"
+
+
+def test_attribute_bit2_sets_bootable(basic_output):
+    parts = get_partitions(basic_output)
+    assert parts["boot"].get("bootable") == "true"
+    assert parts["boot"].get("readonly") == "false"
+
+
+def test_attribute_bit60_sets_readonly(basic_output):
+    parts = get_partitions(basic_output)
+    assert parts["rootfs"].get("bootable") == "false"
+    assert parts["rootfs"].get("readonly") == "true"
+
+
+def test_filename_passthrough(basic_output):
+    assert get_partitions(basic_output)["cdt"].get("filename") == "cdt.bin"
+
+
+def test_partition_image_map_overrides_filename(tmp_path):
+    result, out = run_gen_partition(
+        tmp_path, BASIC_CONF, extra_args=["-m", "cdt=other.bin,boot=boot.img"]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    parts = get_partitions(ET.parse(out).getroot())
+    assert parts["cdt"].get("filename") == "other.bin"
+    assert parts["boot"].get("filename") == "boot.img"
+    assert parts["rootfs"].get("filename") == ""
+
+
+def test_multiple_luns_sorted(tmp_path):
+    conf = """\
+--disk --type=ufs --size=16777216
+--partition --lun=2 --name=late --size=1KB
+--partition --lun=0 --name=early --size=1KB
+"""
+    result, out = run_gen_partition(tmp_path, conf)
+    assert result.returncode == 0, result.stdout + result.stderr
+    root = ET.parse(out).getroot()
+    luns = root.findall("physical_partition")
+    assert len(luns) == 2
+    # physical partitions must be emitted in ascending LUN order
+    assert luns[0].find("partition").get("label") == "early"
+    assert luns[1].find("partition").get("label") == "late"
+
+
+def test_duplicate_disk_entry_fails(tmp_path):
+    conf = "--disk --type=emmc --size=1\n--disk --type=emmc --size=2\n--partition --name=a --size=1KB\n"
+    result, _ = run_gen_partition(tmp_path, conf)
+    assert result.returncode == 1
+    assert "more than one --disk" in result.stdout + result.stderr
+
+
+def test_missing_arguments_shows_usage():
+    result = subprocess.run(
+        [sys.executable, "-m", "qcom_ptool.gen_partition"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 1
+    assert "Usage" in result.stdout + result.stderr

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,73 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for qcom_ptool.utils."""
+
+import binascii
+import pytest
+
+from qcom_ptool.utils import CalcCRC32, EnsureDirectoryExists, reflect
+
+
+class TestReflect:
+    def test_reflect_single_bit_8(self):
+        assert reflect(0b00000001, 8) == 0b10000000
+        assert reflect(0b10000000, 8) == 0b00000001
+
+    def test_reflect_is_involution(self):
+        # Reflecting twice must return the original value.
+        for value in (0x00, 0x01, 0x5A, 0xA5, 0xFF, 0x12345678):
+            nbits = 8 if value <= 0xFF else 32
+            assert reflect(reflect(value, nbits), nbits) == value
+
+    def test_reflect_32(self):
+        assert reflect(0x00000001, 32) == 0x80000000
+        assert reflect(0x12345678, 32) == 0x1E6A2C48
+
+
+class TestCalcCRC32:
+    """CalcCRC32 implements standard CRC-32 (IEEE 802.3, reflected),
+    so binascii.crc32 is used as an independent reference."""
+
+    def test_known_check_value(self):
+        # "123456789" -> 0xCBF43926 is the canonical CRC-32 check value.
+        data = b"123456789"
+        assert CalcCRC32(data, len(data)) == 0xCBF43926
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b"",
+            b"\x00",
+            b"\xff" * 16,
+            bytes(range(256)),
+            b"qcom-ptool",
+        ],
+        ids=["empty", "single-nul", "all-ones", "all-bytes", "ascii"],
+    )
+    def test_matches_binascii_crc32(self, data):
+        assert CalcCRC32(data, len(data)) == binascii.crc32(data) & 0xFFFFFFFF
+
+    def test_partial_length(self):
+        # Only the first Len bytes participate in the checksum.
+        data = b"123456789XXXX"
+        assert CalcCRC32(data, 9) == 0xCBF43926
+
+    def test_accepts_list_input(self):
+        # GPT code paths pass mutable sequences, not only bytes.
+        data = list(b"123456789")
+        assert CalcCRC32(data, len(data)) == 0xCBF43926
+
+
+class TestEnsureDirectoryExists:
+    def test_creates_missing_parents(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "file.bin"
+        EnsureDirectoryExists(str(target))
+        assert (tmp_path / "a" / "b" / "c").is_dir()
+        assert not target.exists()  # only the directory is created
+
+    def test_existing_directory_is_noop(self, tmp_path):
+        target = tmp_path / "file.bin"
+        EnsureDirectoryExists(str(target))
+        EnsureDirectoryExists(str(target))  # second call must not raise
+        assert tmp_path.is_dir()


### PR DESCRIPTION
Add pytest unit tests; shell integration checks untouched.

- tests/unit/test_utils.py: CalcCRC32 verified against binascii.crc32 (implementation matches standard CRC-32/IEEE reflected), reflect() properties, EnsureDirectoryExists behavior.
- tests/unit/test_gen_partition.py: end-to-end coverage of gen_partition via subprocess (the module runs its main logic at import time), covering KB/MB/GB size parsing, GPT attribute bits (bootable/readonly), -m image map overrides, multi-LUN ordering, and error paths.
- tests/unit/test_cli.py: qcom-ptool dispatcher (--version, --help, invalid subcommand, dispatch to each legacy script).