### PR TITLE
qcom_ptool: drop shebangs and executable bits from package modules

### DIFF
--- a/qcom_ptool/gen_contents.py
+++ b/qcom_ptool/gen_contents.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/qcom_ptool/gen_partition.py
+++ b/qcom_ptool/gen_partition.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2019, The Linux Foundation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/qcom_ptool/msp.py
+++ b/qcom_ptool/msp.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # ===========================================================================*/
 # Copyright (c) 2015, The Linux Foundation. All rights reserved.
 

--- a/qcom_ptool/ptool.py
+++ b/qcom_ptool/ptool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # ===========================================================================
 # Copyright (c) 2019, The Linux Foundation. All rights reserved.
 

--- a/qcom_ptool/utils.py
+++ b/qcom_ptool/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 


### PR DESCRIPTION
Remove the shebangs, and the executable bit where it is set. No functional change.