### PR TITLE
packaging: add license-files to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 description = "Qualcomm partition tool - GPT partition table generator and mass storage programmer"
 readme = "README.md"
 license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 
 [project.scripts]


### PR DESCRIPTION
Add the license-files field to pyproject.toml so license files are included in source distributions and wheels in accordance with PEP 639 and modern packaging practices.