### PR TITLE
qcom_ptool: loaders: parse uniqueguid from partition config

### DIFF
--- a/qcom_ptool/loaders/conf.py
+++ b/qcom_ptool/loaders/conf.py
@@ -135,6 +135,8 @@ def partition_options(
             entry["filename"] = arg
         elif opt == "--sparse":
             entry["sparse"] = to_bool(arg)
+        elif opt == "--uniqueguid":
+            entry["uniqueguid"] = arg
     if entry["label"] in image_map:
         entry["filename"] = image_map[entry["label"]]
     return phys_part, entry
@@ -170,6 +172,7 @@ _PARTITION_LONG_OPTS = [
     "successful=",
     "unbootable=",
     "sparse=",
+    "uniqueguid=",
 ]
 
 


### PR DESCRIPTION
ptool already supports assigning a unique partition GUID in the generated XML. This change only extends the configuration parser so this can be specified directly in the partition configuration file.