### PR TITLE
loaders: add YAML partition source with schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ subcommand.
 
 ## Dependencies
 
-At runtime, the scripts use only the Python standard library (Python 3.8+),
-so no runtime dependencies need to be installed beyond the package itself.
+At runtime the tool targets Python 3.8+ and depends on two third-party
+libraries, `PyYAML` and `jsonschema`, used to load and validate the YAML
+partition source. Both are declared in `pyproject.toml` and pulled in
+automatically by `pip install .`.
 
 For development, `make lint` invokes `ruff` and `mypy` and `make unit-test`
 runs the `pytest` suite under `tests/unit/`. On Debian/Ubuntu, install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ qcom-ptool = "qcom_ptool.cli:main"
 [tool.setuptools.packages.find]
 include = ["qcom_ptool*"]
 
+[tool.setuptools.package-data]
+"qcom_ptool.schema" = ["*.json"]
+
 [tool.ruff]
 target-version = "py38"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.8"
+dependencies = [
+    "PyYAML>=5.1",
+    "jsonschema>=3.2",
+]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/qcom_ptool/loaders/__init__.py
+++ b/qcom_ptool/loaders/__init__.py
@@ -37,4 +37,9 @@ def load(path: str, image_map: Mapping[str, str] | None = None) -> LoadedSpec:
         from qcom_ptool.loaders import conf
 
         return conf.load(path, image_map=image_map)
+    if suffix in (".yaml", ".yml"):
+        # Late import so the .conf path never pays for PyYAML / jsonschema.
+        from qcom_ptool.loaders import yaml as yaml_loader
+
+        return yaml_loader.load(path, image_map=image_map)
     raise UnsupportedFormatError(f"No loader registered for suffix {suffix!r}")

--- a/qcom_ptool/loaders/yaml.py
+++ b/qcom_ptool/loaders/yaml.py
@@ -1,0 +1,137 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Loader for the structured YAML partition source (single storage).
+
+A YAML document describes one ``disk`` mapping and a ``partitions`` list; this
+module validates it against ``qcom_ptool/schema/partitions.schema.json`` and
+normalises it into the exact same :class:`qcom_ptool.spec.LoadedSpec` the
+``.conf`` loader produces, so both formats emit byte-identical XML.
+
+Normalisation mirrors ``loaders/conf.py`` field for field: the disk dict is
+built by copying ``DISK_PARAMS_DEFAULTS`` and each partition by copying
+``PARTITION_ENTRY_DEFAULTS``, so key order (and therefore XML attribute order)
+matches the legacy loader. ``partition_size_in_kb`` and the attribute-bit
+decoding are reused / replicated identically.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from importlib import resources
+from typing import Any
+
+import jsonschema
+import yaml  # type: ignore[import-untyped]
+
+from qcom_ptool.loaders.conf import partition_size_in_kb
+from qcom_ptool.spec import (
+    DISK_PARAMS_DEFAULTS,
+    PARTITION_ENTRY_DEFAULTS,
+    DiskParams,
+    LoadedSpec,
+    PartitionEntry,
+    PartitionsByLun,
+)
+
+_SCHEMA_PACKAGE = "qcom_ptool.schema"
+_SCHEMA_RESOURCE = "partitions.schema.json"
+
+
+class YamlParseError(ValueError):
+    """Raised when a YAML partition source is malformed or fails validation."""
+
+
+def _bool_str(value: Any) -> str:
+    """Render a YAML scalar as the lowercase "true"/"false" the .conf loader
+    stores. ``str(True)`` would yield "True", which the emitter would then
+    write verbatim and break parity, so booleans are normalised explicitly."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def load_schema() -> dict[str, Any]:
+    """Return the packaged partition JSON Schema as a dict."""
+    text = resources.files(_SCHEMA_PACKAGE).joinpath(_SCHEMA_RESOURCE).read_text(
+        encoding="utf-8"
+    )
+    schema: dict[str, Any] = json.loads(text)
+    return schema
+
+
+def _disk_from_node(node: Mapping[str, Any]) -> DiskParams:
+    """Normalise the ``disk`` mapping into the canonical disk dict.
+
+    Starts from ``DISK_PARAMS_DEFAULTS`` and overrides only the keys present,
+    exactly like ``conf.disk_options``, so unset fields keep their defaults and
+    the key order is identical.
+    """
+    disk = DISK_PARAMS_DEFAULTS.copy()
+    disk["type"] = str(node["type"])
+    disk["size"] = str(node["size"])
+    if "sector-size" in node:
+        disk["SECTOR_SIZE_IN_BYTES"] = str(node["sector-size"])
+    if "write-protect-boundary" in node:
+        disk["WRITE_PROTECT_BOUNDARY_IN_KB"] = str(node["write-protect-boundary"])
+    if node.get("grow-last-partition"):
+        disk["GROW_LAST_PARTITION_TO_FILL_DISK"] = "true"
+    if "align-partitions" in node:
+        disk["ALIGN_PARTITIONS_TO_PERFORMANCE_BOUNDARY"] = "true"
+        disk["PERFORMANCE_BOUNDARY_IN_KB"] = str(int(node["align-partitions"]) // 1024)
+    return disk
+
+
+def _partition_from_node(
+    node: Mapping[str, Any],
+    image_map: Mapping[str, str],
+) -> tuple[str, PartitionEntry]:
+    """Normalise one partition mapping into ``(phys_part, entry)``.
+
+    Mirrors ``conf.partition_options``: same defaults, same attribute-bit
+    decoding, and the image-map override applied last so it always wins.
+    """
+    entry: PartitionEntry = PARTITION_ENTRY_DEFAULTS.copy()
+    phys_part = "0"
+    if "lun" in node:
+        phys_part = str(node["lun"])
+    elif "phys-part" in node:
+        phys_part = str(node["phys-part"])
+    entry["label"] = str(node["name"])
+    entry["size_in_kb"] = str(partition_size_in_kb(str(node["size"])))
+    entry["type"] = str(node["type-guid"])
+    if "attributes" in node:
+        attribute_bits = int(str(node["attributes"]), 16)
+        entry["bootable"] = "true" if attribute_bits & (1 << 2) else "false"
+        entry["readonly"] = "true" if attribute_bits & (1 << 60) else "false"
+    if "filename" in node:
+        entry["filename"] = str(node["filename"])
+    if "sparse" in node:
+        entry["sparse"] = _bool_str(node["sparse"])
+    if entry["label"] in image_map:
+        entry["filename"] = image_map[entry["label"]]
+    return phys_part, entry
+
+
+def load(path: str, image_map: Mapping[str, str] | None = None) -> LoadedSpec:
+    """Public entry point: read ``path`` and return a normalised ``LoadedSpec``."""
+    if image_map is None:
+        image_map = {}
+    with open(path) as f:
+        document = yaml.safe_load(f)
+    if not isinstance(document, Mapping):
+        raise YamlParseError(
+            "%s: expected a top-level mapping, got %s" % (path, type(document).__name__)
+        )
+    try:
+        jsonschema.validate(document, load_schema())
+    except jsonschema.exceptions.ValidationError as exc:
+        raise YamlParseError("%s: schema validation failed: %s" % (path, exc.message)) from exc
+
+    disk = _disk_from_node(document["disk"])
+    partitions: PartitionsByLun = {}
+    for node in document.get("partitions", []):
+        phys_part, entry = _partition_from_node(node, image_map)
+        partitions.setdefault(phys_part, []).append(entry)
+    return {"disk": disk, "partitions": partitions}

--- a/qcom_ptool/schema/__init__.py
+++ b/qcom_ptool/schema/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Packaged JSON Schema documents for the structured (YAML) partition source.
+
+The ``.json`` files here are shipped as package data (see ``pyproject.toml``)
+and loaded at runtime via ``importlib.resources`` by the YAML loader.
+"""

--- a/qcom_ptool/schema/partitions.schema.json
+++ b/qcom_ptool/schema/partitions.schema.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/qualcomm-linux/qcom-ptool/partitions.schema.json",
+    "title": "qcom-ptool single-storage partition spec",
+    "description": "Structured YAML source for one storage device and its partitions. Reduces to a LoadedSpec (see qcom_ptool/spec.py).",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["disk", "partitions"],
+    "properties": {
+        "disk": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "size"],
+            "properties": {
+                "type": {
+                    "description": "Storage class.",
+                    "type": "string",
+                    "enum": ["emmc", "nand", "nvme", "spinor", "ufs"]
+                },
+                "size": {
+                    "description": "Total device size in bytes.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "sector-size": {
+                    "description": "Sector size in bytes.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "write-protect-boundary": {
+                    "description": "Write-protect boundary in KB.",
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "grow-last-partition": {
+                    "description": "Grow the last partition to fill the device.",
+                    "type": "boolean"
+                },
+                "align-partitions": {
+                    "description": "Performance alignment boundary in bytes.",
+                    "type": "integer",
+                    "minimum": 0
+                }
+            }
+        },
+        "partitions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "size", "type-guid"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "size": {
+                        "description": "Partition size as a quoted string: bytes ('1024') or with a K/M/G[B] suffix ('524288KB'). Quoting is required so values are never misparsed as numbers.",
+                        "type": "string",
+                        "pattern": "^[0-9]+([KkMmGg][Bb]?)?$"
+                    },
+                    "type-guid": {
+                        "description": "Partition type GUID; must be a quoted string to avoid integer misparsing.",
+                        "type": "string",
+                        "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "attributes": {
+                        "description": "GPT attribute bits as a hexadecimal string.",
+                        "type": "string",
+                        "pattern": "^[0-9A-Fa-f]+$"
+                    },
+                    "sparse": {
+                        "type": "boolean"
+                    },
+                    "lun": {
+                        "description": "Physical partition / LUN index (mandatory for multi-LUN UFS).",
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "phys-part": {
+                        "type": "integer",
+                        "minimum": 0
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/data/glymur-crd-nvme.yaml
+++ b/tests/unit/data/glymur-crd-nvme.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Single-storage YAML equivalent of platforms/glymur-crd/nvme/partitions.conf.
+# Used by tests/unit/test_loaders_yaml.py to assert byte-for-byte parity
+# between the .conf and .yaml loaders.
+disk:
+  type: nvme
+  size: 68719476736
+  write-protect-boundary: 65536
+  sector-size: 512
+  grow-last-partition: true
+partitions:
+  - name: efi
+    size: "524288KB"
+    type-guid: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+    filename: efi.bin
+  - name: rootfs
+    size: "33554432KB"
+    type-guid: "B921B045-1DF0-41C3-AF44-4C6F280D3FAE"
+    filename: rootfs.img

--- a/tests/unit/test_loaders_yaml.py
+++ b/tests/unit/test_loaders_yaml.py
@@ -1,0 +1,203 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Unit tests for the YAML partition loader.
+
+The load-bearing property is that the YAML loader produces the *same*
+LoadedSpec as the .conf loader, so both emit byte-identical XML. These tests
+pin that equivalence on a real board, on a synthetic multi-LUN spec with
+attribute bits, and at the XML-bytes level, plus the schema rejections that
+protect against the documented YAML footguns.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from qcom_ptool.gen_partition import generate_partition_xml
+from qcom_ptool.loaders import load
+from qcom_ptool.loaders import yaml as yaml_loader
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+GLYMUR_NVME_CONF = os.path.join(
+    REPO_ROOT, "platforms", "glymur-crd", "nvme", "partitions.conf"
+)
+GLYMUR_NVME_YAML = os.path.join(DATA_DIR, "glymur-crd-nvme.yaml")
+
+
+def _write(tmp_path, name: str, text: str) -> str:
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence with the .conf loader
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_matches_conf_for_glymur_nvme():
+    """The committed YAML fixture and the real board .conf load identically."""
+    assert load(GLYMUR_NVME_YAML) == load(GLYMUR_NVME_CONF)
+
+
+def test_yaml_matches_conf_multi_lun_and_attributes(tmp_path):
+    """LUN grouping and attribute-bit decoding match the .conf loader."""
+    conf = _write(
+        tmp_path,
+        "s.conf",
+        "--disk --type=ufs --size=137438953472 --write-protect-boundary=0 "
+        "--sector-size-in-bytes=4096 --grow-last-partition\n"
+        "--partition --lun=0 --name=rootfs --size=79691776KB "
+        "--type-guid=1B81E7E6-F50D-419B-A739-2AEEF8DA3335 --filename=rootfs.img\n"
+        "--partition --lun=1 --name=xbl_a --size=3584KB "
+        "--type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf "
+        "--attributes=1000000000000004\n",
+    )
+    yml = _write(
+        tmp_path,
+        "s.yaml",
+        "disk:\n"
+        "  type: ufs\n"
+        "  size: 137438953472\n"
+        "  write-protect-boundary: 0\n"
+        "  sector-size: 4096\n"
+        "  grow-last-partition: true\n"
+        "partitions:\n"
+        "  - name: rootfs\n"
+        "    lun: 0\n"
+        '    size: "79691776KB"\n'
+        '    type-guid: "1B81E7E6-F50D-419B-A739-2AEEF8DA3335"\n'
+        "    filename: rootfs.img\n"
+        "  - name: xbl_a\n"
+        "    lun: 1\n"
+        '    size: "3584KB"\n'
+        '    type-guid: "DEA0BA2C-CBDD-4805-B4F9-F428251C3E98"\n'
+        "    filename: xbl.elf\n"
+        '    attributes: "1000000000000004"\n',
+    )
+    spec = load(yml)
+    assert spec == load(conf)
+    # attribute-bit decode: bit 2 -> bootable, bit 60 -> readonly.
+    xbl = spec["partitions"]["1"][0]
+    assert xbl["bootable"] == "true"
+    assert xbl["readonly"] == "true"
+
+
+def test_yaml_and_conf_emit_byte_identical_xml(tmp_path):
+    """End-to-end: the emitter output is identical for both source formats."""
+    conf_xml = tmp_path / "from_conf.xml"
+    yaml_xml = tmp_path / "from_yaml.xml"
+    conf_spec = load(GLYMUR_NVME_CONF)
+    yaml_spec = load(GLYMUR_NVME_YAML)
+    generate_partition_xml(conf_spec["disk"], conf_spec["partitions"], str(conf_xml))
+    generate_partition_xml(yaml_spec["disk"], yaml_spec["partitions"], str(yaml_xml))
+    assert yaml_xml.read_bytes() == conf_xml.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Loader behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_routes_yaml_and_yml(tmp_path):
+    """The dispatcher sends .yaml and .yml to the YAML loader."""
+    body = (
+        "disk:\n"
+        "  type: nvme\n"
+        "  size: 68719476736\n"
+        "partitions:\n"
+        "  - name: efi\n"
+        '    size: "524288KB"\n'
+        '    type-guid: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"\n'
+    )
+    for name in ("s.yaml", "s.yml"):
+        spec = load(_write(tmp_path, name, body))
+        assert spec["disk"]["type"] == "nvme"
+        assert spec["partitions"]["0"][0]["label"] == "efi"
+
+
+def test_sparse_boolean_normalised_to_lowercase(tmp_path):
+    """A YAML boolean must serialise as "true", not Python's "True"."""
+    spec = load(
+        _write(
+            tmp_path,
+            "s.yaml",
+            "disk:\n  type: nvme\n  size: 68719476736\n"
+            "partitions:\n"
+            "  - name: cache\n"
+            '    size: "1024KB"\n'
+            '    type-guid: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"\n'
+            "    sparse: true\n",
+        )
+    )
+    assert spec["partitions"]["0"][0]["sparse"] == "true"
+
+
+def test_image_map_overrides_filename(tmp_path):
+    """The -m image map overrides filename, matching the .conf loader."""
+    spec = load(
+        _write(
+            tmp_path,
+            "s.yaml",
+            "disk:\n  type: nvme\n  size: 68719476736\n"
+            "partitions:\n"
+            "  - name: rootfs\n"
+            '    size: "1024KB"\n'
+            '    type-guid: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"\n'
+            "    filename: rootfs.img\n",
+        ),
+        image_map={"rootfs": "override.img"},
+    )
+    assert spec["partitions"]["0"][0]["filename"] == "override.img"
+
+
+# ---------------------------------------------------------------------------
+# Schema validation (footgun rejection)
+# ---------------------------------------------------------------------------
+
+_VALID_DISK = "disk:\n  type: nvme\n  size: 68719476736\n"
+
+
+def _partition(**overrides) -> str:
+    fields = {
+        "name": "efi",
+        "size": '"524288KB"',
+        "type-guid": '"C12A7328-F81F-11D2-BA4B-00A0C93EC93B"',
+    }
+    fields.update(overrides)
+    lines = "".join(f"    {k}: {v}\n" for k, v in fields.items())
+    return _VALID_DISK + "partitions:\n" + "  -\n" + lines
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # GUID left unquoted and all-digit -> parsed as int -> type error.
+        _VALID_DISK
+        + 'partitions:\n  - name: efi\n    size: "1KB"\n    type-guid: 0123456789012345678901234567\n',
+        # size as a bare integer (unquoted) -> not a string -> rejected.
+        _VALID_DISK
+        + "partitions:\n  - name: efi\n    size: 524288\n"
+        + '    type-guid: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"\n',
+        # unknown partition key -> additionalProperties: false.
+        _partition(typo="1"),
+        # missing required type-guid.
+        _VALID_DISK + 'partitions:\n  - name: efi\n    size: "1KB"\n',
+        # malformed size string.
+        _partition(size='"12XB"'),
+        # unknown disk type.
+        "disk:\n  type: floppy\n  size: 1024\npartitions: []\n",
+    ],
+)
+def test_schema_rejects_invalid(tmp_path, text):
+    with pytest.raises(yaml_loader.YamlParseError):
+        load(_write(tmp_path, "bad.yaml", text))
+
+
+def test_top_level_must_be_mapping(tmp_path):
+    with pytest.raises(yaml_loader.YamlParseError):
+        load(_write(tmp_path, "list.yaml", "- 1\n- 2\n"))


### PR DESCRIPTION
Second step of the partition-source rework [1], building on the loaders package: this adds the structured YAML input format for a single storage device.

The .conf line format cannot be validated: sizes are parsed by best-effort regex, GUIDs are bare strings, booleans are ad-hoc, and mistakes only surface when a device fails to boot. A structured, schema-validated source catches these errors at build time and is the foundation for everything that follows in [1] - shared partition groups, board variants, and multi-storage boards.

A new `loaders/yaml.py` loads a disk mapping plus partitions list, validates it against a packaged JSON Schema, and normalises it into the same `LoadedSpec` the `.conf` loader produces - so both formats emit byte-identical XML, which the test suite pins with an equivalence test against a real board layout and an end-to-end XML comparison. The schema enforces the known YAML footguns up front: GUIDs and sizes must be quoted strings, unknown keys are rejected, disk types are constrained. `PyYAML` and `jsonschema` become the project's first runtime dependencies; the dispatcher late-imports them, so the .conf path never pays for either.

No board is migrated and nothing consumes YAML in the build yet: every generated artifact is unchanged, as CI proves via the pinned checksum manifest.

[1] https://github.com/qualcomm-linux/qcom-ptool/issues/124