### PR TITLE
pyproject: drop duplicate pytest ini_options section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qcom-tool
+# qcom-ptool
 
 qcom-ptool contains various device partitioning utilities like ptool.py, gen_partitions.py and various sample partition configuration files needed for Qualcomm SoCs. Qualcomm Linux currently supports two reference Linux based OSes (Yocto with [meta-qcom](https://github.com/qualcomm-linux/meta-qcom) and Debian with [qcom-deb-images](https://github.com/qualcomm-linux/qcom-deb-images)) which uses this tool to generate partition table layouts. The partition GUIDs, names and size budgets are picked to support boot flows as follows:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 test = ["pytest"]
 
-[tool.pytest.ini_options]
-testpaths = ["tests/unit"]
-
 [project.scripts]
 qcom-ptool = "qcom_ptool.cli:main"
 


### PR DESCRIPTION
Commit https://github.com/qualcomm-linux/qcom-ptool/commit/ef06e88336ca83efec9aa725d038518afd8391fb ("tests: add pytest-based unit tests"), merged to main
via https://github.com/qualcomm-linux/qcom-ptool/commit/d8f5b2617d86b070f46fe3148b036fb5ec3f8cfe ("Merge pull request https://github.com/qualcomm-linux/qcom-ptool/pull/147 from aekoroglu/main"), added a
[tool.pytest.ini_options] section that https://github.com/qualcomm-linux/qcom-ptool/commit/5aad8a964de6a975376b6262921f93c44da76a4e ("tests: add pytest
unit suite for the .conf loader") had already introduced. TOML forbids
declaring the same table twice, so pip now fails to parse
pyproject.toml with "Cannot declare ('tool', 'pytest', 'ini_options')
twice" and the package no longer installs, which breaks the build
workflow on main.

Drop the newly added duplicate and keep the original section, which
also sets pythonpath so pytest can run from the repo root without an
editable install. The testpaths value is identical in both.

Also address a type (tool name) in the README