### PR TITLE
platforms/iq10-rrd: add UFS partition layout

### DIFF
--- a/platforms/iq10-rrd/ufs/contents.xml.in
+++ b/platforms/iq10-rrd/ufs/contents.xml.in
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<!--
+========================================================================
+  contents.in
+
+  General Description
+     Contains information about component builds for this target.
+     It will clone as contents.xml during build compilation process.
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  SPDX-License-Identifier: BSD-3-Clause
+
+========================================================================
+-->
+
+<contents>
+  <product_flavors cmm_pf_var="PRODUCT_FLAVORS">
+    <pf>
+      <name>default</name>
+      <component>
+        <name>common</name>
+        <flavor>default</flavor>
+      </component>
+      <component>
+        <name>apps</name>
+        <flavor>default</flavor>
+      </component>
+    </pf>
+  </product_flavors>
+  <product_info>
+    <product_name>SA8797P.HGY.5.1.7.0</product_name>
+    <hlos_type>LE</hlos_type>
+    <chipid flavor="default" storage_type="ufs" flash_phase="1">SA8797P</chipid>
+    <additional_chipid>QAM8797P,SA8797P,QAM8397P,NORD</additional_chipid>
+    <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
+  </product_info>
+  <builds_flat>
+    <build>
+      <name>apps</name>
+      <role>apps</role>
+      <chipset>SA8797P</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>apps_proc</image_dir>
+    </build>
+    <build>
+      <name>common</name>
+      <role>common</role>
+      <chipset>SA8797P</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>common</image_dir>
+      <device_programmer cmm_file_var="FIREHOSE_DDR_ELF">
+        <file_name>xbl_s_devprg_ns.melf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <download_file>
+        <fastboot_complete>{partition_name}</fastboot_complete>
+        <file_name>{image_name}</file_name>
+        <file_path>.</file_path>
+      </download_file>
+      <partition_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_file>
+      <partition_patch_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_patch_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_patch_file>
+   </build>
+  </builds_flat>
+</contents>

--- a/platforms/iq10-rrd/ufs/partitions.conf
+++ b/platforms/iq10-rrd/ufs/partitions.conf
@@ -1,0 +1,229 @@
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# options if not explicitly provid
+--disk --type=ufs --size=290068671692 --write-protect-boundary=0 --sector-size-in-bytes=4096 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --lun (mandatory for UFS, emmc no need this)
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --attributes  1000000000000004
+#   --filename    ""
+#   --readonly    true
+#   --sparse      false
+
+#This is LUN 0 - Guest VM(s) LUN
+--partition --lun=0 --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+--partition --lun=0 --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --lun=0 --name=reserved1 --size=98304KB --type-guid=4EF7C492-D028-41C6-B47A-BBD33850CB31
+--partition --lun=0 --name=reserved2 --size=98304KB --type-guid=4E351956-AA2A-479E-B5F7-163DA39F14F6
+--partition --lun=0 --name=rawdump --size=68681728KB --type-guid=66C9B323-F7FC-48B6-BF96-6F32E335A428
+--partition --lun=0 --name=testparti --size=4194304KB --type-guid=7BF9AE4A-5610-45F0-86C0-9F60F2BF832F
+--partition --lun=0 --name=recoveryinfo --size=4KB --type-guid=7374B391-291C-49FA-ABC2-0463AB5F713F
+
+#This is LUN 1 - Boot LUN A
+--partition --lun=1 --name=xbl_a --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl_sc.elf
+--partition --lun=1 --name=xbl_bkup_a --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl_sc.elf
+--partition --lun=1 --name=tme_seq_patch_a --size=8KB --type-guid=9542DF23-692D-4505-A2AD-EDE82AD0B2C2 --filename=sequencer_ram.elf
+--partition --lun=1 --name=tme_fw_a --size=1024KB --type-guid=B8DF5B14-9304-442C-AAA3-10CFB51B38CE --filename=signed_firmware_soc_view.elf
+--partition --lun=1 --name=tme_config_a --size=516KB --type-guid=A50BF003-B224-4DD8-881A-2FCC64274267 --filename=tme_config.elf
+--partition --lun=1 --name=multiimgoem_a --size=48KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=oem_misc.mbn
+--partition --lun=1 --name=multiimgqti_a --size=48KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=qti_misc.mbn
+--partition --lun=1 --name=tme_seq_patch_bkup_a --size=8KB --type-guid=E9B1F4EF-E38F-4335-858F-86E70B6FBBAF --filename=sequencer_ram.elf
+--partition --lun=1 --name=tme_fw_bkup_a --size=1024KB --type-guid=EF971291-F4F1-4E91-B367-25414D98EF9C --filename=signed_firmware_soc_view.elf
+--partition --lun=1 --name=tme_config_bkup_a --size=516KB --type-guid=1FF86822-2C39-472B-B1E5-514DB3F0D3C2 --filename=tme_config.elf
+--partition --lun=1 --name=multiimgoem_bkup_a --size=48KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=oem_misc.mbn
+--partition --lun=1 --name=multiimgqti_bkup_a --size=48KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=qti_misc.mbn
+--partition --lun=1 --name=xbl_config_a --size=1024KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --lun=1 --name=xbl_ac_config_a --size=128KB --type-guid=AB3C2889-7AFC-4DB3-8C3F-B31829E769FC --filename=xbl_ac_config.mbn
+--partition --lun=1 --name=apdp_a --size=64KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --lun=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 2 - Boot LUN B
+--partition --lun=2 --name=xbl_b --size=5120KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl_sc.elf
+--partition --lun=2 --name=xbl_bkup_b --size=5120KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl_sc.elf
+--partition --lun=2 --name=tme_seq_patch_b --size=8KB --type-guid=9542DF23-692D-4505-A2AD-EDE82AD0B2C2 --filename=sequencer_ram.elf
+--partition --lun=2 --name=tme_fw_b --size=1024KB --type-guid=B8DF5B14-9304-442C-AAA3-10CFB51B38CE --filename=signed_firmware_soc_view.elf
+--partition --lun=2 --name=tme_config_b --size=516KB --type-guid=A50BF003-B224-4DD8-881A-2FCC64274267 --filename=tme_config.elf
+--partition --lun=2 --name=multiimgoem_b --size=48KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8 --filename=oem_misc.mbn
+--partition --lun=2 --name=multiimgqti_b --size=48KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E --filename=qti_misc.mbn
+--partition --lun=2 --name=tme_seq_patch_bkup_b --size=8KB --type-guid=E9B1F4EF-E38F-4335-858F-86E70B6FBBAF --filename=sequencer_ram.elf
+--partition --lun=2 --name=tme_fw_bkup_b --size=1024KB --type-guid=EF971291-F4F1-4E91-B367-25414D98EF9C --filename=signed_firmware_soc_view.elf
+--partition --lun=2 --name=tme_config_bkup_b --size=516KB --type-guid=1FF86822-2C39-472B-B1E5-514DB3F0D3C2 --filename=tme_config.elf
+--partition --lun=2 --name=multiimgoem_bkup_b --size=48KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970 --filename=oem_misc.mbn
+--partition --lun=2 --name=multiimgqti_bkup_b --size=48KB --type-guid=D30C8B21-DDD9-45B6-8DE0-3165D34395C9 --filename=qti_misc.mbn
+--partition --lun=2 --name=xbl_config_b --size=1024KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
+--partition --lun=2 --name=xbl_ac_config_b --size=128KB --type-guid=A211141B-5596-4B47-B115-29D53DDA83F8 --filename=xbl_ac_config.mbn
+--partition --lun=2 --name=apdp_b --size=64KB --type-guid=110F198D-8174-4193-9AF1-5DA94CDC59C9
+--partition --lun=2 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 3 - OTP LUN
+--partition --lun=3 --name=cdt --size=4KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1
+--partition --lun=3 --name=ddr_training_A --size=512KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --lun=3 --name=ddr_training_golden_A --size=512KB --type-guid=EB44AD17-E65D-44FF-9BAF-7A12EBBB7AA4
+--partition --lun=3 --name=ddr_buffer_e_A --size=256KB --type-guid=13412D86-B419-4A35-B515-1792AB094302
+--partition --lun=3 --name=ddr_buffer_i_A --size=512KB --type-guid=5879D710-543B-4973-BD18-70D4EA3C3954
+--partition --lun=3 --name=ddr_debug_A --size=2816KB --type-guid=2D58205E-BA35-4BF9-B6C1-C6FDC80A373B
+--partition --lun=3 --name=ddr_training_B --size=512KB --type-guid=78A54EF3-D7D7-4518-91D5-1E972C82B282
+--partition --lun=3 --name=ddr_training_golden_B --size=512KB --type-guid=3B534D62-1400-43E3-B351-2B8D48D1517F
+--partition --lun=3 --name=ddr_buffer_e_B --size=256KB --type-guid=D236550E-C75E-45FA-976F-EF8D50564BEA
+--partition --lun=3 --name=ddr_buffer_i_B --size=512KB --type-guid=2AA0E914-EBE2-4249-B5CC-798134DC84CC
+--partition --lun=3 --name=ddr_debug_B --size=2816KB --type-guid=15F5BFE4-CE61-4FE9-AA46-779F54F5417B
+--partition --lun=3 --name=ddr_training_factory --size=512KB --type-guid=E7051F78-5BB3-4AE5-BF23-A224D5731A8A
+--partition --lun=3 --name=ddr_training_factory_golden --size=512KB --type-guid=3B534D62-1400-43E3-B351-2B8D48D1517F
+--partition --lun=3 --name=ddr_buffer_e_factory --size=256KB --type-guid=13412D86-B419-4A35-B515-1792AB094302
+--partition --lun=3 --name=ddr_buffer_i_factory --size=512KB --type-guid=5879D710-543B-4973-BD18-70D4EA3C3954
+--partition --lun=3 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 4 - Primary VM Read-write LUN
+--partition --lun=4 --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --lun=4 --name=SYSFW_VERSION --size=64KB --type-guid=3C44F88B-1878-4C29-B122-EE78766442A7
+--partition --lun=4 --name=aop_a --size=1024KB --type-guid=D69E90A5-4CAB-0071-F6DF-AB977F141A7F --filename=aop.mbn
+--partition --lun=4 --name=aop_config_a --size=512KB --type-guid=3D12F234-C882-4B46-A20C-17D52C8FC03D --filename=aop_devcfg.mbn
+--partition --lun=4 --name=tz_a --size=10240KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --lun=4 --name=hyp_a --size=512000KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --lun=4 --name=devcfg_a --size=256KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_auto_sgvm.mbn
+--partition --lun=4 --name=tz_qti_config_a --size=512KB --type-guid=71AF1E14-AE35-4184-8EA2-7809235BF8D7 --filename=tz_qti_config.mbn
+--partition --lun=4 --name=cpucp_a --size=1024KB --type-guid=1E8615BD-6D8C-41AD-B3EA-50E8BF40E43F --filename=cpucp.elf
+--partition --lun=4 --name=cpucp_dtb_a --size=128KB --type-guid=6C6018BC-4FBE-40C5-B148-4BCB1DB23748 --filename=cpucp_dtbs.elf
+--partition --lun=4 --name=shrm_a --size=256KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --lun=4 --name=ddr_lcp_a --size=64KB --type-guid=AD25F436-8C48-4103-B3A1-950F58BB0CB2 --filename=ddr_lcp.elf
+--partition --lun=4 --name=soccp_a --size=3072KB --type-guid=7999BAF4-9E18-4073-987B-2AC661353F9F --filename=soccp.mbn
+--partition --lun=4 --name=soccp_debug_a --size=512KB --type-guid=95825EE7-01DD-4A7C-A9EE-8C37B997FEC4 --filename=sdi.mbn
+--partition --lun=4 --name=soccp_dcd_a --size=48KB --type-guid=D67CC91F-B88A-43FA-9B3A-12EF5A1892DC --filename=dcd.mbn
+--partition --lun=4 --name=uefi_a --size=12288KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --lun=4 --name=uefi_dtb_a --size=2048KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
+--partition --lun=4 --name=gearvm_a --size=12288KB --type-guid=06EF844E-08FC-494E-89EB-396D4D6C5B27 --filename=gearvm.mbn
+--partition --lun=4 --name=pdp_a --size=512KB --type-guid=4D65EF4C-6B68-4563-80B5-2B079A9E649B --filename=pdp.elf
+--partition --lun=4 --name=pdp_cdb_a --size=128KB --type-guid=39F567C2-CBAA-4378-A88A-F1912512CE10 --filename=pdp_cdb.elf
+--partition --lun=4 --name=xbl_ramdump_a --size=2048KB --type-guid=0382F197-E41F-4E84-B18B-0B564AEAD875 --filename=xbl_ramdump.elf
+--partition --lun=4 --name=xbl_sc_test_mode --size=64KB --type-guid=91FDD2B9-8ED3-4176-BC42-260F2E34D04A
+--partition --lun=4 --name=TZAPPS --size=320KB --type-guid=14D11C40-2A3D-4F97-882D-103A1EC09333
+--partition --lun=4 --name=modem_a --size=262144KB --type-guid=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+--partition --lun=4 --name=core_nhlos_a --size=122880KB --type-guid=6690B4CE-70E9-4817-B9F1-25D64D888357
+--partition --lun=4 --name=mdtpsecapp_a --size=4096KB --type-guid=EA02D680-8712-4552-A3BE-E6087829C1E6
+--partition --lun=4 --name=mdtp_a --size=32768KB --type-guid=3878408A-E263-4B67-B878-6340B35B11E3
+--partition --lun=4 --name=keymaster_a --size=10240KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=onekeymint_virt.mbn
+--partition --lun=4 --name=kmvirt_a --size=1024KB --type-guid=F3E39102-ED76-4BDD-A006-DEE69B68B21B --filename=km5virt_smci.mbn
+--partition --lun=4 --name=dsp_a --size=184320KB --type-guid=7EFE5010-2A1A-4A1A-B8BC-990257813512
+--partition --lun=4 --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
+--partition --lun=4 --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+--partition --lun=4 --name=dip --size=1024KB --type-guid=4114B077-005D-4E12-AC8C-B493BDA684FB
+--partition --lun=4 --name=spunvm --size=8192KB --type-guid=E42E2B4C-33B0-429B-B1EF-D341C547022C
+--partition --lun=4 --name=splash --size=33424KB --type-guid=AD99F201-DC71-4E30-9630-E19EEF553D1B
+--partition --lun=4 --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --lun=4 --name=tgbmon --size=4KB --type-guid=FC9BF4DB-955A-4A27-A889-0D28123AB4B2
+--partition --lun=4 --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372 --filename=logfs_ufs_8mb.bin
+--partition --lun=4 --name=xbl_sc_logs --size=1024KB --type-guid=F7EECB66-781A-439A-8955-70E12ED4A7A0
+--partition --lun=4 --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --lun=4 --name=emac --size=512KB --type-guid=E7E5EFF9-D224-4EB3-8F0B-1D2A4BE18665
+--partition --lun=4 --name=secdata --size=128KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --lun=4 --name=quantumsdk --size=40960KB --type-guid=B09AFFF8-70C4-4BFA-ADD2-2C7C8C5051EE --filename=quantumsdk.fv
+--partition --lun=4 --name=quantumfv --size=1024KB --type-guid=80C23C26-C3F9-4A19-BB38-1E457DACEB09 --filename=Quantum.fv
+--partition --lun=4 --name=quantumcontentfv --size=1024KB --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
+--partition --lun=4 --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C
+--partition --lun=4 --name=bluetooth_a --size=2048KB --type-guid=6CB747F1-C2EF-4092-ADD0-CA39F79C7AF4
+--partition --lun=4 --name=mm_cal_data --size=8192KB --type-guid=54DBC0D1-7C95-435F-8A6A-FB6A63F0EA50
+--partition --lun=4 --name=camera_cal_data --size=1024KB --type-guid=E1DA37AD-8122-4DD3-A16E-C5792C69EE67
+--partition --lun=4 --name=audio_dsp2_dtb_a --size=512KB --type-guid=B5E6F4AB-85F3-49B7-8473-F99F14BACBEF --filename=adsp2_dtbs.elf
+--partition --lun=4 --name=audio_dsp1_dtb_a --size=512KB --type-guid=3F503927-CEC6-47F5-BB9F-F216DBD06232 --filename=adsp1_dtbs.elf
+--partition --lun=4 --name=audio_dsp0_dtb_a --size=512KB --type-guid=B7285610-243A-4E3F-B3B1-0A2A521F8B63 --filename=adsp_dtbs.elf
+--partition --lun=4 --name=audio_dsp2_a --size=40960KB --type-guid=6D17BCCE-F4DB-4646-B844-CC67317F613B --filename=adsp2.mbn
+--partition --lun=4 --name=audio_dsp1_a --size=40960KB --type-guid=2A9072F6-FC78-4678-AD61-0D5B61C0281B --filename=adsp1.mbn
+--partition --lun=4 --name=audio_dsp0_a --size=40960KB --type-guid=FA5B8B1C-E148-453E-A99B-E3B3932D7223 --filename=adsp.mbn
+--partition --lun=4 --name=compute_dsp3_dtb_a --size=512KB --type-guid=1151CE4B-091B-4360-9CD7-845473C1E475 --filename=cdsp3_dtbs.elf
+--partition --lun=4 --name=compute_dsp2_dtb_a --size=512KB --type-guid=0A037D40-AD4A-48D3-BA20-7FCE41D20F36 --filename=cdsp2_dtbs.elf
+--partition --lun=4 --name=compute_dsp1_dtb_a --size=512KB --type-guid=3A92754B-D045-4376-9557-F9E6A6988EF1 --filename=cdsp1_dtbs.elf
+--partition --lun=4 --name=compute_dsp0_dtb_a --size=512KB --type-guid=46905134-0260-478E-8524-04554829FCF6 --filename=cdsp_dtbs.elf
+--partition --lun=4 --name=compute_dsp3_a --size=35840KB --type-guid=AF1F5144-F12D-4F5B-8BD5-C522B363FBB6 --filename=cdsp3.mbn
+--partition --lun=4 --name=compute_dsp2_a --size=35840KB --type-guid=AA5E04A5-DB45-457E-94BA-1736733E3767 --filename=cdsp2.mbn
+--partition --lun=4 --name=compute_dsp1_a --size=35840KB --type-guid=68235422-C461-477C-9CDC-B2A0E7C47F6D --filename=cdsp1.mbn
+--partition --lun=4 --name=compute_dsp0_a --size=35840KB --type-guid=056FD6FA-DDA6-4BC8-AAAB-098A11639DB4 --filename=cdsp.mbn
+--partition --lun=4 --name=CVP_a --size=8192KB --type-guid=04A9DDD6-A516-44F2-8BA7-7D08A040AEDC
+--partition --lun=4 --name=VIDEO_a --size=8192KB --type-guid=18A8CA81-CEA6-46FA-90C5-40D27C509CC2
+--partition --lun=4 --name=Camera2_a --size=2048KB --type-guid=3E6FAD56-C3E3-403F-A220-E5CFB6E71F6B
+--partition --lun=4 --name=Camera_a --size=8192KB --type-guid=7322732B-9902-4D3C-B1C8-3F6E89354453
+--partition --lun=4 --name=GPU_micro_code2_a --size=8KB --type-guid=70DB9385-A3D4-483D-8588-36BB99605FEA
+--partition --lun=4 --name=GPU_micro_code_a --size=8KB --type-guid=CF96F715-9398-452A-A60A-11563EF27DCA
+--partition --lun=4 --name=uefisecapp_a --size=2048KB --type-guid=8ABBA5AA-7550-4FEB-AE4C-F0B09A5C9F38
+--partition --lun=4 --name=questdatafv --size=16384KB --type-guid=160CF0BE-A1D6-4F95-8ECC-DCF981D37507
+--partition --lun=4 --name=qmcs --size=30720KB --type-guid=5FF68F4B-623F-47A1-90AB-006AA34DD742
+--partition --lun=4 --name=qweslicstore_a --size=256KB --type-guid=7BAB3C93-5F73-4D02-B8CB-5B9F899D29A8 --filename=license.bin
+--partition --lun=4 --name=qwesliccache --size=36KB --type-guid=7DDC813A-E88A-491A-95DC-4811A869D313
+--partition --lun=4 --name=storsec --size=128KB --type-guid=68B52F25-2025-44F8-9185-82FF9AFDFA77
+--partition --lun=4 --name=mdcompress --size=20480KB --type-guid=2D106602-6107-4211-8EE4-77F06E455642
+--partition --lun=4 --name=tzsc --size=128KB --type-guid=2C1BC23B-CD3B-41C2-A419-C2B9FD9887D3
+--partition --lun=4 --name=dpm --size=8KB --type-guid=BAC7159A-4B70-4E64-9950-C5E95D00F1F5
+--partition --lun=4 --name=tz_ac_config_a --size=512KB --type-guid=7437F5B5-215F-4E08-927A-F49F53CC1F5D --filename=tz_ac_config.mbn
+--partition --lun=4 --name=hyp_ac_config_a --size=256KB --type-guid=05E0CA06-3F20-49C4-8B82-AC560268F2AE --filename=hyp_ac_config.mbn
+--partition --lun=4 --name=spare1_a --size=8192KB --type-guid=D69CA530-3C9A-4C1E-9D73-2E2F5CEFE9E7
+--partition --lun=4 --name=spare2_a --size=8192KB --type-guid=44E2FE3E-BF26-4B02-A2E7-3CA9333BBF1C
+--partition --lun=4 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 5 - Primary VM Read-write LUN
+--partition --lun=5 --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587
+--partition --lun=5 --name=aop_b --size=1024KB --type-guid=B8B27C4C-4B5B-8AB2-502F-A792B590A896 --filename=aop.mbn
+--partition --lun=5 --name=aop_config_b --size=512KB --type-guid=5738935D-8A89-4F71-9731-514FF00B8B4F --filename=aop_devcfg.mbn
+--partition --lun=5 --name=tz_b --size=10240KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --lun=5 --name=hyp_b --size=512000KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --lun=5 --name=devcfg_b --size=256KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg_auto_sgvm.mbn
+--partition --lun=5 --name=tz_qti_config_b --size=512KB --type-guid=9ED896DD-F1A4-44C2-845F-834967E77879 --filename=tz_qti_config.mbn
+--partition --lun=5 --name=cpucp_b --size=1024KB --type-guid=6C1111FB-5354-41DE-AC17-5B6E542BE836 --filename=cpucp.elf
+--partition --lun=5 --name=cpucp_dtb_b --size=128KB --type-guid=57213A2B-39DE-4184-97DE-645D37913E4E --filename=cpucp_dtbs.elf
+--partition --lun=5 --name=shrm_b --size=256KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+--partition --lun=5 --name=ddr_lcp_b --size=64KB --type-guid=2B098FBF-1BFF-41DA-955D-A797C0675EB4 --filename=ddr_lcp.elf
+--partition --lun=5 --name=soccp_debug_b --size=512KB --type-guid=88CE4B5F-616E-4549-B875-565DAD984951 --filename=sdi.mbn
+--partition --lun=5 --name=soccp_dcd_b --size=48KB --type-guid=BF795A2C-F2EA-4110-85EA-95CC43FE1532 --filename=dcd.mbn
+--partition --lun=5 --name=uefi_b --size=12288KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --lun=5 --name=uefi_dtb_b --size=2048KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
+--partition --lun=5 --name=gearvm_b --size=12288KB --type-guid=4D09E70E-F349-11ED-A05B-0242AC120003 --filename=gearvm.mbn
+--partition --lun=5 --name=pdp_b --size=512KB --type-guid=23BC2066-6DF0-4869-B84D-84B6247E3C53 --filename=pdp.elf
+--partition --lun=5 --name=pdp_cdb_b --size=128KB --type-guid=C49242AA-4C04-43C5-9E81-817AF9C23AD5 --filename=pdp_cdb.elf
+--partition --lun=5 --name=xbl_ramdump_b --size=2048KB --type-guid=FF608BF6-AEDF-4084-BEC5-C92AB4E4534D --filename=xbl_ramdump.elf
+--partition --lun=5 --name=modem_b --size=262144KB --type-guid=6CEFFAAE-691A-49C9-A403-3FCB8F47D06E
+--partition --lun=5 --name=core_nhlos_b --size=122880KB --type-guid=E8867782-68AB-46F5-9FA2-68FDFDBB1E13
+--partition --lun=5 --name=mdtpsecapp_b --size=4096KB --type-guid=970F39AF-33E0-4007-A3DE-49DB996E5C16
+--partition --lun=5 --name=mdtp_b --size=32768KB --type-guid=E7A61565-9B57-4A58-A335-F684B68CDFFC
+--partition --lun=5 --name=keymaster_b --size=10240KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=onekeymint_virt.mbn
+--partition --lun=5 --name=kmvirt_b --size=1024KB --type-guid=D13C4686-4E80-4E49-A4C9-A8C8E807AD14 --filename=km5virt_smci.mbn
+--partition --lun=5 --name=dsp_b --size=184320KB --type-guid=A7CE9095-BE83-4F72-93A6-BCA48C8A534B
+--partition --lun=5 --name=soccp_b --size=3072KB --type-guid=B842FDD7-8ED5-4DAA-A755-D0B43FFF21E6 --filename=soccp.mbn
+--partition --lun=5 --name=qupfw_b --size=128KB --type-guid=1DF89EA5-F53A-41CC-82B1-ED2EE0C2B4B7 --filename=qupv3fw.elf
+--partition --lun=5 --name=bluetooth_b --size=2048KB --type-guid=8EF88AFA-75B6-4BDB-A133-16FC3CB2EE3F
+--partition --lun=5 --name=audio_dsp2_dtb_b --size=512KB --type-guid=3371E7BC-8F6D-4743-9D15-B29BC82D3F9A --filename=adsp2_dtbs.elf
+--partition --lun=5 --name=audio_dsp1_dtb_b --size=512KB --type-guid=75D75340-A777-4003-8C8B-AF5A7CF1147A --filename=adsp1_dtbs.elf
+--partition --lun=5 --name=audio_dsp0_dtb_b --size=512KB --type-guid=46167293-AA20-4405-8338-D9237265FADE --filename=adsp_dtbs.elf
+--partition --lun=5 --name=audio_dsp2_b --size=40960KB --type-guid=D37C1628-22C2-47D5-A228-6BB67E51EA86 --filename=adsp2.mbn
+--partition --lun=5 --name=audio_dsp1_b --size=40960KB --type-guid=7DFD535C-0491-43AA-88F6-FE6ACA602EA8 --filename=adsp1.mbn
+--partition --lun=5 --name=audio_dsp0_b --size=40960KB --type-guid=6E44C534-0226-4578-A023-82B07B7A99FC --filename=adsp.mbn
+--partition --lun=5 --name=compute_dsp3_dtb_b --size=512KB --type-guid=1BED2188-E036-4DD0-B0DD-4204D1F28D27 --filename=cdsp3_dtbs.elf
+--partition --lun=5 --name=compute_dsp2_dtb_b --size=512KB --type-guid=347C3CA6-A333-4A99-98E4-9E37A6A2F4D8 --filename=cdsp2_dtbs.elf
+--partition --lun=5 --name=compute_dsp1_dtb_b --size=512KB --type-guid=25D0E8C7-43A1-45E5-8A03-02907A4E27CF --filename=cdsp1_dtbs.elf
+--partition --lun=5 --name=compute_dsp0_dtb_b --size=512KB --type-guid=50519831-A01C-44B9-BA99-2C7592FC612A --filename=cdsp_dtbs.elf
+--partition --lun=5 --name=compute_dsp3_b --size=35840KB --type-guid=09364527-3E29-425B-9334-0B38694CE737 --filename=cdsp3.mbn
+--partition --lun=5 --name=compute_dsp2_b --size=35840KB --type-guid=3D0C0908-CCAD-4169-8053-1A797F74483B --filename=cdsp2.mbn
+--partition --lun=5 --name=compute_dsp1_b --size=35840KB --type-guid=B7CE0257-44ED-49F7-9CBC-1266F4BBF95D --filename=cdsp1.mbn
+--partition --lun=5 --name=compute_dsp0_b --size=35840KB --type-guid=B13B3FC6-996C-4A13-B4AB-E7B12A74670E --filename=cdsp.mbn
+--partition --lun=5 --name=CVP_b --size=8192KB --type-guid=85500F4A-126D-445C-9CB4-BE0C81321A50
+--partition --lun=5 --name=VIDEO_b --size=8192KB --type-guid=07CD529D-6D7D-4167-9EA0-BFC5D62441ED
+--partition --lun=5 --name=Camera2_b --size=2048KB --type-guid=81C1181B-1BAA-4038-9FA8-505433C91E26
+--partition --lun=5 --name=Camera_b --size=8192KB --type-guid=F31C52F2-79CD-49F3-B15F-EC5241793CA5
+--partition --lun=5 --name=GPU_micro_code2_b --size=8KB --type-guid=4F793617-BCA9-4878-8EE5-D18096D405D0
+--partition --lun=5 --name=GPU_micro_code_b --size=8KB --type-guid=4A1ED899-45C6-4000-AE7C-1EE9F39F6980
+--partition --lun=5 --name=uefisecapp_b --size=2048KB --type-guid=48410CC8-F293-4533-A6BE-EBFED9EC892C
+--partition --lun=5 --name=qweslicstore_b --size=256KB --type-guid=1A702852-77D3-40E6-BE75-884E0E601787 --filename=license.bin
+--partition --lun=5 --name=tz_ac_config_b --size=512KB --type-guid=FA5C1B9B-CED6-4ED8-8C92-97BEC5791F30 --filename=tz_ac_config.mbn
+--partition --lun=5 --name=hyp_ac_config_b --size=256KB --type-guid=43B68B3D-DE1F-4514-B280-69C970E2920A --filename=hyp_ac_config.mbn
+--partition --lun=5 --name=logdump --size=524288KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+--partition --lun=5 --name=spare1_b --size=8192KB --type-guid=5BEF7D08-EEFB-415C-8373-A5128472839B
+--partition --lun=5 --name=spare2_b --size=8192KB --type-guid=1DAFA947-9F7D-490F-A773-A43B6C4E5256
+--partition --lun=5 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000
+
+#This is LUN 6 - Protected Read-write LUN
+--partition --lun=6 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/shikra-test-latest/emmc/contents.xml.in
+++ b/platforms/shikra-test-latest/emmc/contents.xml.in
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<!--
+========================================================================
+  contents.in
+
+  General Description
+     Contains information about component builds for this target.
+     It will clone as contents.xml during build compilation process.
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  SPDX-License-Identifier: BSD-3-Clause
+
+========================================================================
+-->
+
+<contents>
+  <product_flavors cmm_pf_var="PRODUCT_FLAVORS">
+    <pf>
+      <name>default</name>
+      <component>
+        <name>common</name>
+        <flavor>default</flavor>
+      </component>
+      <component>
+        <name>apps</name>
+        <flavor>default</flavor>
+      </component>
+    </pf>
+  </product_flavors>
+  <product_info>
+    <product_name>CQ2390.LE.0.0</product_name>
+    <chipid flavor="default" storage_type="emmc" flash_phase="1">SHIKRA</chipid>
+    <additional_chipid>CQ2390,CQ2390M,CQ2390S</additional_chipid>
+    <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
+  </product_info>
+  <builds_flat>
+    <build>
+      <name>apps</name>
+      <role>apps</role>
+      <chipset>SHIKRA</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>apps_proc</image_dir>
+    </build>
+    <build>
+      <name>common</name>
+      <role>common</role>
+      <chipset>SHIKRA</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>common</image_dir>
+      <device_programmer>
+        <file_name>prog_firehose_ddr.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <device_programmer firehose_type="lite">
+        <file_name>prog_firehose_lite.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <download_file>
+        <fastboot_complete>{partition_name}</fastboot_complete>
+        <file_name>{image_name}</file_name>
+        <file_path>.</file_path>
+      </download_file>
+      <partition_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_file>
+      <partition_patch_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_patch_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_patch_file>
+   </build>
+  </builds_flat>
+</contents>

--- a/platforms/shikra-test-latest/emmc/partitions.conf
+++ b/platforms/shikra-test-latest/emmc/partitions.conf
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# --disk --type=emmc --size=137438953472 --write-protect-boundary=0 --sector-size-in-bytes=512 --grow-last-partition
+--disk --type=emmc --size=137438953472 --write-protect-boundary=0 --sector-size-in-bytes=512 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --filename    ""
+#       true
+#   --sparse      false
+
+# Physical Partition 0 - Main storage partition
+# Boot partitions
+--partition --name=xbl_a --size=4096KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --name=xbl_b --size=4096KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --name=xbl_config_a --size=128KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --name=xbl_config_b --size=128KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
+--partition --name=uefi_a --size=12288KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=12288KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+
+# Firmware partitions
+--partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --name=uefi_dtb_a --size=2048KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
+--partition --name=uefi_dtb_b --size=2048KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
+--partition --name=shrm_a --size=80KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+--partition --name=tz_a --size=8192KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --name=tz_b --size=8192KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
+--partition --name=rpm_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=rpm.mbn
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --name=keymaster_a --size=10240KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
+--partition --name=keymaster_b --size=10240KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
+--partition --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
+--partition --name=qupfw_b --size=128KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C --filename=qupv3fw.elf
+
+# OTP / Misc partitions
+--partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F
+--partition --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687
+--partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
+--partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg_iot.mbn
+--partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7
+--partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8
+--partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970
+--partition --name=multiimgqti --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
+
+# Security partitions
+--partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=catecontentfv --size=1024KB --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
+--partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
+--partition --name=frp --size=512KB --type-guid=91B72D4D-71E0-4CBF-9B8E-236381CFF17A
+--partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+
+# Misc / Utility partitions
+--partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
+--partition --name=questdatafv --size=4096KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=zeros_33sectors.bin
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
+--partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=logdump --size=32768KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+
+# Modem partitions
+--partition --name=modemst1 --size=4096KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=modemst2 --size=4096KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=fsg --size=4096KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
+
+# HLOS partition
+--partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+
+# Physical Partition 1 - OTP storage partition (JEDEC "Boot Area Partition 1")
+--partition --phys-part=1 --name=cdt --size=128KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
+--partition --phys-part=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/shikra-test-new/emmc/contents.xml.in
+++ b/platforms/shikra-test-new/emmc/contents.xml.in
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<!--
+========================================================================
+  contents.in
+
+  General Description
+     Contains information about component builds for this target.
+     It will clone as contents.xml during build compilation process.
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  SPDX-License-Identifier: BSD-3-Clause
+
+========================================================================
+-->
+
+<contents>
+  <product_flavors cmm_pf_var="PRODUCT_FLAVORS">
+    <pf>
+      <name>default</name>
+      <component>
+        <name>common</name>
+        <flavor>default</flavor>
+      </component>
+      <component>
+        <name>apps</name>
+        <flavor>default</flavor>
+      </component>
+    </pf>
+  </product_flavors>
+  <product_info>
+    <product_name>CQ2390.LE.0.0</product_name>
+    <chipid flavor="default" storage_type="emmc" flash_phase="1">SHIKRA</chipid>
+    <additional_chipid>CQ2390,CQ2390M,CQ2390S</additional_chipid>
+    <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
+  </product_info>
+  <builds_flat>
+    <build>
+      <name>apps</name>
+      <role>apps</role>
+      <chipset>SHIKRA</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>apps_proc</image_dir>
+    </build>
+    <build>
+      <name>common</name>
+      <role>common</role>
+      <chipset>SHIKRA</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>common</image_dir>
+      <device_programmer>
+        <file_name>prog_firehose_ddr.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <device_programmer firehose_type="lite">
+        <file_name>prog_firehose_lite.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <download_file>
+        <fastboot_complete>{partition_name}</fastboot_complete>
+        <file_name>{image_name}</file_name>
+        <file_path>.</file_path>
+      </download_file>
+      <partition_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_file>
+      <partition_patch_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_patch_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_patch_file>
+   </build>
+  </builds_flat>
+</contents>

--- a/platforms/shikra-test-new/emmc/partitions.conf
+++ b/platforms/shikra-test-new/emmc/partitions.conf
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# --disk --type=emmc --size=137438953472 --write-protect-boundary=0 --sector-size-in-bytes=512 --grow-last-partition
+--disk --type=emmc --size=137438953472 --write-protect-boundary=0 --sector-size-in-bytes=512 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --filename    ""
+#       true
+#   --sparse      false
+
+# Physical Partition 0 - Main storage partition
+# Boot partitions
+--partition --name=xbl_a --size=4096KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --name=xbl_b --size=4096KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --name=xbl_config_a --size=128KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --name=xbl_config_b --size=128KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
+--partition --name=uefi_a --size=12288KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=12288KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+
+# Firmware partitions
+--partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --name=uefi_dtb_a --size=2048KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
+--partition --name=uefi_dtb_b --size=2048KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
+--partition --name=shrm_a --size=80KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+--partition --name=tz_a --size=8192KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --name=tz_b --size=8192KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
+--partition --name=rpm_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=rpm.mbn
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --name=keymaster_a --size=10240KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
+--partition --name=keymaster_b --size=10240KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
+--partition --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
+--partition --name=qupfw_b --size=128KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C --filename=qupv3fw.elf
+
+# OTP / Misc partitions
+--partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F
+--partition --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687
+--partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
+--partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg_iot.mbn
+--partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7
+--partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8
+--partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970
+--partition --name=multiimgqti --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
+
+# Security partitions
+--partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=catecontentfv --size=1024KB --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
+--partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
+--partition --name=frp --size=512KB --type-guid=91B72D4D-71E0-4CBF-9B8E-236381CFF17A
+--partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+
+# Misc / Utility partitions
+--partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
+--partition --name=questdatafv --size=4096KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=zeros_33sectors.bin
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
+--partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=logdump --size=32768KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+
+# Modem partitions
+--partition --name=modemst1 --size=4096KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=modemst2 --size=4096KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=fsg --size=4096KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
+
+# HLOS partition
+--partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+
+# Physical Partition 1 - OTP storage partition (JEDEC "Boot Area Partition 1")
+--partition --phys-part=1 --name=cdt --size=128KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
+--partition --phys-part=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000

--- a/platforms/shikra-test/emmc/contents.xml.in
+++ b/platforms/shikra-test/emmc/contents.xml.in
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<!--
+========================================================================
+  contents.in
+
+  General Description
+     Contains information about component builds for this target.
+     It will clone as contents.xml during build compilation process.
+
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+  SPDX-License-Identifier: BSD-3-Clause
+
+========================================================================
+-->
+
+<contents>
+  <product_flavors cmm_pf_var="PRODUCT_FLAVORS">
+    <pf>
+      <name>default</name>
+      <component>
+        <name>common</name>
+        <flavor>default</flavor>
+      </component>
+      <component>
+        <name>apps</name>
+        <flavor>default</flavor>
+      </component>
+    </pf>
+  </product_flavors>
+  <product_info>
+    <product_name>CQ2390.LE.0.0</product_name>
+    <chipid flavor="default" storage_type="emmc" flash_phase="1">SHIKRA</chipid>
+    <additional_chipid>CQ2390,CQ2390M,CQ2390S</additional_chipid>
+    <meta_type>FULL_STACK</meta_type>
+    <build_type>K2L</build_type>
+  </product_info>
+  <builds_flat>
+    <build>
+      <name>apps</name>
+      <role>apps</role>
+      <chipset>SHIKRA</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>apps_proc</image_dir>
+    </build>
+    <build>
+      <name>common</name>
+      <role>common</role>
+      <chipset>SHIKRA</chipset>
+      <windows_root_path>.\</windows_root_path>
+      <linux_root_path>./</linux_root_path>
+      <image_dir>common</image_dir>
+      <device_programmer>
+        <file_name>prog_firehose_ddr.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <device_programmer firehose_type="lite">
+        <file_name>prog_firehose_lite.elf</file_name>
+        <file_path>.</file_path>
+      </device_programmer>
+      <download_file>
+        <fastboot_complete>{partition_name}</fastboot_complete>
+        <file_name>{image_name}</file_name>
+        <file_path>.</file_path>
+      </download_file>
+      <partition_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_file>
+      <partition_patch_file>
+        <storage_type>{storage_type}</storage_type>
+        <file_name>{partition_patch_file_name}</file_name>
+        <file_path flavor="default">.</file_path>
+      </partition_patch_file>
+   </build>
+  </builds_flat>
+</contents>

--- a/platforms/shikra-test/emmc/partitions.conf
+++ b/platforms/shikra-test/emmc/partitions.conf
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# select disk type emmc | nand | ufs Mandatory
+# disk size in bytes Mandatory
+# options if not explicitly provid
+--disk --type=emmc --size=137438953472 --write-protect-boundary=0 --sector-size-in-bytes=512 --grow-last-partition
+
+# per partition entry
+# mandatory options:
+#   --lun (mandatory for UFS, emmc no need this)
+#   --name
+#   --size in bytes
+#   --type-guid
+# optional options: (defaults used if not provided)
+#   --attributes  1000000000000004
+#   --filename    ""
+#   --readonly    true
+#   --sparse      false
+
+# Physical Partition 0 (--phys-part=0) - Main storage partition (JEDEC "User Data Area")
+--partition --name=xbl_a --size=4096KB --type-guid=DEA0BA2C-CBDD-4805-B4F9-F428251C3E98 --filename=xbl.elf
+--partition --name=xbl_b --size=4096KB --type-guid=7A3DF1A3-A31A-454D-BD78-DF259ED486BE --filename=xbl.elf
+--partition --name=xbl_config_a --size=128KB --type-guid=5A325AE4-4276-B66D-0ADD-3494DF27706A --filename=xbl_config.elf
+--partition --name=xbl_config_b --size=128KB --type-guid=F462E0EA-A20E-4B10-867A-2D4455366548 --filename=xbl_config.elf
+--partition --name=uefi_a --size=12288KB --type-guid=400FFDCD-22E0-47E7-9A23-F16ED9382388 --filename=uefi.elf
+--partition --name=uefi_b --size=12288KB --type-guid=9F234B5B-0EFB-4313-8E4C-0AF1F605536B --filename=uefi.elf
+--partition --name=dtb_a --size=65536KB --type-guid=2A1A52FC-AA0B-401C-A808-5EA0F91068F8 --filename=dtb.bin
+--partition --name=dtb_b --size=65536KB --type-guid=A166F11A-2B39-4FAA-B7E7-F8AA080D0587 --filename=dtb.bin
+--partition --name=uefi_dtb_a --size=2048KB --type-guid=C84D3B5E-EF34-4FA4-8118-30EAE18D3FA6 --filename=uefi_dtbs.elf
+--partition --name=uefi_dtb_b --size=2048KB --type-guid=5F7D760A-3EF5-4AA5-B915-69A4ECAAE662 --filename=uefi_dtbs.elf
+--partition --name=shrm_a --size=80KB --type-guid=CB74CA22-2F0D-4B82-A1D6-C4213F348D73 --filename=shrm.elf
+--partition --name=shrm_b --size=80KB --type-guid=39FD6C00-49EB-6BD1-6899-2FB849DD4F75 --filename=shrm.elf
+--partition --name=tz_a --size=8192KB --type-guid=A053AA7F-40B8-4B1C-BA08-2F68AC71A4F4 --filename=tz.mbn
+--partition --name=tz_b --size=8192KB --type-guid=C832EA16-8B0D-4398-A67B-EBB30EF98E7E --filename=tz.mbn
+--partition --name=rpm_a --size=512KB --type-guid=098DF793-D712-413D-9D4E-89D711772228 --filename=rpm.mbn
+--partition --name=rpm_b --size=512KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34 --filename=rpm.mbn
+--partition --name=hyp_a --size=8192KB --type-guid=E1A6A689-0C8D-4CC6-B4E8-55A4320FBD8A --filename=hypvm.mbn
+--partition --name=hyp_b --size=8192KB --type-guid=CB45ECA0-504E-42BB-91BA-C9B3236F6A6E --filename=hypvm.mbn
+--partition --name=keymaster_a --size=10240KB --type-guid=A11D2A7C-D82A-4C2F-8A01-1805240E6626 --filename=zeros_33sectors.bin
+--partition --name=keymaster_b --size=10240KB --type-guid=441EEF80-DE15-4522-9995-563398D94889 --filename=zeros_33sectors.bin
+--partition --name=qupfw_a --size=128KB --type-guid=21D1219F-2ED1-4AB4-930A-41A16AE75F7F --filename=qupv3fw.elf
+--partition --name=qupfw_b --size=128KB --type-guid=F0BDD669-EE04-4F41-84BD-8F3B7B799B6C --filename=qupv3fw.elf
+--partition --name=ddr --size=1024KB --type-guid=20A0C19C-286A-42FA-9CE7-F64C3226A794
+--partition --name=imagefv_a --size=2048KB --type-guid=17911177-C9E6-4372-933C-804B678E666F
+--partition --name=imagefv_b --size=2048KB --type-guid=920CFC3D-7285-4A47-9C1C-4A87590E0687
+--partition --name=uefisecapp_a --size=2048KB --type-guid=BE8A7E08-1B7A-4CAE-993A-D5B7FB55B3C2 --filename=uefi_sec.mbn
+--partition --name=uefisecapp_b --size=2048KB --type-guid=538CBDBA-D4A4-4438-A466-D7B356FAC165 --filename=uefi_sec.mbn
+--partition --name=devcfg_a --size=128KB --type-guid=F65D4B16-343D-4E25-AAFC-BE99B6556A6D --filename=devcfg_iot.mbn
+--partition --name=devcfg_b --size=128KB --type-guid=169534E7-7809-4240-9763-0BA5DC37B5FF --filename=devcfg_iot.mbn
+--partition --name=featenabler_a --size=128KB --type-guid=741813D2-8C87-4465-8C69-032C771CCCE7
+--partition --name=featenabler_b --size=128KB --type-guid=77036CD4-03D5-42BB-8ED1-37E5A88BAA34
+--partition --name=multiimgoem_a --size=32KB --type-guid=E126A436-757E-42D0-8D19-0F362F7A62B8
+--partition --name=multiimgoem_b --size=32KB --type-guid=3E3E3ECD-C512-4F95-9144-6063826A8970
+--partition --name=multiimgqti --size=32KB --type-guid=846C6F05-EB46-4C0A-A1A3-3648EF3F9D0E
+--partition --name=secdata --size=25KB --type-guid=76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93
+--partition --name=catecontentfv --size=1024KB --type-guid=E12D830B-7F62-4F0B-B48A-8178C5BF3AC1
+--partition --name=keystore --size=512KB --type-guid=DE7D4029-0F5B-41C8-AE7E-F6C023A02B33
+--partition --name=frp --size=512KB --type-guid=91B72D4D-71E0-4CBF-9B8E-236381CFF17A
+--partition --name=apdp --size=256KB --type-guid=E6E98DA2-E22A-4D12-AB33-169E7DEAA507
+--partition --name=devinfo --size=4KB --type-guid=65ADDCF4-0C5C-4D9A-AC2D-D90B5CBFCD03
+--partition --name=misc --size=1024KB --type-guid=82ACC91F-357C-4A68-9C8F-689E1B1A23A1
+--partition --name=questdatafv --size=4096KB --type-guid=7F86D79A-7C83-4FC8-BEF2-7D0A7A97AF23
+--partition --name=limits --size=4KB --type-guid=10A0C19C-516A-5444-5CE3-664C3226A794
+--partition --name=toolsfv --size=1024KB --type-guid=97745ABA-135A-44C3-9ADC-05616173C24C --filename=zeros_33sectors.bin
+--partition --name=logfs --size=8192KB --type-guid=BC0330EB-3410-4951-A617-03898DBE3372
+--partition --name=cateloader --size=2048KB --type-guid=AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191
+--partition --name=logdump --size=32768KB --type-guid=5AF80809-AABB-4943-9168-CDFC38742598
+--partition --name=modemst1 --size=4096KB --type-guid=EBBEADAF-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=modemst2 --size=4096KB --type-guid=0A288B1F-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=fsg --size=4096KB --type-guid=638FF8E2-22C9-E33B-8F5D-0E81686A68CB
+--partition --name=efi --size=524288KB --type-guid=C12A7328-F81F-11D2-BA4B-00A0C93EC93B --filename=efi.bin
+--partition --name=rootfs --size=16777216KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+
+# Physical Partition 1 (--phys-part=1) - OTP storage partition (JEDEC "Boot Area Partition 1")
+--partition --phys-part=1 --name=cdt --size=128KB --type-guid=A19F205F-CCD8-4B6D-8F1E-2D9BC24CFFB1 --filename=cdt.bin
+--partition --phys-part=1 --name=last_parti --size=0KB --type-guid=00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Adds the UFS partition layout for the iq10-rrd (NORD SoC) board bring-up.

Note: this branch previously carried a fix for the duplicate `[tool.pytest.ini_options]` table in pyproject.toml (hit while building this board); that fix has since landed upstream via #161, so this branch was rebased onto main to pick it up and the branch now carries only the board-specific partition layout.