### PR TITLE
board: add multi-storage board model with composition

### DIFF
--- a/qcom_ptool/board.py
+++ b/qcom_ptool/board.py
@@ -1,0 +1,298 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Multi-storage board model and composition resolver.
+
+A board file declares a ``platform`` and a list of ``storage`` devices, each
+with its own partitions. Three composition mechanisms layer on top:
+
+* board-level ``extends:`` - inherit a single base board and override by
+  stable identifier (storage ``id``, partition ``name``);
+* storage-level ``includes:`` - concatenate shared partition fragments from
+  ``_common/`` into a storage's partition list;
+* variant overlays (``--hlos`` / ``--boot-fw``) - applied last, merged by the
+  same identifiers.
+
+Resolution order is: base board -> derived board -> storage includes ->
+variant overlays. Merges are deep and field-by-field; entries are matched by
+``id`` (storage) or ``name`` (partition), and anything unmatched is appended
+in file order. There is no partition deletion in v1.
+
+The resolver operates on raw YAML dicts. Each fully-resolved storage is then
+validated against the strict single-storage ``partitions.schema.json`` and
+reduced to a :class:`qcom_ptool.spec.LoadedSpec` through the very same
+normalisation helpers the YAML loader uses, so a resolved board emits XML
+byte-identical to an equivalent hand-written single-storage file.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from collections.abc import Mapping, Sequence
+from importlib import resources
+from typing import Any, TypedDict
+
+import jsonschema
+import yaml  # type: ignore[import-untyped]
+
+from qcom_ptool.loaders.yaml import _disk_from_node, _partition_from_node
+from qcom_ptool.spec import LoadedSpec, PartitionsByLun
+
+_SCHEMA_PACKAGE = "qcom_ptool.schema"
+
+# Storage keys that describe the disk geometry (everything except id / includes
+# / partitions). Used to reduce a resolved storage into the single-storage
+# document shape that partitions.schema.json validates.
+_DISK_KEYS = (
+    "type",
+    "size",
+    "sector-size",
+    "write-protect-boundary",
+    "grow-last-partition",
+    "align-partitions",
+)
+
+
+class BoardResolveError(ValueError):
+    """Raised when a board file cannot be loaded, composed or validated."""
+
+
+class ResolvedBoard(TypedDict):
+    """A board with every extends/includes/variant applied."""
+
+    platform: dict[str, Any]
+    storage: list[dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Schema / file helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_schema(name: str) -> dict[str, Any]:
+    text = resources.files(_SCHEMA_PACKAGE).joinpath(name).read_text(encoding="utf-8")
+    schema: dict[str, Any] = json.loads(text)
+    return schema
+
+
+def _read_mapping(path: str, schema: str) -> dict[str, Any]:
+    """Load ``path`` as YAML, validate against ``schema`` and return a copy."""
+    try:
+        with open(path) as f:
+            document = yaml.safe_load(f)
+    except OSError as exc:
+        raise BoardResolveError("cannot read %s: %s" % (path, exc)) from exc
+    if not isinstance(document, Mapping):
+        raise BoardResolveError(
+            "%s: expected a top-level mapping, got %s" % (path, type(document).__name__)
+        )
+    try:
+        jsonschema.validate(document, _load_schema(schema))
+    except jsonschema.exceptions.ValidationError as exc:
+        raise BoardResolveError("%s: schema validation failed: %s" % (path, exc.message)) from exc
+    return copy.deepcopy(dict(document))
+
+
+# ---------------------------------------------------------------------------
+# Deep-merge primitives (by stable identifier)
+# ---------------------------------------------------------------------------
+
+
+def _merge_partitions(base: list[dict[str, Any]], overlay: Sequence[Mapping[str, Any]]) -> None:
+    """Merge ``overlay`` partitions into ``base`` by ``name``.
+
+    A same-named partition is deep-merged field-by-field in place (so an
+    override can set only ``size`` and inherit the rest); a new partition is
+    appended in overlay order. Nothing is ever moved or removed.
+    """
+    index = {p["name"]: p for p in base if "name" in p}
+    for entry in overlay:
+        name = entry.get("name")
+        target = index.get(name)
+        if target is not None:
+            target.update(copy.deepcopy(dict(entry)))
+        else:
+            new_entry = copy.deepcopy(dict(entry))
+            base.append(new_entry)
+            if name is not None:
+                index[name] = new_entry
+
+
+def _merge_storage(base: dict[str, Any], overlay: Mapping[str, Any]) -> None:
+    """Merge one storage ``overlay`` into ``base`` (matched by id upstream)."""
+    for key, value in overlay.items():
+        if key == "id":
+            continue
+        if key == "partitions":
+            base.setdefault("partitions", [])
+            _merge_partitions(base["partitions"], value)
+        elif key == "includes":
+            merged = base.setdefault("includes", [])
+            for inc in value:
+                if inc not in merged:
+                    merged.append(inc)
+        else:
+            base[key] = copy.deepcopy(value)
+
+
+def _merge_storage_list(base: list[dict[str, Any]], overlay: Sequence[Mapping[str, Any]]) -> None:
+    """Merge ``overlay`` storage entries into ``base`` by ``id``."""
+    index = {s["id"]: s for s in base if "id" in s}
+    for entry in overlay:
+        sid = entry.get("id")
+        target = index.get(sid)
+        if target is not None:
+            _merge_storage(target, entry)
+        else:
+            new_entry = copy.deepcopy(dict(entry))
+            base.append(new_entry)
+            if sid is not None:
+                index[sid] = new_entry
+
+
+# ---------------------------------------------------------------------------
+# Board-level extends
+# ---------------------------------------------------------------------------
+
+
+def _load_board_with_extends(path: str, root: str, chain: tuple[str, ...]) -> dict[str, Any]:
+    """Load a board file and fold its single base (if any) underneath it."""
+    real = os.path.realpath(path)
+    if real in chain:
+        raise BoardResolveError("extends cycle detected at %s" % path)
+    board = _read_mapping(path, "board.schema.json")
+    base_ref = board.pop("extends", None)
+    if base_ref is None:
+        return board
+    base_path = os.path.join(root, base_ref)
+    base = _load_board_with_extends(base_path, root, (*chain, real))
+    _merge_storage_list(base.setdefault("storage", []), board.get("storage", []))
+    if "platform" in board:
+        base["platform"] = board["platform"]
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Storage-level includes
+# ---------------------------------------------------------------------------
+
+
+def _fragment_partitions(path: str, root: str, chain: tuple[str, ...]) -> list[dict[str, Any]]:
+    """Resolve a ``_common/`` fragment (transitively) into a partition list."""
+    real = os.path.realpath(path)
+    if real in chain:
+        raise BoardResolveError("includes cycle detected at %s" % path)
+    fragment = _read_mapping(path, "include.schema.json")
+    partitions: list[dict[str, Any]] = []
+    for inc in fragment.get("includes", []):
+        inc_parts = _fragment_partitions(os.path.join(root, inc), root, (*chain, real))
+        _merge_partitions(partitions, inc_parts)
+    _merge_partitions(partitions, fragment.get("partitions", []))
+    return partitions
+
+
+def _expand_includes(storage: dict[str, Any], root: str) -> None:
+    """Replace a storage's ``includes:`` + inline ``partitions:`` with one list.
+
+    Ordering: included fragments in listed order first, then the storage's own
+    inline partitions, with same-named entries merged in place.
+    """
+    includes = storage.pop("includes", [])
+    expanded: list[dict[str, Any]] = []
+    for inc in includes:
+        inc_parts = _fragment_partitions(os.path.join(root, inc), root, ())
+        _merge_partitions(expanded, inc_parts)
+    _merge_partitions(expanded, storage.get("partitions", []))
+    storage["partitions"] = expanded
+
+
+# ---------------------------------------------------------------------------
+# Public resolution
+# ---------------------------------------------------------------------------
+
+
+def _variant_path(root: str, axis: str, name: str) -> str:
+    return os.path.join(root, "variants", axis, name + ".yaml")
+
+
+def _validate_resolved_storage(storage: Mapping[str, Any]) -> None:
+    """Validate a fully-resolved storage against the strict single-storage schema."""
+    disk = {k: storage[k] for k in _DISK_KEYS if k in storage}
+    document = {"disk": disk, "partitions": storage.get("partitions", [])}
+    try:
+        jsonschema.validate(document, _load_schema("partitions.schema.json"))
+    except jsonschema.exceptions.ValidationError as exc:
+        raise BoardResolveError(
+            "storage %r resolved to an invalid spec: %s"
+            % (storage.get("id", "?"), exc.message)
+        ) from exc
+
+
+def resolve_board(
+    path: str,
+    root: str | None = None,
+    hlos: str | None = None,
+    boot_fw: str | None = None,
+) -> ResolvedBoard:
+    """Resolve ``path`` into a fully-composed :class:`ResolvedBoard`.
+
+    ``root`` is the platforms directory that ``extends:`` / ``includes:`` paths
+    and variant names resolve against; it defaults to the parent of the board
+    file's directory when that directory is ``boards/``, else the board file's
+    own directory.
+    """
+    if root is None:
+        parent = os.path.dirname(os.path.abspath(path))
+        root = os.path.dirname(parent) if os.path.basename(parent) == "boards" else parent
+
+    board = _load_board_with_extends(path, root, ())
+    storages = board.get("storage", [])
+    if not storages:
+        raise BoardResolveError("%s: board declares no storage" % path)
+
+    for storage in storages:
+        _expand_includes(storage, root)
+
+    for axis, name in (("hlos", hlos), ("boot-fw", boot_fw)):
+        if name is None:
+            continue
+        overlay = _read_mapping(_variant_path(root, axis, name), "board.schema.json")
+        _merge_storage_list(storages, overlay.get("storage", []))
+
+    for storage in storages:
+        _validate_resolved_storage(storage)
+
+    return {"platform": board.get("platform", {}), "storage": storages}
+
+
+# ---------------------------------------------------------------------------
+# Reduction to the emitter's LoadedSpec
+# ---------------------------------------------------------------------------
+
+
+def storage_to_loaded_spec(
+    storage: Mapping[str, Any],
+    image_map: Mapping[str, str] | None = None,
+) -> LoadedSpec:
+    """Reduce one resolved storage to a LoadedSpec via the YAML loader helpers."""
+    if image_map is None:
+        image_map = {}
+    disk = _disk_from_node(storage)
+    partitions: PartitionsByLun = {}
+    for node in storage.get("partitions", []):
+        phys_part, entry = _partition_from_node(node, image_map)
+        partitions.setdefault(phys_part, []).append(entry)
+    return {"disk": disk, "partitions": partitions}
+
+
+def board_to_specs(
+    board: ResolvedBoard,
+    image_map: Mapping[str, str] | None = None,
+) -> list[tuple[str, LoadedSpec]]:
+    """Reduce a resolved board to ``[(storage_id, LoadedSpec), ...]`` in order."""
+    return [
+        (storage.get("id", ""), storage_to_loaded_spec(storage, image_map))
+        for storage in board["storage"]
+    ]

--- a/qcom_ptool/cli.py
+++ b/qcom_ptool/cli.py
@@ -12,6 +12,7 @@ SUBCOMMANDS = {
     "gen_contents": "qcom_ptool.gen_contents",
     "ptool": "qcom_ptool.ptool",
     "msp": "qcom_ptool.msp",
+    "show": "qcom_ptool.show",
 }
 
 

--- a/qcom_ptool/gen_partition.py
+++ b/qcom_ptool/gen_partition.py
@@ -39,8 +39,13 @@ from qcom_ptool.spec import DiskParams, PartitionsByLun
 
 def usage() -> NoReturn:
     print(
-        "\n\tUsage: %s -i <input> -o <output> -m [partition_name1=image_filename1,partition_name2=image_filename2,...]\n\tVersion 1.0\n"
-        % (sys.argv[0])
+        "\n\tUsage:\n"
+        "\t  %s -i <input> -o <output> "
+        "[-m name1=image1,name2=image2,...]\n"
+        "\t  %s --board <board.yaml> [--hlos <name>] [--boot-fw <name>] "
+        "[--root <dir>] -o <out1> [-o <out2> ...]\n"
+        "\n\tIn --board mode one -o is given per storage, in declared order.\n"
+        "\tVersion 1.0\n" % (sys.argv[0], sys.argv[0])
     )
     sys.exit(1)
 
@@ -99,18 +104,32 @@ def main(argv: list[str] | None = None) -> int:
         usage()
 
     input_file: str | None = None
-    output_xml: str | None = None
+    board_file: str | None = None
+    root: str | None = None
+    hlos: str | None = None
+    boot_fw: str | None = None
+    outputs: list[str] = []
     image_map: dict[str, str] = {}
 
     if argv[1] == "-h" or argv[1] == "--help":
         usage()
     try:
-        opts, _rem = getopt.getopt(argv[1:], "i:o:m:")
+        opts, _rem = getopt.getopt(
+            argv[1:], "i:o:m:", ["board=", "hlos=", "boot-fw=", "root="]
+        )
         for opt, arg in opts:
             if opt == "-i":
                 input_file = arg
             elif opt == "-o":
-                output_xml = arg
+                outputs.append(arg)
+            elif opt == "--board":
+                board_file = arg
+            elif opt == "--hlos":
+                hlos = arg
+            elif opt == "--boot-fw":
+                boot_fw = arg
+            elif opt == "--root":
+                root = arg
             elif opt == "-m":
                 for mapping in arg.split(","):
                     tags = mapping.split("=")
@@ -122,16 +141,57 @@ def main(argv: list[str] | None = None) -> int:
         print(str(argerr))
         usage()
 
-    if input_file is None or output_xml is None:
+    if (board_file is None) == (input_file is None):
+        print("Error: pass exactly one of -i <input> or --board <board.yaml>")
+        usage()
+    if not outputs:
         usage()
 
+    if board_file is not None:
+        return _run_board(board_file, root, hlos, boot_fw, outputs, image_map)
+
+    if input_file is None or len(outputs) != 1:
+        print("Error: -i single-storage mode takes exactly one -o")
+        usage()
     try:
         spec = load_spec(input_file, image_map=image_map)
     except Exception as e:
         print("Error: ", e)
         return 1
 
-    generate_partition_xml(spec["disk"], spec["partitions"], output_xml)
+    generate_partition_xml(spec["disk"], spec["partitions"], outputs[0])
+    return 0
+
+
+def _run_board(
+    board_file: str,
+    root: str | None,
+    hlos: str | None,
+    boot_fw: str | None,
+    outputs: list[str],
+    image_map: dict[str, str],
+) -> int:
+    # Late import so the -i path never pulls in PyYAML / jsonschema.
+    from qcom_ptool.board import board_to_specs, resolve_board
+
+    try:
+        board = resolve_board(board_file, root=root, hlos=hlos, boot_fw=boot_fw)
+        specs = board_to_specs(board, image_map=image_map)
+    except Exception as e:
+        print("Error: ", e)
+        return 1
+
+    if len(outputs) != len(specs):
+        ids = ", ".join(sid for sid, _ in specs)
+        print(
+            "Error: board declares %d storage(s) [%s] but %d -o output(s) given"
+            % (len(specs), ids, len(outputs))
+        )
+        return 1
+
+    for (sid, spec), output in zip(specs, outputs):
+        print("Storage %s -> %s" % (sid, output))
+        generate_partition_xml(spec["disk"], spec["partitions"], output)
     return 0
 
 

--- a/qcom_ptool/schema/board.schema.json
+++ b/qcom_ptool/schema/board.schema.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/qualcomm-linux/qcom-ptool/board.schema.json",
+    "title": "qcom-ptool board / variant source",
+    "description": "Structural schema for a board file, a derived (extends) board, or a variant overlay. Storage entries and partitions are permissive here because overrides are partial (e.g. a derived board may set only a partition size); the fully-resolved storage is validated strictly against partitions.schema.json.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["storage"],
+    "properties": {
+        "platform": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {"type": "string"}
+            }
+        },
+        "extends": {
+            "description": "Path (relative to the platforms root) of a single base board to inherit.",
+            "type": "string"
+        },
+        "storage": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string", "minLength": 1},
+                    "type": {"type": "string", "enum": ["emmc", "nand", "nvme", "spinor", "ufs"]},
+                    "size": {"type": "integer", "minimum": 1},
+                    "sector-size": {"type": "integer", "minimum": 1},
+                    "write-protect-boundary": {"type": "integer", "minimum": 0},
+                    "grow-last-partition": {"type": "boolean"},
+                    "align-partitions": {"type": "integer", "minimum": 0},
+                    "includes": {
+                        "description": "Shared partition fragments (relative to the platforms root) concatenated into this storage's partition list.",
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "partitions": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/partition"}
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "partition": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "size": {"type": "string", "pattern": "^[0-9]+([KkMmGg][Bb]?)?$"},
+                "type-guid": {"type": "string", "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"},
+                "filename": {"type": "string"},
+                "attributes": {"type": "string", "pattern": "^[0-9A-Fa-f]+$"},
+                "sparse": {"type": "boolean"},
+                "lun": {"type": "integer", "minimum": 0},
+                "phys-part": {"type": "integer", "minimum": 0}
+            }
+        }
+    }
+}

--- a/qcom_ptool/schema/include.schema.json
+++ b/qcom_ptool/schema/include.schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/qualcomm-linux/qcom-ptool/include.schema.json",
+    "title": "qcom-ptool shared partition fragment",
+    "description": "A reusable partition group under platforms/_common/, pulled into a storage via 'includes:'. May itself pull in further fragments.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "includes": {
+            "type": "array",
+            "items": {"type": "string"}
+        },
+        "partitions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name"],
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "size": {"type": "string", "pattern": "^[0-9]+([KkMmGg][Bb]?)?$"},
+                    "type-guid": {"type": "string", "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"},
+                    "filename": {"type": "string"},
+                    "attributes": {"type": "string", "pattern": "^[0-9A-Fa-f]+$"},
+                    "sparse": {"type": "boolean"},
+                    "lun": {"type": "integer", "minimum": 0},
+                    "phys-part": {"type": "integer", "minimum": 0}
+                }
+            }
+        }
+    }
+}

--- a/qcom_ptool/show.py
+++ b/qcom_ptool/show.py
@@ -1,0 +1,70 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+``qcom-ptool show`` - print a board's fully-resolved spec.
+
+Derived boards and heavy ``includes:`` use make the effective partition
+layout impossible to read from a single file. This subcommand resolves all
+``extends`` / ``includes`` / variant overlays and prints the result as YAML,
+so reviewers and integrators can see exactly what will be emitted without
+chasing the composition chain by hand.
+"""
+
+from __future__ import annotations
+
+import getopt
+import sys
+from typing import NoReturn
+
+import yaml  # type: ignore[import-untyped]
+
+from qcom_ptool.board import resolve_board
+
+
+def usage() -> NoReturn:
+    print(
+        "\n\tUsage: %s --board <board.yaml> [--hlos <name>] "
+        "[--boot-fw <name>] [--root <dir>]\n" % sys.argv[0]
+    )
+    sys.exit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv
+
+    board_file: str | None = None
+    root: str | None = None
+    hlos: str | None = None
+    boot_fw: str | None = None
+
+    try:
+        opts, _rem = getopt.getopt(argv[1:], "", ["board=", "hlos=", "boot-fw=", "root="])
+        for opt, arg in opts:
+            if opt == "--board":
+                board_file = arg
+            elif opt == "--hlos":
+                hlos = arg
+            elif opt == "--boot-fw":
+                boot_fw = arg
+            elif opt == "--root":
+                root = arg
+    except Exception as argerr:
+        print(str(argerr))
+        usage()
+
+    if board_file is None:
+        usage()
+
+    try:
+        board = resolve_board(board_file, root=root, hlos=hlos, boot_fw=boot_fw)
+    except Exception as e:
+        print("Error: ", e)
+        return 1
+
+    yaml.safe_dump(dict(board), sys.stdout, sort_keys=False, default_flow_style=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_board.py
+++ b/tests/unit/test_board.py
@@ -1,0 +1,437 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Unit tests for the multi-storage board resolver (qcom_ptool/board.py).
+
+These pin the composition contract: board-level ``extends``,
+storage-level ``includes`` (with transitivity), variant overlays, deep-merge
+by stable identifier, the deterministic ordering rule, cycle detection, and
+the reduction to a byte-parity LoadedSpec.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+
+import pytest
+
+from qcom_ptool.board import (
+    BoardResolveError,
+    board_to_specs,
+    resolve_board,
+)
+from qcom_ptool.gen_partition import generate_partition_xml
+from qcom_ptool.loaders import load as load_spec
+
+GUID_A = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+GUID_B = "B921B045-1DF0-41C3-AF44-4C6F280D3FAE"
+GUID_C = "DEA0BA2C-CBDD-4805-B4F9-F428251C3E98"
+GUID_D = "CD6CDFAB-B3F7-46C6-BFFE-1A1D2B8B7BA0"
+
+
+def _tree(tmp_path, files: dict[str, str]) -> str:
+    """Write a mini platforms tree and return its root path."""
+    root = tmp_path / "platforms"
+    for rel, text in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(text))
+    return str(root)
+
+
+def _names(storage: dict) -> list[str]:
+    return [p["name"] for p in storage["partitions"]]
+
+
+def _by_id(board, sid: str) -> dict:
+    return next(s for s in board["storage"] if s["id"] == sid)
+
+
+_BASE = """
+    platform: {name: base}
+    storage:
+      - id: nvme0
+        type: nvme
+        size: 68719476736
+        sector-size: 512
+        write-protect-boundary: 65536
+        grow-last-partition: true
+        partitions:
+          - name: efi
+            size: "524288KB"
+            type-guid: "%s"
+            filename: efi.bin
+          - name: rootfs
+            size: "1024KB"
+            type-guid: "%s"
+""" % (GUID_A, GUID_B)
+
+
+# ---------------------------------------------------------------------------
+# extends
+# ---------------------------------------------------------------------------
+
+
+def test_extends_inherits_and_overrides_by_name(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "boards/base.yaml": _BASE,
+            "boards/derived.yaml": """
+                extends: boards/base.yaml
+                platform: {name: derived}
+                storage:
+                  - id: nvme0
+                    partitions:
+                      - name: rootfs
+                        size: "2048KB"
+            """,
+        },
+    )
+    board = resolve_board(os.path.join(root, "boards/derived.yaml"))
+    assert board["platform"] == {"name": "derived"}
+    nvme = _by_id(board, "nvme0")
+    rootfs = next(p for p in nvme["partitions"] if p["name"] == "rootfs")
+    # size overridden, type-guid inherited field-by-field.
+    assert rootfs["size"] == "2048KB"
+    assert rootfs["type-guid"] == GUID_B
+    # order preserved: overridden entry stays in place.
+    assert _names(nvme) == ["efi", "rootfs"]
+
+
+def test_extends_appends_new_storage_and_partition(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "boards/base.yaml": _BASE,
+            "boards/derived.yaml": """
+                extends: boards/base.yaml
+                storage:
+                  - id: nvme0
+                    partitions:
+                      - name: extra
+                        size: "8KB"
+                        type-guid: "%s"
+                  - id: emmc0
+                    type: emmc
+                    size: 1024
+                    partitions:
+                      - name: boot
+                        size: "8KB"
+                        type-guid: "%s"
+            """ % (GUID_C, GUID_D),
+        },
+    )
+    board = resolve_board(os.path.join(root, "boards/derived.yaml"))
+    assert [s["id"] for s in board["storage"]] == ["nvme0", "emmc0"]
+    assert _names(_by_id(board, "nvme0")) == ["efi", "rootfs", "extra"]
+
+
+def test_extends_cycle_is_rejected(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "boards/a.yaml": "extends: boards/b.yaml\nstorage: []\n",
+            "boards/b.yaml": "extends: boards/a.yaml\nstorage: []\n",
+        },
+    )
+    with pytest.raises(BoardResolveError, match="cycle"):
+        resolve_board(os.path.join(root, "boards/a.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# includes
+# ---------------------------------------------------------------------------
+
+
+def test_includes_concatenate_then_inline_last(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "_common/boot.yaml": """
+                partitions:
+                  - name: XBL_SC
+                    size: "2520KB"
+                    type-guid: "%s"
+                  - name: BOOT_FW1
+                    size: "12288KB"
+                    type-guid: "%s"
+            """ % (GUID_C, GUID_D),
+            "boards/b.yaml": """
+                platform: {name: b}
+                storage:
+                  - id: spinor0
+                    type: spinor
+                    size: 67108864
+                    sector-size: 4096
+                    write-protect-boundary: 0
+                    includes: [_common/boot.yaml]
+                    partitions:
+                      - name: cdt
+                        size: "4KB"
+                        type-guid: "%s"
+            """ % GUID_A,
+        },
+    )
+    board = resolve_board(os.path.join(root, "boards/b.yaml"))
+    # included fragments first (in order), inline partitions last.
+    assert _names(_by_id(board, "spinor0")) == ["XBL_SC", "BOOT_FW1", "cdt"]
+
+
+def test_includes_are_transitive(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "_common/leaf.yaml": """
+                partitions:
+                  - name: LEAF
+                    size: "4KB"
+                    type-guid: "%s"
+            """ % GUID_A,
+            "_common/mid.yaml": """
+                includes: [_common/leaf.yaml]
+                partitions:
+                  - name: MID
+                    size: "4KB"
+                    type-guid: "%s"
+            """ % GUID_B,
+            "boards/b.yaml": """
+                storage:
+                  - id: spinor0
+                    type: spinor
+                    size: 67108864
+                    sector-size: 4096
+                    includes: [_common/mid.yaml]
+                    partitions: []
+            """,
+        },
+    )
+    board = resolve_board(os.path.join(root, "boards/b.yaml"))
+    assert _names(_by_id(board, "spinor0")) == ["LEAF", "MID"]
+
+
+def test_includes_cycle_is_rejected(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "_common/a.yaml": "includes: [_common/b.yaml]\n",
+            "_common/b.yaml": "includes: [_common/a.yaml]\n",
+            "boards/b.yaml": """
+                storage:
+                  - id: s0
+                    type: spinor
+                    size: 67108864
+                    includes: [_common/a.yaml]
+            """,
+        },
+    )
+    with pytest.raises(BoardResolveError, match="cycle"):
+        resolve_board(os.path.join(root, "boards/b.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# variant overlays
+# ---------------------------------------------------------------------------
+
+
+def test_variants_apply_last_over_includes(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "_common/boot.yaml": """
+                partitions:
+                  - name: BOOT_FW1
+                    size: "12288KB"
+                    type-guid: "%s"
+                    filename: bootfw1.bin
+            """ % GUID_D,
+            "boards/b.yaml": """
+                storage:
+                  - id: nvme0
+                    type: nvme
+                    size: 68719476736
+                    sector-size: 512
+                    partitions:
+                      - name: rootfs
+                        size: "1024KB"
+                        type-guid: "%s"
+                  - id: spinor0
+                    type: spinor
+                    size: 67108864
+                    sector-size: 4096
+                    includes: [_common/boot.yaml]
+                    partitions:
+                      - name: cdt
+                        size: "4KB"
+                        type-guid: "%s"
+            """ % (GUID_B, GUID_A),
+            "variants/hlos/debian.yaml": """
+                storage:
+                  - id: nvme0
+                    partitions:
+                      - name: rootfs
+                        size: "33554432KB"
+                        filename: rootfs.img
+            """,
+            "variants/boot-fw/xbl-v3.yaml": """
+                storage:
+                  - id: spinor0
+                    partitions:
+                      - name: BOOT_FW1
+                        size: "16384KB"
+                        filename: bootfw1-v3.bin
+                      - name: vm-data
+                        size: "8192KB"
+                        type-guid: "%s"
+            """ % GUID_C,
+        },
+    )
+    board = resolve_board(
+        os.path.join(root, "boards/b.yaml"), hlos="debian", boot_fw="xbl-v3"
+    )
+    nvme = _by_id(board, "nvme0")
+    rootfs = nvme["partitions"][0]
+    assert rootfs["size"] == "33554432KB"
+    assert rootfs["filename"] == "rootfs.img"
+    assert rootfs["type-guid"] == GUID_B  # inherited through the overlay
+
+    spinor = _by_id(board, "spinor0")
+    # BOOT_FW1 overridden in place; vm-data appended after inline cdt.
+    assert _names(spinor) == ["BOOT_FW1", "cdt", "vm-data"]
+    boot_fw1 = spinor["partitions"][0]
+    assert boot_fw1["size"] == "16384KB"
+    assert boot_fw1["filename"] == "bootfw1-v3.bin"
+
+
+# ---------------------------------------------------------------------------
+# final validation
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_storage_missing_type_is_rejected(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "boards/b.yaml": """
+                storage:
+                  - id: nvme0
+                    size: 68719476736
+                    partitions:
+                      - name: efi
+                        size: "1KB"
+                        type-guid: "%s"
+            """ % GUID_A,
+        },
+    )
+    with pytest.raises(BoardResolveError, match="invalid spec"):
+        resolve_board(os.path.join(root, "boards/b.yaml"))
+
+
+def test_partition_missing_type_guid_after_resolution_is_rejected(tmp_path):
+    # rootfs never gets a type-guid from base or any overlay -> invalid.
+    root = _tree(
+        tmp_path,
+        {
+            "boards/b.yaml": """
+                storage:
+                  - id: nvme0
+                    type: nvme
+                    size: 68719476736
+                    partitions:
+                      - name: rootfs
+                        size: "1KB"
+            """,
+        },
+    )
+    with pytest.raises(BoardResolveError, match="invalid spec"):
+        resolve_board(os.path.join(root, "boards/b.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# reduction / byte parity
+# ---------------------------------------------------------------------------
+
+
+def test_board_reduces_to_byte_identical_xml(tmp_path):
+    """A resolved single-storage board emits the same XML as the equivalent
+    hand-written single-storage YAML loaded via the Phase 2 loader."""
+    root = _tree(
+        tmp_path,
+        {
+            "boards/b.yaml": """
+                platform: {name: b}
+                storage:
+                  - id: nvme0
+                    type: nvme
+                    size: 68719476736
+                    write-protect-boundary: 65536
+                    sector-size: 512
+                    grow-last-partition: true
+                    partitions:
+                      - name: efi
+                        size: "524288KB"
+                        type-guid: "%s"
+                        filename: efi.bin
+                      - name: rootfs
+                        size: "33554432KB"
+                        type-guid: "%s"
+                        filename: rootfs.img
+            """ % (GUID_A, GUID_B),
+        },
+    )
+    single = tmp_path / "single.yaml"
+    single.write_text(
+        textwrap.dedent(
+            """
+            disk:
+              type: nvme
+              size: 68719476736
+              write-protect-boundary: 65536
+              sector-size: 512
+              grow-last-partition: true
+            partitions:
+              - name: efi
+                size: "524288KB"
+                type-guid: "%s"
+                filename: efi.bin
+              - name: rootfs
+                size: "33554432KB"
+                type-guid: "%s"
+                filename: rootfs.img
+            """ % (GUID_A, GUID_B)
+        )
+    )
+
+    board = resolve_board(os.path.join(root, "boards/b.yaml"))
+    (sid, spec) = board_to_specs(board)[0]
+    assert sid == "nvme0"
+
+    board_xml = tmp_path / "board.xml"
+    single_xml = tmp_path / "single.xml"
+    generate_partition_xml(spec["disk"], spec["partitions"], str(board_xml))
+    single_spec = load_spec(str(single))
+    generate_partition_xml(single_spec["disk"], single_spec["partitions"], str(single_xml))
+    assert board_xml.read_bytes() == single_xml.read_bytes()
+
+
+def test_image_map_flows_through_reduction(tmp_path):
+    root = _tree(
+        tmp_path,
+        {
+            "boards/b.yaml": """
+                storage:
+                  - id: nvme0
+                    type: nvme
+                    size: 68719476736
+                    partitions:
+                      - name: rootfs
+                        size: "1KB"
+                        type-guid: "%s"
+                        filename: rootfs.img
+            """ % GUID_B,
+        },
+    )
+    board = resolve_board(os.path.join(root, "boards/b.yaml"))
+    specs = board_to_specs(board, image_map={"rootfs": "override.img"})
+    assert specs[0][1]["partitions"]["0"][0]["filename"] == "override.img"

--- a/tests/unit/test_cli_board.py
+++ b/tests/unit/test_cli_board.py
@@ -1,0 +1,139 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+CLI tests for board-mode ``gen_partition`` and the ``show`` subcommand.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from qcom_ptool import gen_partition, show
+
+GUID_A = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+GUID_B = "B921B045-1DF0-41C3-AF44-4C6F280D3FAE"
+
+_BOARD = """
+    platform: {name: demo}
+    storage:
+      - id: nvme0
+        type: nvme
+        size: 68719476736
+        sector-size: 512
+        write-protect-boundary: 65536
+        grow-last-partition: true
+        partitions:
+          - name: efi
+            size: "524288KB"
+            type-guid: "%s"
+            filename: efi.bin
+      - id: spinor0
+        type: spinor
+        size: 67108864
+        sector-size: 4096
+        write-protect-boundary: 0
+        partitions:
+          - name: cdt
+            size: "4KB"
+            type-guid: "%s"
+            filename: cdt.bin
+""" % (GUID_A, GUID_B)
+
+
+def _board(tmp_path) -> str:
+    root = tmp_path / "platforms"
+    (root / "boards").mkdir(parents=True)
+    path = root / "boards" / "demo.yaml"
+    path.write_text(textwrap.dedent(_BOARD))
+    return str(path)
+
+
+def test_board_mode_emits_one_xml_per_storage(tmp_path):
+    board = _board(tmp_path)
+    nvme = tmp_path / "nvme.xml"
+    spinor = tmp_path / "spinor.xml"
+    rc = gen_partition.main(
+        ["gen_partition", "--board", board, "-o", str(nvme), "-o", str(spinor)]
+    )
+    assert rc == 0
+    assert 'label="efi"' in nvme.read_text()
+    assert 'label="cdt"' in spinor.read_text()
+
+
+def test_board_mode_output_count_mismatch_returns_1(tmp_path):
+    board = _board(tmp_path)
+    rc = gen_partition.main(
+        ["gen_partition", "--board", board, "-o", str(tmp_path / "only.xml")]
+    )
+    assert rc == 1
+
+
+def test_requires_exactly_one_source(tmp_path):
+    board = _board(tmp_path)
+    # both -i and --board -> usage() exits.
+    with pytest.raises(SystemExit):
+        gen_partition.main(
+            ["gen_partition", "-i", "x.conf", "--board", board, "-o", "out.xml"]
+        )
+
+
+def test_legacy_single_storage_still_works(tmp_path):
+    src = tmp_path / "single.yaml"
+    src.write_text(
+        textwrap.dedent(
+            """
+            disk:
+              type: nvme
+              size: 68719476736
+            partitions:
+              - name: efi
+                size: "524288KB"
+                type-guid: "%s"
+                filename: efi.bin
+            """ % GUID_A
+        )
+    )
+    out = tmp_path / "out.xml"
+    rc = gen_partition.main(["gen_partition", "-i", str(src), "-o", str(out)])
+    assert rc == 0
+    assert 'label="efi"' in out.read_text()
+
+
+def test_show_prints_resolved_spec(tmp_path, capsys):
+    board = _board(tmp_path)
+    rc = show.main(["show", "--board", board])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "nvme0" in out
+    assert "spinor0" in out
+    assert "cdt" in out
+
+
+def test_show_applies_variants(tmp_path, capsys):
+    root = tmp_path / "platforms"
+    (root / "boards").mkdir(parents=True)
+    (root / "variants" / "hlos").mkdir(parents=True)
+    (root / "boards" / "demo.yaml").write_text(textwrap.dedent(_BOARD))
+    (root / "variants" / "hlos" / "debian.yaml").write_text(
+        textwrap.dedent(
+            """
+            storage:
+              - id: nvme0
+                partitions:
+                  - name: efi
+                    filename: efi-debian.bin
+            """
+        )
+    )
+    rc = show.main(
+        ["show", "--board", str(root / "boards" / "demo.yaml"), "--hlos", "debian"]
+    )
+    assert rc == 0
+    assert "efi-debian.bin" in capsys.readouterr().out
+
+
+def test_show_requires_board():
+    with pytest.raises(SystemExit):
+        show.main(["show"])


### PR DESCRIPTION
Third step of the partition-source rework [1]: a board file that declares a platform with multiple storages, and the composition layer on top of it.

The per-(board, storage) directory convention cannot say "this board has these two storages", cannot share common partition groups except by copy-paste, and cannot express variants (Debian vs QLI rootfs, boot-firmware versions) at all - adding a variant today means duplicating a directory and editing it by hand.

`board.py` resolves a board file through three mechanisms, applied in a fixed order: board-level `extends:` inherits a single base board; storage-level `includes:` concatenates shared partition fragments; `--hlos` / `--boot-fw` overlays apply last.

Merges are deep and field-by-field, matched by stable identifier (storage id, partition name); unmatched entries append in file order, and same-name overrides merge in place so partition order - which determines GPT offsets - stays deterministic. Each resolved storage is validated against the strict schema from [2] and reduced to the same `LoadedSpec`, so a resolved board emits byte-identical XML to the equivalent hand-written file. gen_partition `--board` emits one `partitions.xml` per storage; qcom-ptool show `--board` prints the fully-resolved layout so reviewers never have to chase the composition chain by hand.

[1] https://github.com/qualcomm-linux/qcom-ptool/issues/124
[2] https://github.com/qualcomm-linux/qcom-ptool/pull/155